### PR TITLE
fix: explicitly bringToFront smaller polygons for click priority

### DIFF
--- a/Applications/PGAN.Poracle.Web.App/ClientApp/src/app/shared/components/area-map/area-map.component.ts
+++ b/Applications/PGAN.Poracle.Web.App/ClientApp/src/app/shared/components/area-map/area-map.component.ts
@@ -377,6 +377,14 @@ export class AreaMapComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.polygonByName.set(fence.name, polygon);
     }
 
+    // Ensure smaller polygons are visually and interactively on top by
+    // bringing them to the front of the SVG/Canvas layer in reverse order
+    // (last bringToFront call wins, so iterate largest-to-smallest which
+    // is already the sort order — smallest ends up on top).
+    for (const layer of this.polygonLayers) {
+      layer.bringToFront();
+    }
+
     if (allBounds.length > 0) {
       this.allBoundsRect = L.latLngBounds(allBounds);
       if (!this.selectedRegion()) {


### PR DESCRIPTION
## Summary
- Follow-up to #12 / PR #13 — sorting polygons by area alone wasn't sufficient for Leaflet SVG hit detection
- Now explicitly calls `bringToFront()` on each polygon after rendering (largest first), ensuring smaller polygons end up at the top of the SVG DOM and receive click events

## Test plan
- [ ] Open area selection page with a small polygon inside a larger one
- [ ] Verify clicking the smaller polygon selects it (not the larger one)