### PR TITLE
fix: dashboard profile card shows 'Default' when no profiles exist

### DIFF
--- a/Applications/PGAN.Poracle.Web.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
+++ b/Applications/PGAN.Poracle.Web.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
@@ -96,9 +96,10 @@ export class DashboardComponent implements OnInit {
   readonly profiles = signal<Profile[]>([]);
   readonly profileName = computed(() => {
     const profiles = this.profiles();
+    if (profiles.length === 0) return 'Default';
     const no = this.profileNo();
     const match = profiles.find(p => p.profileNo === no);
-    return match?.name ?? `Profile ${no}`;
+    return match?.name ?? 'Default';
   });
 
   readonly selectedAreas = signal<string[]>([]);


### PR DESCRIPTION
## Summary
- Show "Default" instead of "Profile 1" when user has no profile records
- Applies to both the zero-profiles case and the case where a profile record exists but doesn't match the current profile number

Closes #23

## Test plan
- [x] 391 frontend tests pass
- [ ] Verify users with no profiles see "Default" on the dashboard
- [ ] Verify users with named profiles still see their profile name