### PR TITLE
chore: resolve all build, lint, and prettier warnings

### DIFF
--- a/Applications/PGAN.Poracle.Web.Api/Controllers/AdminController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -11,7 +12,7 @@ using PGAN.Poracle.Web.Core.Models;
 namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/admin")]
-public class AdminController(
+public partial class AdminController(
     IHumanService humanService,
     IPwebSettingService pwebSettingService,
     IPoracleApiProxy poracleApiProxy,
@@ -221,7 +222,7 @@ public class AdminController(
         };
 
         var created = await this._humanService.CreateAsync(human);
-        this._logger.LogInformation("Admin {AdminId} created webhook {WebhookId}", this.UserId, request.Url);
+        LogWebhookCreated(this._logger, this.UserId, request.Url);
         return this.Ok(created);
     }
 
@@ -258,7 +259,7 @@ public class AdminController(
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch Poracle config for admin list.");
+            LogPoracleConfigFetchFailed(this._logger, ex);
         }
 
         return this.Ok(admins);
@@ -351,13 +352,12 @@ public class AdminController(
                 result[webhookId] = [.. users];
             }
 
-            this._logger.LogInformation("Loaded {Count} delegateAdministration entries from {Path}",
-                result.Count, localJsonPath);
+            LogDelegateEntriesLoaded(this._logger, result.Count, localJsonPath);
             return result;
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to read delegateAdministration from local.json.");
+            LogDelegateReadFailed(this._logger, ex);
             return [];
         }
     }
@@ -373,7 +373,7 @@ public class AdminController(
         const string prefix = "webhook_delegates:";
         var allSettings = await this._pwebSettingService.GetAllAsync();
         var result = allSettings
-            .Where(s => s.Setting?.StartsWith(prefix) == true)
+            .Where(s => s.Setting?.StartsWith(prefix, StringComparison.Ordinal) == true)
             .ToDictionary(
                 s => s.Setting![prefix.Length..],
                 s => s.Value?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? []);
@@ -468,7 +468,7 @@ public class AdminController(
             new("type", human.Type ?? "discord:user"),
             new("isAdmin", "false"),
             new("enabled", (human.Enabled == 1 && human.AdminDisable == 0).ToString().ToLowerInvariant()),
-            new("profileNo", human.CurrentProfileNo.ToString()),
+            new("profileNo", human.CurrentProfileNo.ToString(CultureInfo.InvariantCulture)),
             new("impersonatedBy", this.UserId),
         };
 
@@ -487,7 +487,7 @@ public class AdminController(
             signingCredentials: credentials);
 
         var jwt = new JwtSecurityTokenHandler().WriteToken(token);
-        this._logger.LogInformation("Admin {AdminId} impersonating {UserId}", this.UserId, request.UserId);
+        LogAdminImpersonating(this._logger, this.UserId, request.UserId);
         return this.Ok(new
         {
             token = jwt
@@ -510,7 +510,7 @@ public class AdminController(
             return this.NotFound();
         }
 
-        this._logger.LogInformation("Admin {AdminId} deleted user {UserId}", this.UserId, id);
+        LogUserDeleted(this._logger, this.UserId, id);
         return this.NoContent();
     }
 
@@ -538,7 +538,7 @@ public class AdminController(
             new("type", human.Type ?? "discord:user"),
             new("isAdmin", "false"),
             new("enabled", (human.Enabled == 1 && human.AdminDisable == 0).ToString().ToLowerInvariant()),
-            new("profileNo", human.CurrentProfileNo.ToString()),
+            new("profileNo", human.CurrentProfileNo.ToString(CultureInfo.InvariantCulture)),
             new("impersonatedBy", this.UserId),
         };
 
@@ -558,7 +558,7 @@ public class AdminController(
 
         var jwt = new JwtSecurityTokenHandler().WriteToken(token);
 
-        this._logger.LogInformation("Admin {AdminId} impersonating user {UserId}", this.UserId, id);
+        LogAdminImpersonatingUser(this._logger, this.UserId, id);
 
         return this.Ok(new
         {
@@ -588,7 +588,7 @@ public class AdminController(
 
         try
         {
-            this._logger.LogInformation("Admin {AdminId} restarting Poracle server {Host}", this.UserId, host);
+            LogServerRestarting(this._logger, this.UserId, host);
             var status = await this._poracleServerService.RestartServerAsync(host);
             return this.Ok(status);
         }
@@ -601,7 +601,7 @@ public class AdminController(
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Failed to restart Poracle server {Host}", host);
+            LogServerRestartFailed(this._logger, ex, host);
             return this.StatusCode(500, new
             {
                 error = "Failed to restart server"
@@ -617,14 +617,14 @@ public class AdminController(
             return this.Forbid();
         }
 
-        this._logger.LogInformation("Admin {AdminId} restarting all Poracle servers", this.UserId);
+        LogAllServersRestarting(this._logger, this.UserId);
         var statuses = await this._poracleServerService.RestartAllAsync();
         return this.Ok(statuses);
     }
 
     private static string GetDefaultAvatarUrl(string userId, string? type)
     {
-        if (type?.StartsWith("discord") != true)
+        if (type?.StartsWith("discord", StringComparison.Ordinal) != true)
         {
             return "https://cdn.discordapp.com/embed/avatars/0.png";
         }
@@ -638,4 +638,33 @@ public class AdminController(
         return "https://cdn.discordapp.com/embed/avatars/0.png";
     }
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} created webhook {WebhookId}")]
+    private static partial void LogWebhookCreated(ILogger logger, string adminId, string webhookId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin list.")]
+    private static partial void LogPoracleConfigFetchFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} delegateAdministration entries from {Path}")]
+    private static partial void LogDelegateEntriesLoaded(ILogger logger, int count, string path);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to read delegateAdministration from local.json.")]
+    private static partial void LogDelegateReadFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} impersonating {UserId}")]
+    private static partial void LogAdminImpersonating(ILogger logger, string adminId, string userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} deleted user {UserId}")]
+    private static partial void LogUserDeleted(ILogger logger, string adminId, string userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} impersonating user {UserId}")]
+    private static partial void LogAdminImpersonatingUser(ILogger logger, string adminId, string userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} restarting Poracle server {Host}")]
+    private static partial void LogServerRestarting(ILogger logger, string adminId, string host);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to restart Poracle server {Host}")]
+    private static partial void LogServerRestartFailed(ILogger logger, Exception exception, string host);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Admin {AdminId} restarting all Poracle servers")]
+    private static partial void LogAllServersRestarting(ILogger logger, string adminId);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/AdminGeofenceController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/AdminGeofenceController.cs
@@ -4,7 +4,7 @@ using PGAN.Poracle.Web.Core.Abstractions.Services;
 namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/admin/geofences")]
-public class AdminGeofenceController(IUserGeofenceService userGeofenceService, ILogger<AdminGeofenceController> logger) : BaseApiController
+public partial class AdminGeofenceController(IUserGeofenceService userGeofenceService, ILogger<AdminGeofenceController> logger) : BaseApiController
 {
     private readonly IUserGeofenceService _userGeofenceService = userGeofenceService;
     private readonly ILogger<AdminGeofenceController> _logger = logger;
@@ -48,7 +48,7 @@ public class AdminGeofenceController(IUserGeofenceService userGeofenceService, I
         }
         catch (InvalidOperationException ex)
         {
-            this._logger.LogWarning(ex, "Failed to admin delete geofence {Id}", id);
+            LogAdminDeleteFailed(_logger, ex, id);
             return this.NotFound(new
             {
                 error = ex.Message
@@ -71,7 +71,7 @@ public class AdminGeofenceController(IUserGeofenceService userGeofenceService, I
         }
         catch (InvalidOperationException ex)
         {
-            this._logger.LogWarning(ex, "Failed to approve geofence submission {Id}", id);
+            LogApproveSubmissionFailed(_logger, ex, id);
             return this.NotFound(new
             {
                 error = ex.Message
@@ -94,7 +94,7 @@ public class AdminGeofenceController(IUserGeofenceService userGeofenceService, I
         }
         catch (InvalidOperationException ex)
         {
-            this._logger.LogWarning(ex, "Failed to reject geofence submission {Id}", id);
+            LogRejectSubmissionFailed(_logger, ex, id);
             return this.NotFound(new
             {
                 error = ex.Message
@@ -114,4 +114,13 @@ public class AdminGeofenceController(IUserGeofenceService userGeofenceService, I
     {
         public string ReviewNotes { get; set; } = string.Empty;
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to admin delete geofence {Id}")]
+    private static partial void LogAdminDeleteFailed(ILogger logger, Exception ex, int id);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to approve geofence submission {Id}")]
+    private static partial void LogApproveSubmissionFailed(ILogger logger, Exception ex, int id);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to reject geofence submission {Id}")]
+    private static partial void LogRejectSubmissionFailed(ILogger logger, Exception ex, int id);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/AreaController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/AreaController.cs
@@ -5,7 +5,7 @@ using PGAN.Poracle.Web.Core.Abstractions.Services;
 namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/areas")]
-public class AreaController(IHumanService humanService, IPoracleApiProxy poracleApiProxy, ILogger<AreaController> logger) : BaseApiController
+public partial class AreaController(IHumanService humanService, IPoracleApiProxy poracleApiProxy, ILogger<AreaController> logger) : BaseApiController
 {
     private readonly IHumanService _humanService = humanService;
     private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
@@ -30,7 +30,7 @@ public class AreaController(IHumanService humanService, IPoracleApiProxy poracle
             }
             catch (Exception ex)
             {
-                this._logger.LogWarning(ex, "Failed to parse area JSON for user {UserId}, falling back to comma-separated", this.UserId);
+                LogParseAreaJsonFailed(_logger, ex, this.UserId);
                 // Fallback: treat as comma-separated
                 areas = human.Area.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             }
@@ -52,7 +52,7 @@ public class AreaController(IHumanService humanService, IPoracleApiProxy poracle
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch available areas from Poracle API for user {UserId}", this.UserId);
+            LogFetchAvailableAreasFailed(_logger, ex, this.UserId);
         }
 
         return this.Ok(Array.Empty<object>());
@@ -94,7 +94,7 @@ public class AreaController(IHumanService humanService, IPoracleApiProxy poracle
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch geofence data from Poracle API");
+            LogFetchGeofenceDataFailed(_logger, ex);
         }
 
         return this.Ok(new
@@ -120,7 +120,7 @@ public class AreaController(IHumanService humanService, IPoracleApiProxy poracle
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch map URL for area {AreaName} from Poracle API", areaName);
+            LogFetchAreaMapFailed(_logger, ex, areaName);
         }
 
         return this.NotFound();
@@ -133,4 +133,16 @@ public class AreaController(IHumanService humanService, IPoracleApiProxy poracle
             get; set;
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse area JSON for user {UserId}, falling back to comma-separated")]
+    private static partial void LogParseAreaJsonFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch available areas from Poracle API for user {UserId}")]
+    private static partial void LogFetchAvailableAreasFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch geofence data from Poracle API")]
+    private static partial void LogFetchGeofenceDataFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch map URL for area {AreaName} from Poracle API")]
+    private static partial void LogFetchAreaMapFailed(ILogger logger, Exception ex, string areaName);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/AuthController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -16,7 +17,7 @@ namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/auth")]
 [EnableRateLimiting("auth")]
-public class AuthController(
+public partial class AuthController(
     IHumanService humanService,
     IPoracleApiProxy poracleApiProxy,
     IPwebSettingService pwebSettingService,
@@ -112,7 +113,7 @@ public class AuthController(
         if (!tokenResponse.IsSuccessStatusCode)
         {
             var errorBody = await tokenResponse.Content.ReadAsStringAsync();
-            this._logger.LogWarning("Discord token exchange failed: {Status} {Body}", tokenResponse.StatusCode, errorBody);
+            LogDiscordTokenExchangeFailed(this._logger, tokenResponse.StatusCode, errorBody);
             return this.Redirect($"{frontendUrl}/login#error=token_exchange_failed");
         }
 
@@ -355,7 +356,7 @@ public class AuthController(
             new("type", user.Type),
             new("isAdmin", user.IsAdmin.ToString().ToLowerInvariant()),
             new("enabled", user.Enabled.ToString().ToLowerInvariant()),
-            new("profileNo", user.ProfileNo.ToString()),
+            new("profileNo", user.ProfileNo.ToString(CultureInfo.InvariantCulture)),
         };
 
         if (!string.IsNullOrEmpty(user.AvatarUrl))
@@ -407,7 +408,7 @@ public class AuthController(
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch Poracle config for admin check for {UserId}.", userId);
+            LogPoracleConfigFetchFailed(this._logger, ex, userId);
         }
 
         // Call getAdministrationRoles once — resolves delegation including Discord guild roles
@@ -455,7 +456,7 @@ public class AuthController(
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch administration roles for {UserId}.", userId);
+            LogAdminRolesFetchFailed(this._logger, ex, userId);
         }
 
         if (isAdmin)
@@ -470,7 +471,7 @@ public class AuthController(
             const string prefix = "webhook_delegates:";
             foreach (var setting in allSettings)
             {
-                if (setting.Setting?.StartsWith(prefix) == true)
+                if (setting.Setting?.StartsWith(prefix, StringComparison.Ordinal) == true)
                 {
                     var delegates = setting.Value?.Split(',',
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
@@ -483,7 +484,7 @@ public class AuthController(
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch pweb_settings delegates for {UserId}.", userId);
+            LogPwebDelegatesFetchFailed(this._logger, ex, userId);
         }
 
         return (false, managed.Count > 0 ? managed.ToArray() : null);
@@ -520,7 +521,7 @@ public class AuthController(
             // Need bot token and guild ID to check roles
             if (string.IsNullOrEmpty(this._discordSettings.BotToken) || string.IsNullOrEmpty(this._discordSettings.GuildId))
             {
-                this._logger.LogWarning("Role-based access enabled but Discord BotToken or GuildId not configured.");
+                LogRoleMisconfigured(this._logger);
                 return null; // Misconfigured, fail open
             }
 
@@ -535,8 +536,7 @@ public class AuthController(
             if (!response.IsSuccessStatusCode)
             {
                 var errorBody = await response.Content.ReadAsStringAsync();
-                this._logger.LogWarning("Failed to fetch guild member {UserId}: {Status} {Body}",
-                    discordId, response.StatusCode, errorBody);
+                LogGuildMemberFetchFailed(this._logger, discordId, response.StatusCode, errorBody);
                 // 404 = not in guild, 403 = bot doesn't have access
                 return response.StatusCode == System.Net.HttpStatusCode.NotFound
                     ? "not_in_guild"
@@ -557,11 +557,12 @@ public class AuthController(
                 }
             }
 
-            this._logger.LogInformation(
-                "Role check for {UserId}: required=[{Required}], user=[{UserRoles}]",
-                discordId,
-                string.Join(", ", allowedRoles),
-                string.Join(", ", userRoles));
+            if (this._logger.IsEnabled(LogLevel.Information))
+            {
+#pragma warning disable CA1873 // args are only evaluated inside IsEnabled guard
+                LogRoleCheck(this._logger, discordId, string.Join(", ", allowedRoles), string.Join(", ", userRoles));
+#pragma warning restore CA1873
+            }
 
             // User must have ALL of the allowed roles
             if (allowedRoles.IsSubsetOf(userRoles))
@@ -569,12 +570,12 @@ public class AuthController(
                 return null;
             }
 
-            this._logger.LogInformation("User {UserId} denied: missing required roles.", discordId);
+            LogRoleDenied(this._logger, discordId);
             return "missing_required_role";
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Role check failed for {UserId}, denying access.", discordId);
+            LogRoleCheckFailed(this._logger, ex, discordId);
             return "role_check_failed";
         }
     }
@@ -593,4 +594,30 @@ public class AuthController(
         return $"{this.Request.Scheme}://{this.Request.Host}";
     }
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Role-based access enabled but Discord BotToken or GuildId not configured.")]
+    private static partial void LogRoleMisconfigured(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch guild member {UserId}: {Status} {Body}")]
+    private static partial void LogGuildMemberFetchFailed(ILogger logger, string userId, System.Net.HttpStatusCode status, string body);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Role check for {UserId}: required=[{Required}], user=[{UserRoles}]")]
+    private static partial void LogRoleCheck(ILogger logger, string userId, string required, string userRoles);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "User {UserId} denied: missing required roles.")]
+    private static partial void LogRoleDenied(ILogger logger, string userId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Role check failed for {UserId}, denying access.")]
+    private static partial void LogRoleCheckFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord token exchange failed: {Status} {Body}")]
+    private static partial void LogDiscordTokenExchangeFailed(ILogger logger, System.Net.HttpStatusCode status, string body);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]
+    private static partial void LogPoracleConfigFetchFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch administration roles for {UserId}.")]
+    private static partial void LogAdminRolesFetchFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch pweb_settings delegates for {UserId}.")]
+    private static partial void LogPwebDelegatesFetchFailed(ILogger logger, Exception ex, string userId);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/BaseApiController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/BaseApiController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +11,7 @@ namespace PGAN.Poracle.Web.Api.Controllers;
 public abstract class BaseApiController : ControllerBase
 {
     protected string UserId => this.User.FindFirstValue("userId") ?? throw new UnauthorizedAccessException();
-    protected int ProfileNo => int.Parse(this.User.FindFirstValue("profileNo") ?? "1");
+    protected int ProfileNo => int.Parse(this.User.FindFirstValue("profileNo") ?? "1", CultureInfo.InvariantCulture);
     protected bool IsAdmin => this.User.FindFirstValue("isAdmin") == "true";
     protected string Username => this.User.FindFirstValue("username") ?? string.Empty;
     protected string[] ManagedWebhooks => this.User.FindFirstValue("managedWebhooks")

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/ConfigController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/ConfigController.cs
@@ -6,7 +6,7 @@ using PGAN.Poracle.Web.Core.Models;
 namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/config")]
-public class ConfigController(IPoracleApiProxy poracleApiProxy, ILogger<ConfigController> logger) : BaseApiController
+public partial class ConfigController(IPoracleApiProxy poracleApiProxy, ILogger<ConfigController> logger) : BaseApiController
 {
     private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
     private readonly ILogger<ConfigController> _logger = logger;
@@ -25,7 +25,7 @@ public class ConfigController(IPoracleApiProxy poracleApiProxy, ILogger<ConfigCo
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch Poracle templates");
+            LogFetchTemplatesFailed(_logger, ex);
         }
 
         return this.Ok(new
@@ -67,7 +67,7 @@ public class ConfigController(IPoracleApiProxy poracleApiProxy, ILogger<ConfigCo
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch Poracle config");
+            LogFetchConfigFailed(_logger, ex);
         }
 
         return this.Ok(new PoracleConfig
@@ -86,4 +86,10 @@ public class ConfigController(IPoracleApiProxy poracleApiProxy, ILogger<ConfigCo
             MaxDistance = 10726000
         });
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle templates")]
+    private static partial void LogFetchTemplatesFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config")]
+    private static partial void LogFetchConfigFailed(ILogger logger, Exception ex);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/GeofenceFeedController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/GeofenceFeedController.cs
@@ -8,7 +8,7 @@ namespace PGAN.Poracle.Web.Api.Controllers;
 
 [ApiController]
 [Route("api/geofence-feed")]
-public class GeofenceFeedController(
+public partial class GeofenceFeedController(
     IUserGeofenceRepository repository,
     IKojiService kojiService,
     ILogger<GeofenceFeedController> logger) : ControllerBase
@@ -45,7 +45,7 @@ public class GeofenceFeedController(
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Failed to fetch admin geofences from Koji — serving user geofences only");
+            LogFetchAdminGeofencesFailed(_logger, ex);
         }
 
         // User geofences from local DB (not user-selectable, not displayed in matches)
@@ -61,7 +61,7 @@ public class GeofenceFeedController(
                 }
                 catch (JsonException ex)
                 {
-                    this._logger.LogWarning(ex, "Failed to deserialize polygon for geofence '{KojiName}' (ID {Id})", g.KojiName, g.Id);
+                    LogDeserializePolygonFailed(_logger, ex, g.KojiName, g.Id);
                 }
 
                 if (polygon == null || polygon.Length < 3)
@@ -88,4 +88,10 @@ public class GeofenceFeedController(
             data = combined,
         });
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to fetch admin geofences from Koji — serving user geofences only")]
+    private static partial void LogFetchAdminGeofencesFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to deserialize polygon for geofence '{KojiName}' (ID {Id})")]
+    private static partial void LogDeserializePolygonFailed(ILogger logger, Exception ex, string? kojiName, int id);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/ProfileController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/ProfileController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -121,7 +122,7 @@ public class ProfileController(
 
             claims.Add(new Claim(claim.Type, claim.Value));
         }
-        claims.Add(new Claim("profileNo", profileNo.ToString()));
+        claims.Add(new Claim("profileNo", profileNo.ToString(CultureInfo.InvariantCulture)));
 
         var token = new JwtSecurityToken(
             issuer: this._jwtSettings.Issuer,

--- a/Applications/PGAN.Poracle.Web.Api/Controllers/UserGeofenceController.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Controllers/UserGeofenceController.cs
@@ -5,7 +5,7 @@ using PGAN.Poracle.Web.Core.Models;
 namespace PGAN.Poracle.Web.Api.Controllers;
 
 [Route("api/geofences")]
-public class UserGeofenceController(IUserGeofenceService userGeofenceService, ILogger<UserGeofenceController> logger) : BaseApiController
+public partial class UserGeofenceController(IUserGeofenceService userGeofenceService, ILogger<UserGeofenceController> logger) : BaseApiController
 {
     private readonly IUserGeofenceService _userGeofenceService = userGeofenceService;
     private readonly ILogger<UserGeofenceController> _logger = logger;
@@ -27,7 +27,7 @@ public class UserGeofenceController(IUserGeofenceService userGeofenceService, IL
         }
         catch (InvalidOperationException ex)
         {
-            this._logger.LogWarning(ex, "Failed to create custom geofence for user {UserId}", this.UserId);
+            LogCreateGeofenceFailed(_logger, ex, this.UserId);
             return this.BadRequest(new
             {
                 error = ex.Message
@@ -52,7 +52,7 @@ public class UserGeofenceController(IUserGeofenceService userGeofenceService, IL
         }
         catch (UnauthorizedAccessException ex)
         {
-            this._logger.LogWarning(ex, "User {UserId} attempted to delete geofence ID {Id} they don't own", this.UserId, id);
+            LogDeleteGeofenceUnauthorized(_logger, ex, this.UserId, id);
             return this.Forbid();
         }
     }
@@ -74,7 +74,7 @@ public class UserGeofenceController(IUserGeofenceService userGeofenceService, IL
         }
         catch (UnauthorizedAccessException ex)
         {
-            this._logger.LogWarning(ex, "User {UserId} attempted to submit geofence '{KojiName}' they don't own", this.UserId, kojiName);
+            LogSubmitGeofenceUnauthorized(_logger, ex, this.UserId, kojiName);
             return this.Forbid();
         }
     }
@@ -89,8 +89,20 @@ public class UserGeofenceController(IUserGeofenceService userGeofenceService, IL
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to fetch geofence regions from Koji");
+            LogFetchRegionsFailed(_logger, ex);
             return this.Ok(Array.Empty<object>());
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to create custom geofence for user {UserId}")]
+    private static partial void LogCreateGeofenceFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "User {UserId} attempted to delete geofence ID {Id} they don't own")]
+    private static partial void LogDeleteGeofenceUnauthorized(ILogger logger, Exception ex, string userId, int id);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "User {UserId} attempted to submit geofence '{KojiName}' they don't own")]
+    private static partial void LogSubmitGeofenceUnauthorized(ILogger logger, Exception ex, string userId, string kojiName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch geofence regions from Koji")]
+    private static partial void LogFetchRegionsFailed(ILogger logger, Exception ex);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Program.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Program.cs
@@ -137,7 +137,7 @@ using (var scope = app.Services.CreateScope())
     {
         var startupLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger("Startup");
-        startupLogger.LogWarning(ex, "Could not alter pweb_settings.value column (may already be LONGTEXT).");
+        StartupLog.LogPwebSettingsAlterFailed(startupLogger, ex);
     }
 }
 
@@ -149,7 +149,7 @@ app.UseExceptionHandler(errorApp => errorApp.Run(async context =>
         var exceptionFeature = context.Features.Get<IExceptionHandlerFeature>();
         if (exceptionFeature is not null)
         {
-            logger.LogError(exceptionFeature.Error, "Unhandled exception occurred.");
+            StartupLog.LogUnhandledException(logger, exceptionFeature.Error);
         }
 
         context.Response.StatusCode = StatusCodes.Status500InternalServerError;
@@ -178,11 +178,11 @@ app.Use(async (context, next) =>
     context.Response.OnStarting(() =>
     {
         var headers = context.Response.Headers;
-        headers["X-Content-Type-Options"] = "nosniff";
-        headers["X-Frame-Options"] = "DENY";
-        headers["X-XSS-Protection"] = "0";
+        headers.XContentTypeOptions = "nosniff";
+        headers.XFrameOptions = "DENY";
+        headers.XXSSProtection = "0";
         headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
-        headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://raw.githubusercontent.com";
+        headers.ContentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://raw.githubusercontent.com";
         return Task.CompletedTask;
     });
     await next();
@@ -212,3 +212,12 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.Run();
+
+internal static partial class StartupLog
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not alter pweb_settings.value column (may already be LONGTEXT).")]
+    public static partial void LogPwebSettingsAlterFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unhandled exception occurred.")]
+    public static partial void LogUnhandledException(ILogger logger, Exception ex);
+}

--- a/Applications/PGAN.Poracle.Web.Api/Services/AvatarCacheService.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Services/AvatarCacheService.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace PGAN.Poracle.Web.Api.Services;
 
-public class AvatarCacheService(ILogger<AvatarCacheService> logger) : BackgroundService
+public partial class AvatarCacheService(ILogger<AvatarCacheService> logger) : BackgroundService
 {
     private readonly ILogger<AvatarCacheService> _logger = logger;
 
@@ -32,7 +32,7 @@ public class AvatarCacheService(ILogger<AvatarCacheService> logger) : Background
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         this.LoadFromDisk();
-        this._logger.LogInformation("Loaded {Count} avatars from disk cache.", Avatars.Count);
+        LogLoadedAvatars(this._logger, Avatars.Count);
         return Task.CompletedTask;
     }
 
@@ -59,7 +59,13 @@ public class AvatarCacheService(ILogger<AvatarCacheService> logger) : Background
         }
         catch (Exception ex)
         {
-            this._logger.LogWarning(ex, "Failed to load avatar cache from disk");
+            LogAvatarCacheLoadFailed(this._logger, ex);
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} avatars from disk cache.")]
+    private static partial void LogLoadedAvatars(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to load avatar cache from disk")]
+    private static partial void LogAvatarCacheLoadFailed(ILogger logger, Exception ex);
 }

--- a/Applications/PGAN.Poracle.Web.Api/Services/DtsCacheService.cs
+++ b/Applications/PGAN.Poracle.Web.Api/Services/DtsCacheService.cs
@@ -12,7 +12,7 @@ namespace PGAN.Poracle.Web.Api.Services;
 ///
 /// The service watches for file changes and reloads automatically.
 /// </summary>
-public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundService
+public partial class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundService
 {
     private readonly ILogger<DtsCacheService> _logger = logger;
     private static string? _cachedJson;
@@ -53,7 +53,7 @@ public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundServic
                     // Also save to data dir as a cache
                     var cachePath = Path.Combine(dataDir, "dts-cache.json");
                     File.WriteAllText(cachePath, merged);
-                    this._logger.LogInformation("DTS loaded from Poracle config at {Dir}", sourceDir);
+                    LogDtsLoadedFromConfig(this._logger, sourceDir);
                     return;
                 }
             }
@@ -67,15 +67,15 @@ public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundServic
                 {
                     _cachedJson = json;
                 }
-                this._logger.LogInformation("DTS loaded from cache file at {Path}", fallbackPath);
+                LogDtsLoadedFromCache(this._logger, fallbackPath);
                 return;
             }
 
-            this._logger.LogWarning("No DTS files found. Template previews will be unavailable.");
+            LogNoDtsFilesFound(this._logger);
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Failed to load DTS files");
+            LogDtsLoadFailed(this._logger, ex);
         }
     }
 
@@ -111,7 +111,7 @@ public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundServic
                 return null;
             }
 
-            this._logger.LogInformation("Loaded {Count} DTS entries from {Path}", mainEntries.Length, mainDtsPath);
+            LogDtsEntriesLoaded(this._logger, mainEntries.Length, mainDtsPath);
 
             // Look for override files
             var overrideCandidates = new[]
@@ -155,13 +155,13 @@ public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundServic
                             }
                         }
 
-                        this._logger.LogInformation("Merged {Count} DTS overrides from {Path}", overrides.Length, overridePath);
+                        LogDtsOverridesMerged(this._logger, overrides.Length, overridePath);
                         return JsonSerializer.Serialize(merged);
                     }
                 }
                 catch (Exception ex)
                 {
-                    this._logger.LogWarning(ex, "Failed to parse DTS override file at {Path}", overridePath);
+                    LogDtsOverrideParseFailed(this._logger, ex, overridePath);
                 }
             }
 
@@ -169,8 +169,32 @@ public class DtsCacheService(ILogger<DtsCacheService> logger) : BackgroundServic
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Failed to parse DTS from Poracle config at {Dir}", configDir);
+            LogDtsConfigParseFailed(this._logger, ex, configDir);
             return null;
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "DTS loaded from Poracle config at {Dir}")]
+    private static partial void LogDtsLoadedFromConfig(ILogger logger, string dir);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "DTS loaded from cache file at {Path}")]
+    private static partial void LogDtsLoadedFromCache(ILogger logger, string path);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No DTS files found. Template previews will be unavailable.")]
+    private static partial void LogNoDtsFilesFound(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to load DTS files")]
+    private static partial void LogDtsLoadFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} DTS entries from {Path}")]
+    private static partial void LogDtsEntriesLoaded(ILogger logger, int count, string path);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Merged {Count} DTS overrides from {Path}")]
+    private static partial void LogDtsOverridesMerged(ILogger logger, int count, string path);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse DTS override file at {Path}")]
+    private static partial void LogDtsOverrideParseFailed(ILogger logger, Exception ex, string path);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to parse DTS from Poracle config at {Dir}")]
+    private static partial void LogDtsConfigParseFailed(ILogger logger, Exception ex, string dir);
 }

--- a/Core/PGAN.Poracle.Web.Core.Services/PoracleServerService.cs
+++ b/Core/PGAN.Poracle.Web.Core.Services/PoracleServerService.cs
@@ -106,7 +106,7 @@ public partial class PoracleServerService(
         {
             var sshArgs = $"-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o SendEnv=none -i {this._sshKeyPath} {server.SshUser}@{server.Host} \"{server.RestartCommand}\"";
 
-            this._logger.LogInformation("Executing SSH restart command for server {Host}", server.Host);
+            LogExecutingSshRestart(this._logger, server.Host);
 
             using var process = new Process();
             process.StartInfo = new ProcessStartInfo
@@ -142,7 +142,7 @@ public partial class PoracleServerService(
                 catch { /* best effort */ }
                 status.Online = false;
                 status.Message = "SSH command timed out after 30 seconds";
-                this._logger.LogWarning("SSH restart timed out for server {Host}", server.Host);
+                LogSshRestartTimedOut(this._logger, server.Host);
             }
             else
             {
@@ -153,16 +153,14 @@ public partial class PoracleServerService(
                 status.Online = process.ExitCode == 0;
                 status.Message = output;
 
-                this._logger.LogInformation(
-                    "SSH restart for server {Host} completed with exit code {ExitCode}: {Output}",
-                    server.Host, process.ExitCode, output);
+                LogSshRestartCompleted(this._logger, server.Host, process.ExitCode, output);
             }
         }
         catch (Exception ex)
         {
             status.Online = false;
             status.Message = $"Failed to execute SSH command: {ex.Message}";
-            this._logger.LogError(ex, "Failed to restart server {Host} via SSH", server.Host);
+            LogRestartFailed(this._logger, ex, server.Host);
         }
 
         status.CheckedAt = DateTime.UtcNow;
@@ -222,18 +220,39 @@ public partial class PoracleServerService(
 
                 if (process.ExitCode == 0)
                 {
-                    this._logger.LogInformation("Updated group_map.json on {Host}: {Name} -> {Group}", server.Host, geofenceName, group);
+                    LogGroupMapUpdated(this._logger, server.Host, geofenceName, group);
                 }
                 else
                 {
                     var stderr = await process.StandardError.ReadToEndAsync();
-                    this._logger.LogWarning("Failed to update group_map.json on {Host}: {Error}", server.Host, stderr);
+                    LogGroupMapUpdateFailed(this._logger, server.Host, stderr);
                 }
             }
             catch (Exception ex)
             {
-                this._logger.LogWarning(ex, "Failed to update group_map.json on {Host}", server.Host);
+                LogGroupMapUpdateException(this._logger, ex, server.Host);
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Executing SSH restart command for server {Host}")]
+    private static partial void LogExecutingSshRestart(ILogger logger, string host);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SSH restart timed out for server {Host}")]
+    private static partial void LogSshRestartTimedOut(ILogger logger, string host);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "SSH restart for server {Host} completed with exit code {ExitCode}: {Output}")]
+    private static partial void LogSshRestartCompleted(ILogger logger, string host, int exitCode, string output);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to restart server {Host} via SSH")]
+    private static partial void LogRestartFailed(ILogger logger, Exception ex, string host);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Updated group_map.json on {Host}: {Name} -> {Group}")]
+    private static partial void LogGroupMapUpdated(ILogger logger, string host, string name, string group);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to update group_map.json on {Host}: {Error}")]
+    private static partial void LogGroupMapUpdateFailed(ILogger logger, string host, string error);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to update group_map.json on {Host}")]
+    private static partial void LogGroupMapUpdateException(ILogger logger, Exception ex, string host);
 }

--- a/Core/PGAN.Poracle.Web.Core.Services/QuickPickService.cs
+++ b/Core/PGAN.Poracle.Web.Core.Services/QuickPickService.cs
@@ -5,7 +5,7 @@ using PGAN.Poracle.Web.Core.Models;
 
 namespace PGAN.Poracle.Web.Core.Services;
 
-public class QuickPickService(
+public partial class QuickPickService(
     IPwebSettingService settingService,
     IMonsterService monsterService,
     IRaidService raidService,
@@ -175,9 +175,7 @@ public class QuickPickService(
         var json = JsonSerializer.Serialize(appliedState, JsonOptions);
         await this._settingService.CreateOrUpdateAsync(new PwebSetting { Setting = appliedKey, Value = json });
 
-        this._logger.LogInformation(
-            "Applied quick pick '{QuickPickId}' for user {UserId} profile {ProfileNo}, created {Count} alarm(s).",
-            quickPickId, userId, profileNo, trackedUids.Count);
+        LogQuickPickApplied(this._logger, quickPickId, userId, profileNo, trackedUids.Count);
 
         return appliedState;
     }
@@ -246,9 +244,7 @@ public class QuickPickService(
         // Delete the applied state
         await this._settingService.DeleteAsync(appliedKey);
 
-        this._logger.LogInformation(
-            "Removed quick pick '{QuickPickId}' for user {UserId} profile {ProfileNo}, deleted {Count} alarm(s).",
-            quickPickId, userId, profileNo, appliedState.TrackedUids.Count);
+        LogQuickPickRemoved(this._logger, quickPickId, userId, profileNo, appliedState.TrackedUids.Count);
 
         return true;
     }
@@ -269,8 +265,7 @@ public class QuickPickService(
             await this._settingService.DeleteAsync(key);
         }
 
-        this._logger.LogInformation("Seeding {Count} default quick picks (replaced {Existing} existing).",
-            Defaults.Count, existingKeys.Count);
+        LogSeedingDefaults(this._logger, Defaults.Count, existingKeys.Count);
 
         foreach (var definition in Defaults)
         {
@@ -770,4 +765,13 @@ public class QuickPickService(
         new() { Id = "lure-rainy", Name = "Rainy Lures", Description = "Track Rainy Lure Modules at PokeStops", Icon = "water_drop", Category = "Lures", AlarmType = "lure", SortOrder = 63, Filters = new() { ["lureId"] = 504 } },
         new() { Id = "lure-golden", Name = "Golden Lures", Description = "Track Golden Lure Modules at PokeStops", Icon = "stars", Category = "Lures", AlarmType = "lure", SortOrder = 64, Filters = new() { ["lureId"] = 505 } },
     ];
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Applied quick pick '{QuickPickId}' for user {UserId} profile {ProfileNo}, created {Count} alarm(s).")]
+    private static partial void LogQuickPickApplied(ILogger logger, string quickPickId, string userId, int profileNo, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Removed quick pick '{QuickPickId}' for user {UserId} profile {ProfileNo}, deleted {Count} alarm(s).")]
+    private static partial void LogQuickPickRemoved(ILogger logger, string quickPickId, string userId, int profileNo, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Seeding {Count} default quick picks (replaced {Existing} existing).")]
+    private static partial void LogSeedingDefaults(ILogger logger, int count, int existing);
 }

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/AdminControllerTests.cs
@@ -414,7 +414,7 @@ public class AdminControllerTests : ControllerTestBase
     public async Task GetPoracleAdminsHandlesProxyFailure()
     {
         SetupUser(this._sut, isAdmin: true);
-        this._proxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new Exception("fail"));
+        this._proxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new InvalidOperationException("fail"));
 
         var result = await this._sut.GetPoracleAdmins();
         // Should still return OK with just configured admin IDs
@@ -483,7 +483,7 @@ public class AdminControllerTests : ControllerTestBase
     {
         SetupUser(this._sut, isAdmin: true);
         this._poracleServerService.Setup(s => s.RestartServerAsync("10.0.0.1"))
-            .ThrowsAsync(new Exception("unexpected"));
+            .ThrowsAsync(new ApplicationException("unexpected"));
 
         var result = await this._sut.RestartPoracleServer("10.0.0.1");
         var statusCode = Assert.IsType<ObjectResult>(result);

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/AreaControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/AreaControllerTests.cs
@@ -167,7 +167,7 @@ public class AreaControllerTests : ControllerTestBase
     [Fact]
     public async Task GetGeofencePolygonsReturnsFallbackWhenThrows()
     {
-        this._proxy.Setup(p => p.GetAllGeofenceDataAsync()).ThrowsAsync(new Exception());
+        this._proxy.Setup(p => p.GetAllGeofenceDataAsync()).ThrowsAsync(new InvalidOperationException());
         Assert.IsType<OkObjectResult>(await this._sut.GetGeofencePolygons());
     }
 
@@ -191,7 +191,7 @@ public class AreaControllerTests : ControllerTestBase
     [Fact]
     public async Task GetAreaMapReturnsNotFoundWhenThrows()
     {
-        this._proxy.Setup(p => p.GetAreaMapUrlAsync(It.IsAny<string>())).ThrowsAsync(new Exception());
+        this._proxy.Setup(p => p.GetAreaMapUrlAsync(It.IsAny<string>())).ThrowsAsync(new InvalidOperationException());
         Assert.IsType<NotFoundResult>(await this._sut.GetAreaMap("bad"));
     }
 }

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/ConfigControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/ConfigControllerTests.cs
@@ -85,7 +85,7 @@ public class ConfigControllerTests : ControllerTestBase
     [Fact]
     public async Task GetConfigReturnsFallbackConfigWhenExceptionThrown()
     {
-        this._proxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new Exception("fail"));
+        this._proxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new InvalidOperationException("fail"));
 
         var result = await this._sut.GetConfig();
 

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/ControllerTestBase.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/ControllerTestBase.cs
@@ -11,7 +11,7 @@ public abstract class ControllerTestBase
         var claims = new List<Claim>
         {
             new("userId", userId),
-            new("profileNo", profileNo.ToString()),
+            new("profileNo", profileNo.ToString(System.Globalization.CultureInfo.InvariantCulture)),
             new("isAdmin", isAdmin.ToString().ToLowerInvariant()),
             new("username", username),
         };

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/LocationControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/LocationControllerTests.cs
@@ -154,7 +154,7 @@ public class LocationControllerTests : ControllerTestBase, IDisposable
     [Fact]
     public async Task GetStaticMapReturnsNotFoundWhenThrows()
     {
-        this._proxy.Setup(p => p.GetLocationMapUrlAsync(It.IsAny<double>(), It.IsAny<double>())).ThrowsAsync(new Exception());
+        this._proxy.Setup(p => p.GetLocationMapUrlAsync(It.IsAny<double>(), It.IsAny<double>())).ThrowsAsync(new InvalidOperationException());
         Assert.IsType<NotFoundResult>(await this._sut.GetStaticMap(0, 0));
     }
 
@@ -179,7 +179,7 @@ public class LocationControllerTests : ControllerTestBase, IDisposable
     public async Task GetDistanceMapReturnsNotFoundWhenThrows()
     {
         this._proxy.Setup(p => p.GetDistanceMapUrlAsync(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<int>()))
-            .ThrowsAsync(new Exception());
+            .ThrowsAsync(new InvalidOperationException());
         Assert.IsType<NotFoundResult>(await this._sut.GetDistanceMap(0, 0, 0));
     }
 

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/ScannerControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/ScannerControllerTests.cs
@@ -59,6 +59,6 @@ public class ScannerControllerTests : ControllerTestBase
         var result = await sut.GetActiveRaids();
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        Assert.Single(Assert.IsAssignableFrom<IEnumerable<RaidData>>(ok.Value));
+        Assert.Single(Assert.IsType<IEnumerable<RaidData>>(ok.Value, exactMatch: false));
     }
 }

--- a/Tests/PGAN.Poracle.Web.Tests/Controllers/UserGeofenceControllerTests.cs
+++ b/Tests/PGAN.Poracle.Web.Tests/Controllers/UserGeofenceControllerTests.cs
@@ -212,7 +212,7 @@ public class UserGeofenceControllerTests : ControllerTestBase
     [Fact]
     public async Task GetRegionsReturnsEmptyArrayWhenServiceThrows()
     {
-        this._service.Setup(s => s.GetRegionsAsync()).ThrowsAsync(new Exception("Koji unreachable"));
+        this._service.Setup(s => s.GetRegionsAsync()).ThrowsAsync(new InvalidOperationException("Koji unreachable"));
 
         var result = await this._sut.GetRegions();
 


### PR DESCRIPTION
## Summary
- Fixes #14 — eliminates all actionable build warnings across the solution (21 files, 0 code warnings remaining)
- Converts all `ILogger` extension method calls to `[LoggerMessage]` source-generated static partial methods for improved performance
- Fixes locale-sensitive `ToString`/`Parse`/`StartsWith` calls with explicit culture/comparison
- Replaces generic `Exception` with specific types in test mocks
- Uses typed header properties instead of string indexers in `Program.cs`
- Auto-formats 2 spec files with Prettier

## Test plan
- [x] All 410 backend tests pass
- [x] `dotnet build` — 0 code warnings
- [x] `npm run prettier-check` — all files clean
- [x] `dotnet format --verify-no-changes` — no formatting issues