### PR TITLE
docs: add MkDocs Material documentation site with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocs-mermaid2-plugin
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# PGAN.Poracle.Web
+# PoracleWeb.NET
 
-A web application for managing Poracle Pokemon GO notification alarms. Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+A web application for managing [Poracle](https://github.com/KartulUdworworkin/PoracleJS) Pokemon GO notification alarms. Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+
+**[Documentation](https://pgan-dev.github.io/PoracleWeb.NET/)** | **[Changelog](CHANGELOG.md)**
 
 ## Tech Stack
 
@@ -10,553 +12,71 @@ A web application for managing Poracle Pokemon GO notification alarms. Users aut
 - **Testing**: Jest (frontend), xUnit (backend)
 - **CI/CD**: GitHub Actions, Docker (ghcr.io)
 
-## Prerequisites
-
-| Requirement | Version | Purpose |
-|---|---|---|
-| MySQL | 5.7+ or 8.0+ | Poracle database (existing Poracle installation) |
-| Poracle | PoracleJS | Running instance with REST API enabled |
-| Discord App | - | OAuth2 application for user authentication |
-| Koji | - | Geofence management server (required for custom geofences feature) |
-| .NET SDK | 10.0 | Backend development (not needed for Docker) |
-| Node.js | 22+ | Frontend development (not needed for Docker) |
-| Docker | 20+ | Production deployment |
-
 ## Quick Start (Docker)
 
-This is the recommended way to run in production.
-
-### 1. Create environment file
-
-Copy the example and fill in your values:
-
 ```bash
+# 1. Configure
 cp .env.example .env
-```
+# Edit .env with your database, Discord, and Poracle settings
 
-Edit `.env` with your configuration:
-
-```env
-# Database — your existing Poracle MySQL instance
-DB_HOST=host.docker.internal    # Use host IP if not on same machine
-DB_PORT=3306
-DB_NAME=poracle
-DB_USER=root
-DB_PASSWORD=your_db_password
-
-# JWT Secret — generate a random string, minimum 32 characters
-JWT_SECRET=generate-a-long-random-secret-key-at-least-32-chars
-
-# Discord OAuth2 — create an app at https://discord.com/developers/applications
-# Set the redirect URI to: http://your-domain:8082/auth/discord/callback
-DISCORD_CLIENT_ID=your_discord_client_id
-DISCORD_CLIENT_SECRET=your_discord_client_secret
-DISCORD_BOT_TOKEN=your_discord_bot_token      # Optional: enables avatar display
-DISCORD_GUILD_ID=your_discord_server_id        # Optional: for guild-specific features
-
-# Poracle API — your running PoracleJS instance
-PORACLE_API_ADDRESS=http://host.docker.internal:3030
-PORACLE_API_SECRET=your_poracle_api_secret
-PORACLE_ADMIN_IDS=your_discord_user_id         # Comma-separated admin Discord IDs
-
-# Poracle config directory — mount for DTS template previews
-PORACLE_CONFIG_DIR=/path/to/PoracleJS/config
-
-# Optional: PoracleWeb DB for custom geofences (separate from Poracle DB)
-WEB_DB_HOST=host.docker.internal
-WEB_DB_PORT=3306
-WEB_DB_NAME=poracle_web
-WEB_DB_USER=root
-WEB_DB_PASSWORD=your_db_password
-
-# Optional: Koji geofence API (required for custom geofences)
-KOJI_API_ADDRESS=http://host.docker.internal:8080
-KOJI_BEARER_TOKEN=your_koji_bearer_token
-KOJI_PROJECT_ID=1
-KOJI_PROJECT_NAME=your_koji_project_name   # Project name for /geofence/poracle/{name} endpoint
-
-# Optional: Discord forum channel for geofence submission threads
-DISCORD_GEOFENCE_FORUM_CHANNEL_ID=
-
-# Optional: Scanner DB for nest/Pokemon data
-# SCANNER_DB_CONNECTION=Server=host.docker.internal;Port=3306;Database=rdmdb;User=root;Password=your_password
-
-# Optional: Telegram authentication
-TELEGRAM_ENABLED=false
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_BOT_USERNAME=
-```
-
-### 2. Start with pre-built image from GitHub Container Registry
-
-Pull the latest image from `ghcr.io` and start:
-
-```bash
+# 2. Pull and run
 docker pull ghcr.io/pgan-dev/poracleweb.net:latest
-```
-
-Update `docker-compose.yml` to use the registry image:
-
-```yaml
-services:
-  poracle-web:
-    image: ghcr.io/pgan-dev/poracleweb.net:latest
-    # ...rest of config
-```
-
-Then start:
-
-```bash
 docker compose up -d
 ```
 
 The app will be available at **http://localhost:8082**.
 
-### 3. Build from source (alternative)
-
-If you want to build the Docker image locally instead of pulling from the registry:
-
-```bash
-# Build and tag the image
-docker build -t poracleweb-local:latest .
-
-# Update docker-compose.yml to use local image:
-#   image: poracleweb-local:latest
-
-# Start the container
-docker compose up -d
-```
-
-To force a clean rebuild:
-
-```bash
-docker build --no-cache -t poracleweb-local:latest .
-docker compose up -d --force-recreate
-```
-
-### Updating
-
-```bash
-# If using ghcr.io image:
-docker pull ghcr.io/pgan-dev/poracleweb.net:latest
-docker compose up -d --force-recreate
-
-# If building from source:
-git pull
-docker build -t poracleweb-local:latest .
-docker compose up -d --force-recreate
-```
-
-## Development Setup
-
-### 1. Clone and install dependencies
-
-```bash
-git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
-cd PoracleWeb.NET
-
-# Install frontend dependencies
-cd Applications/PGAN.Poracle.Web.App/ClientApp
-npm install
-cd ../../..
-```
-
-### 2. Configure secrets
-
-Create `Applications/PGAN.Poracle.Web.Api/appsettings.Development.json` (gitignored):
-
-```json
-{
-  "ConnectionStrings": {
-    "PoracleDb": "Server=localhost;Port=3306;Database=poracle;User=root;Password=your_password;AllowZeroDateTime=true;ConvertZeroDateTime=true",
-    "PoracleWebDb": "Server=localhost;Port=3306;Database=poracle_web;User=root;Password=your_password;AllowZeroDateTime=true;ConvertZeroDateTime=true",
-    "ScannerDb": ""
-  },
-  "Jwt": {
-    "Secret": "your-development-secret-key-at-least-32-characters-long"
-  },
-  "Discord": {
-    "ClientId": "your_discord_client_id",
-    "ClientSecret": "your_discord_client_secret",
-    "RedirectUri": "http://localhost:4200/auth/discord/callback",
-    "FrontendUrl": "http://localhost:4200",
-    "BotToken": "your_discord_bot_token",
-    "GuildId": "your_discord_guild_id",
-    "GeofenceForumChannelId": ""
-  },
-  "Telegram": {
-    "Enabled": false,
-    "BotToken": "",
-    "BotUsername": ""
-  },
-  "Poracle": {
-    "ApiAddress": "http://localhost:3030",
-    "ApiSecret": "your_poracle_secret",
-    "AdminIds": "your_discord_user_id"
-  },
-  "Koji": {
-    "ApiAddress": "http://localhost:8080",
-    "BearerToken": "your_koji_bearer_token",
-    "ProjectId": 1,
-    "ProjectName": "your_koji_project_name"
-  }
-}
-```
-
-### 3. Run the application
-
-You need two terminals — one for the backend API and one for the Angular dev server:
-
-**Terminal 1 — Backend API (http://localhost:5048):**
-
-```bash
-cd Applications/PGAN.Poracle.Web.Api
-dotnet run
-```
-
-**Terminal 2 — Frontend dev server (http://localhost:4200):**
-
-```bash
-cd Applications/PGAN.Poracle.Web.App/ClientApp
-npm start
-```
-
-The Angular dev server proxies API requests to the .NET backend. Open **http://localhost:4200** in your browser.
-
-### 4. Running tests
-
-```bash
-# Frontend tests (Jest)
-cd Applications/PGAN.Poracle.Web.App/ClientApp
-npm test
-
-# Backend tests (xUnit)
-dotnet test
-```
-
-### 5. Linting and formatting
-
-```bash
-cd Applications/PGAN.Poracle.Web.App/ClientApp
-
-# Check lint
-npm run lint
-
-# Check formatting
-npm run prettier-check
-
-# Auto-fix lint issues
-npx eslint --fix src/
-
-# Auto-format code
-npm run prettier-format
-```
-
-## Project Structure
-
-```
-PGAN.Poracle.Web.slnx
-├── Applications/
-│   ├── Web.Api/                    ASP.NET Core host
-│   │   ├── Controllers/            REST API controllers (all under /api/)
-│   │   │                           incl. UserGeofenceController, AdminGeofenceController,
-│   │   │                           GeofenceFeedController
-│   │   ├── Configuration/          DI registration, settings classes (incl. KojiSettings)
-│   │   └── Services/               Background services (avatar cache, DTS cache)
-│   └── Web.App/ClientApp/          Angular 21 SPA
-│       └── src/app/
-│           ├── core/               Guards, services, interceptors, models
-│           ├── modules/            Feature pages (dashboard, pokemon, raids, geofences, etc.)
-│           └── shared/             Reusable components (area-map, pokemon-selector,
-│                                   region-selector, geofence-name-dialog,
-│                                   geofence-approval-dialog, etc.)
-│                                   utils/ (geo.utils: point-in-polygon, centroid)
-├── Core/
-│   ├── Core.Abstractions/          Interfaces (IRepository, IService, IUnitOfWork)
-│   ├── Core.Models/                DTOs passed between layers
-│   ├── Core.Mappings/              AutoMapper profiles
-│   ├── Core.Repositories/          Data access implementations
-│   ├── Core.Services/              Business logic (incl. UserGeofenceService, KojiService,
-│   │                               DiscordNotificationService)
-│   └── Core.UnitsOfWork/           Unit of work pattern
-├── Data/
-│   ├── Data/                       EF Core DbContexts (PoracleContext, PoracleWebContext),
-│   │                               Entities (incl. UserGeofenceEntity), Configurations
-│   └── Data.Scanner/               Optional scanner DB context (RDM)
-└── Tests/
-    └── PGAN.Poracle.Web.Tests/     xUnit backend tests
-```
-
-## Configuration Reference
-
-All configuration can be provided via environment variables (Docker) or `appsettings.json` (development):
-
-| Setting | Env Variable | Required | Description |
-|---|---|---|---|
-| `ConnectionStrings:PoracleDb` | `ConnectionStrings__PoracleDb` | Yes | MySQL connection to Poracle database |
-| `ConnectionStrings:PoracleWebDb` | `ConnectionStrings__PoracleWebDb` | No | MySQL connection to PoracleWeb database (user geofences). Required for custom geofences feature. |
-| `ConnectionStrings:ScannerDb` | `ConnectionStrings__ScannerDb` | No | Scanner database connection (RDM) |
-| `Jwt:Secret` | `Jwt__Secret` | Yes | JWT signing key (minimum 32 characters) |
-| `Jwt:ExpirationMinutes` | `Jwt__ExpirationMinutes` | No | Token expiry, default 1440 (24 hours) |
-| `Discord:ClientId` | `Discord__ClientId` | Yes | Discord OAuth2 application client ID |
-| `Discord:ClientSecret` | `Discord__ClientSecret` | Yes | Discord OAuth2 application client secret |
-| `Discord:BotToken` | `Discord__BotToken` | No | Enables Discord avatar display |
-| `Discord:GuildId` | `Discord__GuildId` | No | Discord server ID |
-| `Discord:GeofenceForumChannelId` | `Discord__GeofenceForumChannelId` | No | Discord forum channel for geofence submission threads |
-| `Telegram:Enabled` | `Telegram__Enabled` | No | Enable Telegram authentication (default: false) |
-| `Telegram:BotToken` | `Telegram__BotToken` | No | Telegram bot token |
-| `Telegram:BotUsername` | `Telegram__BotUsername` | No | Telegram bot username |
-| `Poracle:ApiAddress` | `Poracle__ApiAddress` | Yes | Poracle API base URL |
-| `Poracle:ApiSecret` | `Poracle__ApiSecret` | Yes | Poracle API shared secret |
-| `Poracle:AdminIds` | `Poracle__AdminIds` | Yes | Comma-separated Discord admin user IDs |
-| `Koji:ApiAddress` | `Koji__ApiAddress` | No | Koji geofence server URL. Required for custom geofences feature. |
-| `Koji:BearerToken` | `Koji__BearerToken` | No | Koji API bearer token for authentication |
-| `Koji:ProjectId` | `Koji__ProjectId` | No | Koji project ID for admin-promoted geofences (default: 0) |
-| `Koji:ProjectName` | `Koji__ProjectName` | No | Koji project name for fetching geofences from `/geofence/poracle/{name}` endpoint. Required for unified geofence feed. |
-| `Poracle:Servers` | `Poracle__Servers__0__Name`, etc. | No | Array of PoracleJS server configs (name, host, API address, SSH user) for remote management |
-| `Poracle:SshKeyPath` | `Poracle__SshKeyPath` | No | Path to SSH private key inside container (default `/app/ssh_key`) |
-| `Cors:AllowedOrigins` | `Cors__AllowedOrigins__0` | No | Allowed CORS origin (empty = allow all) |
-
-## Custom Geofences Setup
-
-Users can draw custom polygon geofences on the "My Geofences" page for precise notification zones (e.g., park boundaries) instead of distance-from-center circles.
-
-### How it works
-
-PoracleWeb acts as the **single geofence source** for PoracleJS. Instead of PoracleJS connecting to Koji directly, PoracleWeb fetches admin geofences from Koji, resolves group names from the Koji parent chain, merges them with user-drawn geofences from its own database, and serves everything via one endpoint. No custom code is needed in PoracleJS or Koji — standard upstream versions work.
-
-1. User draws a polygon on the map, saved to the PoracleWeb database
-2. PoracleWeb serves a **unified geofence feed** via `GET /api/geofence-feed` — admin geofences from Koji (cached 5 minutes) plus user geofences from the local DB
-3. PoracleJS loads **all** geofences from a single PoracleWeb URL (no direct Koji connection needed)
-4. User geofences have `displayInMatches: false` — names are hidden from all DMs for privacy
-5. Admin geofences have `displayInMatches: true` and `group` populated from Koji parent hierarchy
-6. Users can submit geofences for admin review, which creates a Discord forum post with a static map
-7. Admins approve, and the geofence is promoted to Koji as a public area visible to all users
-8. If Koji is unreachable, user geofences are still served (graceful degradation)
-9. If PoracleWeb itself is down, PoracleJS falls back to its built-in `.cache/` directory
-
-### Component Diagram
-
-```mermaid
-graph LR
-    KojiServer[(Koji Server<br/>Public areas)] -->|admin geofences<br/>cached 5 min| PoracleWeb
-    subgraph PoracleWeb
-        Feed[GeofenceFeedController<br/>GET /api/geofence-feed<br/>Unified proxy]
-        DB[(poracle_web DB<br/>user geofences)]
-    end
-    PoracleWeb -->|single URL<br/>admin + user geofences| Poracle[PoracleJS<br/>geofence.path]
-    Poracle -.->|failover| Cache[PoracleJS .cache/]
-```
-
-**Detailed internal flow:**
-
-```mermaid
-graph TB
-    subgraph PoracleWeb
-        UI1[My Geofences Page<br/>Draw / Name / Submit]
-        UI2[Geofence Mgmt<br/>Approve / Reject / Delete]
-        Feed[GeofenceFeedController<br/>GET /api/geofence-feed<br/>Unified proxy]
-        Svc[UserGeofenceService<br/>Create / Delete / Submit / Approve]
-        Koji[KojiService<br/>Fetch admin geofences + approve]
-        Discord[DiscordNotificationService<br/>Forum posts + maps]
-    end
-
-    DB[(poracle_web DB<br/>user_geofences)]
-    KojiServer[(Koji Server<br/>Public areas)]
-    DiscordForum[(Discord Forum<br/>Threads + Tags)]
-    Poracle[PoracleJS<br/>Single URL to PoracleWeb]
-
-    UI1 --> Svc
-    UI2 --> Svc
-    Svc --> DB
-    Svc --> Koji
-    Svc --> Discord
-    Feed --> DB
-    Feed --> Koji
-    Koji --> KojiServer
-    Discord --> DiscordForum
-    Feed -.->|admin + user geofences| Poracle
-```
-
-### Geofence Lifecycle Flow
-
-```mermaid
-stateDiagram-v2
-    [*] --> Create : User draws polygon
-    Create --> Active : Save to DB + add to area + reload Poracle
-
-    Active --> Active : Alerts work via feed endpoint
-    Active --> Submitted : User clicks Submit for Review
-
-    Submitted --> PendingReview : Discord forum post created with map
-    PendingReview --> PendingReview : Still works privately
-
-    PendingReview --> Approved : Admin approves
-    PendingReview --> Rejected : Admin rejects
-
-    Approved --> [*] : Push to Koji as public area\nLock Discord thread
-    Rejected --> Active : Stays private with review notes\nLock Discord thread
-
-    note right of Active : Private — only owner\ngets alerts.\nName hidden from\nall DMs.
-    note right of Approved : Public — all users\ncan select it on\nthe Areas page.
-```
-
-### Setup
-
-1. **Create the PoracleWeb database** — a separate MySQL/MariaDB database for app-owned data:
-   ```sql
-   CREATE DATABASE poracle_web;
-   ```
-   The `user_geofences` table is created automatically on first run.
-
-2. **Configure the Koji connection** — set the following in your environment or `appsettings.json`:
-   - `Koji:ApiAddress` — Koji server URL (e.g., `http://localhost:8080`)
-   - `Koji:BearerToken` — Koji API bearer token
-   - `Koji:ProjectId` — Koji project ID for promoted geofences
-   - `Koji:ProjectName` — Koji project name, used to fetch geofences from the `/geofence/poracle/{name}` endpoint
-
-3. **Point PoracleJS to PoracleWeb** — set `geofence.path` to a single PoracleWeb URL. PoracleJS no longer needs a direct Koji connection for geofences:
-   ```json
-   "geofence": {
-     "path": "http://poracleweb-host:8082/api/geofence-feed"
-   }
-   ```
-   Remove `kojiOptions.bearerToken` from the PoracleJS geofence config if present (it is harmless if left, but no longer needed).
-
-4. **Remove `group_map.json`** from PoracleJS if it exists — group names are now resolved automatically from the Koji parent chain by PoracleWeb.
-
-5. **Restart PoracleJS** — `pm2 restart all`
-
-6. **Discord forum channel** (optional) — for geofence submission discussions. Set `Discord:GeofenceForumChannelId` and give the bot **View Channel**, **Send Messages in Threads**, and **Manage Threads** permissions on the channel. Forum tags (Pending/Approved/Rejected) are auto-created if the bot has **Manage Channels** permission, or create them manually.
-
-> **PoracleJS Failover**: PoracleJS's built-in `.cache/` directory automatically caches geofence data. If PoracleWeb is temporarily unavailable, PoracleJS falls back to its last cached copy.
-
-## Poracle Server Management Setup
-
-Admins can monitor and restart PoracleJS instances remotely from the "Poracle Servers" admin page.
-
-### How it works
-
-1. Health check pings each server's API endpoint — any HTTP response = online, no response = offline
-2. Restart executes an SSH command (default: `pm2 restart all`) on the remote server
-3. Each server can have a custom restart command (e.g., for macOS where PM2 isn't in PATH)
-
-### Component Diagram
-
-```mermaid
-graph TB
-    subgraph PoracleWeb
-        UI[Poracle Servers Page<br/>Status cards + Restart buttons]
-        Svc[PoracleServerService<br/>Health check + SSH restart]
-    end
-
-    UI --> Svc
-
-    subgraph Servers
-        S1[Main Server<br/>10.0.3.178 · Linux<br/>API :3030 · root]
-        S2[Secondary Server<br/>10.0.6.107 · macOS<br/>API :3035 · hokiepokedad]
-    end
-
-    Svc -->|HTTP health check| S1
-    Svc -->|HTTP health check| S2
-    Svc -->|SSH + pm2 restart all| S1
-    Svc -->|SSH + PATH=... pm2 restart all| S2
-```
-
-### Restart Flow
-
-```mermaid
-flowchart TD
-    A[Admin clicks Restart] --> B{Confirm Dialog}
-    B -->|Cancel| Z[No action]
-    B -->|Confirm| C[POST /api/admin/poracle/servers/host/restart]
-    C --> D[SSH to server with key<br/>30 second timeout]
-    D --> E{Result}
-    E -->|Exit code 0| F[✅ Snackbar: Server restarted<br/>Status refreshed]
-    E -->|Timeout 30s| G[⚠️ Kill process tree<br/>Snackbar: Timed out]
-    E -->|SSH error| H[❌ Snackbar: Failed<br/>Check key/host]
-```
-
-### Requirements
-
-1. **SSH key** — mount a private key that has access to your PoracleJS servers:
-   ```yaml
-   # docker-compose.yml
-   volumes:
-     - /path/to/your/ssh_key:/app/ssh_key:ro
-   ```
-   Or in `docker-compose.override.yml`:
-   ```yaml
-   services:
-     poracle-web:
-       volumes:
-         - ~/.ssh/id_ed25519:/app/ssh_key:ro
-   ```
-
-2. **Server configuration** — add servers via environment variables in `.env`:
-   ```env
-   # Server 1 (Linux)
-   PORACLE_SERVER_1_NAME=Main
-   PORACLE_SERVER_1_HOST=10.0.3.178
-   PORACLE_SERVER_1_API=http://10.0.3.178:3030
-   PORACLE_SERVER_1_SSH_USER=root
-   # PORACLE_SERVER_1_RESTART_CMD=pm2 restart all   # default
-
-   # Server 2 (macOS — needs full PATH for PM2)
-   PORACLE_SERVER_2_NAME=Secondary
-   PORACLE_SERVER_2_HOST=10.0.6.107
-   PORACLE_SERVER_2_API=http://10.0.6.107:3035
-   PORACLE_SERVER_2_SSH_USER=hokiepokedad
-   PORACLE_SERVER_2_RESTART_CMD=PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin pm2 restart all
-   ```
-
-3. **SSH access** — ensure the SSH key is authorized on each PoracleJS server (`~/.ssh/authorized_keys`).
-
-4. **Firewall** — the Docker container needs SSH access (port 22) to each PoracleJS server, and HTTP access to each server's API port for health checks.
-
-## Docker Compose Details
-
-The `docker-compose.yml` configures:
-
-- **Port mapping**: Host `8082` → Container `8080`
-- **Volumes**: `./data` for avatar/DTS cache persistence, Poracle config directory (read-only)
-- **Health check**: HTTP check every 30s with 15s startup grace period
-- **Resource limits**: 2 CPUs, 2GB memory
-- **Logging**: JSON file driver, 10MB max per file, 3 file rotation
-- **Restart policy**: `unless-stopped`
-
-## Discord OAuth2 Setup
-
-1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
-2. Create a new application
-3. Under **OAuth2**, add a redirect URI:
-   - Production: `http://your-domain:8082/auth/discord/callback`
-   - Development: `http://localhost:4200/auth/discord/callback`
-4. Copy the **Client ID** and **Client Secret**
-5. Optionally, create a Bot under the application for avatar display support
-
-## CI/CD
-
-Two GitHub Actions workflows run on push to `main` and pull requests:
-
-- **ci.yml**: Builds backend (.NET 10), runs backend tests, builds frontend (Angular), runs lint/prettier/jest
-- **docker-publish.yml**: Builds Docker image and publishes to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net) with `latest` and commit SHA tags
+See the [Quick Start guide](https://pgan-dev.github.io/PoracleWeb.NET/getting-started/quick-start/) for detailed setup instructions.
 
 ## Features
 
-- **Alarm Management**: Create, edit, and delete filters for Pokemon, Raids, Quests, Invasions, Lures, Nests, and Gyms
-- **Bulk Operations**: Multi-select alarms with bulk delete and bulk distance update
-- **Quick Picks**: Admin-defined alarm templates users can apply with one click
-- **Area Management**: Interactive Leaflet map for selecting geofence areas
-- **Custom Geofences**: Users can draw custom geofence polygons on a map, which are automatically added to their active areas. Geofences are served to PoracleJS via a built-in feed endpoint. Users can submit geofences for admin review to be promoted to public areas.
-- **Geofence Admin Review**: Admins can review, approve, or reject user-submitted geofences. Approved geofences are promoted to Koji as public areas. Discord forum integration provides threaded discussion for each submission with auto-tagging (Pending/Approved/Rejected).
-- **Profile Switching**: Multiple alarm profiles per user
-- **Discord Notification Preview**: Live preview of DTS templates with Handlebars evaluation
-- **Dark/Light Mode**: Theme toggle with localStorage persistence
-- **Accent Themes**: Customizable toolbar and UI accent colors (Pokemon, Raids, Mystic, Valor, Instinct)
-- **Responsive Design**: Full mobile support with fullscreen dialogs and collapsible sidebar
-- **Onboarding Wizard**: First-run setup guide for new users
-- **Keyboard Shortcuts**: `?` for help, `[`/`]` for sidebar collapse
-- **18 Languages**: Pokemon name localization
-- **Poracle Server Management**: Monitor health and restart PoracleJS instances remotely from the admin panel, with multi-server support and SSH + PM2 integration
-- **Admin Panel**: User management, webhook configuration, site settings, geofence submission review
+- **Alarm Management** — Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms
+- **Bulk Operations** — Multi-select with bulk delete and distance update
+- **Custom Geofences** — Draw polygons, auto-served to PoracleJS via unified feed
+- **Geofence Admin Review** — Approve/reject with Discord forum integration
+- **Quick Picks** — One-click alarm templates
+- **Profile Switching** — Multiple alarm profiles per user
+- **DTS Preview** — Live Discord notification template preview
+- **Dark/Light Mode** — Theme toggle with accent color customization
+- **Server Management** — Monitor and restart PoracleJS instances remotely
+- **18 Languages** — Pokemon name localization
+- **Admin Panel** — User management, webhooks, settings, geofence review
+
+## Documentation
+
+Full documentation is available at **[pgan-dev.github.io/PoracleWeb.NET](https://pgan-dev.github.io/PoracleWeb.NET/)**:
+
+- [Quick Start (Docker)](https://pgan-dev.github.io/PoracleWeb.NET/getting-started/quick-start/)
+- [Development Setup](https://pgan-dev.github.io/PoracleWeb.NET/getting-started/development-setup/)
+- [Configuration Reference](https://pgan-dev.github.io/PoracleWeb.NET/configuration/reference/)
+- [Architecture Overview](https://pgan-dev.github.io/PoracleWeb.NET/architecture/overview/)
+- [Custom Geofences](https://pgan-dev.github.io/PoracleWeb.NET/features/custom-geofences/)
+- [Server Management](https://pgan-dev.github.io/PoracleWeb.NET/features/server-management/)
+- [Troubleshooting](https://pgan-dev.github.io/PoracleWeb.NET/troubleshooting/)
+
+## Development
+
+```bash
+# Clone
+git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
+cd PoracleWeb.NET
+
+# Backend (http://localhost:5048)
+cd Applications/PGAN.Poracle.Web.Api
+dotnet run
+
+# Frontend (http://localhost:4200)
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+npm install && npm start
+
+# Tests
+dotnet test                  # Backend
+cd Applications/PGAN.Poracle.Web.App/ClientApp && npm test  # Frontend
+```
+
+See the [Development Setup guide](https://pgan-dev.github.io/PoracleWeb.NET/getting-started/development-setup/) for full instructions.
+
+## CI/CD
+
+- **ci.yml** — Builds backend, runs tests, builds frontend, runs lint/prettier/jest
+- **docker-publish.yml** — Builds and publishes Docker image to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net)

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -1,0 +1,95 @@
+# Backend Patterns
+
+## Repository layer
+
+`BaseRepository<TEntity, TModel>` uses expression-based filters and AutoMapper projections.
+
+### EnsureNotNullDefaults
+
+Many Poracle DB columns are `NOT NULL` with empty-string defaults, but EF Core maps them as `string?`. The `EnsureNotNullDefaults()` method sets null strings to `""` before saving to avoid constraint violations.
+
+### Targeted distance updates
+
+`UpdateDistanceByUidsAsync()` does targeted distance-only SQL updates without touching other fields. Use this for bulk distance operations instead of the generic `UpdateAsync`.
+
+## AutoMapper update models
+
+All `*Update` models (MonsterUpdate, RaidUpdate, etc.) use **nullable `int?`** properties so partial updates don't zero out unset fields.
+
+```csharp
+// The mapping profile skips null properties
+.ForAllMembers(opts => opts.Condition((_, _, srcMember) => srcMember != null))
+```
+
+!!! danger "Full object spread required"
+    When calling the PUT `/{uid}` endpoint from the frontend, always spread the full alarm object:
+
+    ```typescript
+    // ✅ Correct — preserves all existing fields
+    this.http.put(`/api/pokemon/${uid}`, { ...alarm, distance });
+
+    // ❌ Wrong — zeros out clean, template, filter settings
+    this.http.put(`/api/pokemon/${uid}`, { distance });
+    ```
+
+## Bulk operations
+
+Each alarm controller has three distance endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `PUT /{uid}` | Update a single alarm (full object) |
+| `PUT /distance` | Update ALL alarms' distance for the current user/profile |
+| `PUT /distance/bulk` | Update distance for specific UIDs: `{ uids: number[], distance: number }` |
+
+The `/distance/bulk` endpoint does a targeted `SetDistance()` on matching entities, bypassing AutoMapper entirely — safe for bulk operations.
+
+## Poracle API proxy
+
+`IPoracleApiProxy` / `PoracleApiProxy` wraps HttpClient calls to the external Poracle REST API.
+
+- Used for: fetching config, areas/geofences, templates, sending commands
+- Registered via `AddHttpClient<IPoracleApiProxy, PoracleApiProxy>()`
+
+### Config parsing
+
+`PoracleConfig` is parsed from Poracle's JSON configuration. The `defaultTemplateName` field can be a number or string — deserialization handles both via `JsonElement`.
+
+## Areas
+
+User areas are stored as JSON arrays in the `humans.area` column:
+
+```json
+["west end", "downtown"]
+```
+
+Geofence polygons come from the Poracle API (via the unified feed), not the database.
+
+## Service lifetimes
+
+| Service | Lifetime | Reason |
+|---|---|---|
+| Most services | **Scoped** | Per-request |
+| `MasterDataService` | **Singleton** | Cached game data |
+
+!!! warning "DbContext is not thread-safe"
+    `DashboardService` runs sequential DB queries (not `Task.WhenAll`) because it uses a single scoped `DbContext` instance.
+
+## Profiles
+
+- `humans.current_profile_no` (not `profile_no`) tracks the active profile
+- All alarm tables reference `profile_no` to filter by active profile
+
+## Rate limiting
+
+Auth endpoints use **per-IP** partitioned rate limiting:
+
+| Policy | Limit | Window |
+|---|---|---|
+| `auth` | 30 requests | 60 seconds |
+| `auth-read` | 120 requests | 60 seconds |
+
+Configured in `Program.cs` using `RateLimitPartition.GetFixedWindowLimiter` keyed by `RemoteIpAddress`.
+
+!!! danger "Never use global rate limiting for auth"
+    Global (non-partitioned) `AddFixedWindowLimiter` for auth causes cascading login failures — multiple users share one bucket.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,0 +1,64 @@
+# Database
+
+PoracleWeb uses two separate MySQL databases and optionally connects to a third scanner database.
+
+## Database contexts
+
+### PoracleContext
+
+The primary EF Core context connecting to the existing **Poracle database** managed by PoracleJS.
+
+- Connection string: `ConnectionStrings:PoracleDb`
+- Contains: `humans`, `monsters`, `raid`, `quest`, `invasion`, `lure`, `nest`, `gym`, `egg`, `profile` tables
+- **Read-write** — PoracleWeb manages alarm filters and user settings but does not modify the schema
+
+!!! warning "MySQL provider"
+    This project uses `MySql.EntityFrameworkCore` (Oracle's official provider), **not** Pomelo (`Pomelo.EntityFrameworkCore.MySql`), which is incompatible with EF Core 10. Connection setup uses `options.UseMySQL(connectionString)` (capital SQL).
+
+### PoracleWebContext
+
+A separate EF Core context for **application-owned data**.
+
+- Connection string: `ConnectionStrings:PoracleWebDb`
+- Database: `poracle_web`
+- Contains: `user_geofences` table
+- Schema managed by EF Core `EnsureCreated()` or migrations
+- Does **not** modify the Poracle DB schema
+
+### RdmScannerContext (optional)
+
+Connects to an RDM scanner database for nest/Pokemon data.
+
+- Connection string: `ConnectionStrings:ScannerDb`
+- If not configured, `IScannerService` is not registered and scanner endpoints return appropriate responses
+
+## Entity conventions
+
+### NULL string columns
+
+Many Poracle DB columns are `NOT NULL` with empty-string defaults, but EF Core maps them as `string?`. The `EnsureNotNullDefaults()` method in `BaseRepository` handles this:
+
+```csharp
+// Sets all null string properties to "" before saving
+protected void EnsureNotNullDefaults(TEntity entity)
+```
+
+Call this before any save operation to avoid MySQL constraint violations.
+
+## User geofences table
+
+The `user_geofences` table stores user-drawn polygon geofences:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | int (PK) | Auto-increment ID |
+| `discord_id` | string | Owner's Discord ID |
+| `display_name` | string | User-provided name |
+| `koji_name` | string | Lowercase Poracle-compatible name |
+| `polygon` | JSON | Array of lat/lng coordinates |
+| `status` | string | `active`, `pending_review`, `approved`, `rejected` |
+| `region` | string | Auto-detected region name |
+| `review_notes` | string | Admin notes on approval/rejection |
+| `discord_thread_id` | string | Discord forum thread ID |
+| `created_at` | datetime | Creation timestamp |
+| `updated_at` | datetime | Last update timestamp |

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,0 +1,70 @@
+# Frontend Patterns
+
+## Angular conventions
+
+- All components are **standalone** (no NgModules)
+- Uses `inject()` function instead of constructor injection
+- Uses Angular signals for reactive state where applicable
+- Lazy-loaded routes in `app.routes.ts`
+- Services in `core/services/` use `HttpClient` to call the .NET API
+
+## Project structure
+
+```
+src/app/
+├── core/
+│   ├── guards/          Auth guard, admin guard
+│   ├── services/        HTTP services for each API resource
+│   ├── interceptors/    JWT token interceptor
+│   └── models/          TypeScript interfaces
+├── modules/
+│   ├── auth/            Login page
+│   ├── dashboard/       Dashboard with onboarding
+│   ├── pokemon/         Pokemon alarm management
+│   ├── raids/           Raid alarm management
+│   ├── quests/          Quest alarm management
+│   ├── invasions/       Invasion alarm management
+│   ├── lures/           Lure alarm management
+│   ├── nests/           Nest alarm management
+│   ├── gyms/            Gym alarm management
+│   ├── areas/           Area selection with map
+│   ├── geofences/       Custom geofence drawing
+│   ├── profiles/        Profile management
+│   ├── cleaning/        Alarm cleanup tools
+│   ├── quick-picks/     Quick pick alarm templates
+│   └── admin/           Admin panel (users, servers, geofences)
+└── shared/
+    ├── components/      Reusable UI components
+    └── utils/           Utility functions (geo.utils, etc.)
+```
+
+## UI patterns
+
+### Alarm lists
+Card grid with filter pills showing IV/CP/Level/PVP/Gender at a glance.
+
+### Bulk operations
+Select mode toggle (checklist icon) on each alarm list. Bulk toolbar provides Select All, Update Distance, and Delete actions.
+
+### Loading states
+Animated skeleton card placeholders on Pokemon, Raids, and Quests pages.
+
+### Animations
+Grid items fade in with 30ms stagger delay.
+
+### Theming
+
+**Accent themes** — Toolbar gradient, sidenav active link, and UI accent colors are customizable via the user menu. Colors are applied as CSS custom properties on `document.body.style` to work across Angular's view encapsulation.
+
+**Dark/light mode** — CSS variables bridge Material tokens to component styles. Theme stored in `localStorage('poracle-theme')`.
+
+### Onboarding wizard
+Shows on the dashboard for new users until explicitly dismissed. Detects existing location/areas/alarms and marks steps as complete. Route-based actions (Choose Areas, Add Alarm) hide the overlay temporarily without setting the localStorage completion flag.
+
+### Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| ++question++ | Help |
+| ++bracket-left++ | Collapse sidebar |
+| ++bracket-right++ | Expand sidebar |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,84 @@
+# Architecture Overview
+
+PoracleWeb is a full-stack application with a .NET 10 backend API and Angular 21 frontend SPA.
+
+## Solution structure
+
+```
+PGAN.Poracle.Web.slnx
+├── Applications/
+│   ├── Web.Api/                    ASP.NET Core host
+│   │   ├── Controllers/            REST API controllers (all under /api/)
+│   │   ├── Configuration/          DI registration, settings classes
+│   │   └── Services/               Background services (avatar cache, DTS cache)
+│   └── Web.App/ClientApp/          Angular 21 SPA
+│       └── src/app/
+│           ├── core/               Guards, services, interceptors, models
+│           ├── modules/            Feature pages (dashboard, pokemon, raids, etc.)
+│           └── shared/             Reusable components, utilities
+├── Core/
+│   ├── Core.Abstractions/          Interfaces (IRepository, IService, IUnitOfWork)
+│   ├── Core.Models/                DTOs passed between layers
+│   ├── Core.Mappings/              AutoMapper profiles
+│   ├── Core.Repositories/          Data access implementations
+│   ├── Core.Services/              Business logic
+│   └── Core.UnitsOfWork/           Unit of work pattern
+├── Data/
+│   ├── Data/                       EF Core DbContexts, Entities, Configurations
+│   └── Data.Scanner/               Optional scanner DB context (RDM)
+└── Tests/
+    └── PGAN.Poracle.Web.Tests/     xUnit backend tests
+```
+
+## Layer diagram
+
+```mermaid
+graph TB
+    subgraph Frontend
+        Angular[Angular 21 SPA<br/>Material Design 3]
+    end
+
+    subgraph Backend["ASP.NET Core API"]
+        Controllers[Controllers<br/>20+ REST endpoints]
+        Services[Services<br/>Business logic]
+        Repositories[Repositories<br/>Data access]
+        UoW[Unit of Work]
+    end
+
+    subgraph Data
+        PoracleDB[(Poracle DB<br/>MySQL)]
+        WebDB[(PoracleWeb DB<br/>MySQL)]
+        ScannerDB[(Scanner DB<br/>RDM · Optional)]
+    end
+
+    subgraph External
+        Poracle[PoracleJS API]
+        Koji[Koji Server]
+        Discord[Discord API]
+    end
+
+    Angular -->|HTTP / JWT| Controllers
+    Controllers --> Services
+    Services --> Repositories
+    Services --> UoW
+    Repositories --> PoracleDB
+    Repositories --> WebDB
+    Repositories --> ScannerDB
+    Services -->|HttpClient| Poracle
+    Services -->|HttpClient| Koji
+    Services -->|HttpClient| Discord
+```
+
+## Key design decisions
+
+### Separate databases
+PoracleWeb does **not** modify the Poracle DB schema. The Poracle database remains exclusively managed by PoracleJS. Application-owned data (user geofences, etc.) lives in a separate `poracle_web` database.
+
+### Unified geofence feed
+PoracleWeb acts as the single geofence source for PoracleJS. It fetches admin geofences from Koji, merges them with user-drawn geofences, and serves everything via one endpoint (`GET /api/geofence-feed`). No custom code needed in PoracleJS or Koji.
+
+### AutoMapper for partial updates
+All update models use nullable `int?` properties so partial updates don't zero out unset fields. The mapping profile skips null properties automatically.
+
+### Per-IP rate limiting
+Auth endpoints use per-IP partitioned rate limiting (not global). This prevents one user's activity from locking out others.

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -1,0 +1,82 @@
+# Docker Compose
+
+The `docker-compose.yml` provides a production-ready container configuration.
+
+## Container settings
+
+| Setting | Value |
+|---|---|
+| **Port mapping** | Host `8082` → Container `8080` |
+| **Volumes** | `./data` for avatar/DTS cache persistence, Poracle config directory (read-only) |
+| **Health check** | HTTP check every 30s with 15s startup grace period |
+| **Resource limits** | 2 CPUs, 2GB memory |
+| **Logging** | JSON file driver, 10MB max per file, 3 file rotation |
+| **Restart policy** | `unless-stopped` |
+
+## Example docker-compose.yml
+
+```yaml
+services:
+  poracle-web:
+    image: ghcr.io/pgan-dev/poracleweb.net:latest
+    ports:
+      - "8082:8080"
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+      - ${PORACLE_CONFIG_DIR}:/app/poracle-config:ro
+    restart: unless-stopped
+```
+
+## Volume mounts
+
+### Data directory
+
+The `./data` directory persists:
+
+- Cached Discord avatars
+- Cached DTS template files
+
+### Poracle config directory
+
+Mount your PoracleJS `config/` directory as read-only for DTS template preview functionality:
+
+```yaml
+volumes:
+  - /path/to/PoracleJS/config:/app/poracle-config:ro
+```
+
+### SSH key (optional)
+
+For remote server management, mount an SSH private key:
+
+```yaml
+volumes:
+  - ~/.ssh/id_ed25519:/app/ssh_key:ro
+```
+
+Or in `docker-compose.override.yml`:
+
+```yaml
+services:
+  poracle-web:
+    volumes:
+      - ~/.ssh/id_ed25519:/app/ssh_key:ro
+```
+
+## Building locally
+
+```bash
+# Build from source
+docker build -t poracleweb-local:latest .
+
+# Force clean rebuild
+docker build --no-cache -t poracleweb-local:latest .
+
+# Start
+docker compose up -d
+
+# Force recreate
+docker compose up -d --force-recreate
+```

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -1,0 +1,74 @@
+# Configuration Reference
+
+All configuration can be provided via environment variables (Docker) or `appsettings.json` (development).
+
+## Required settings
+
+| Setting | Env Variable | Description |
+|---|---|---|
+| `ConnectionStrings:PoracleDb` | `ConnectionStrings__PoracleDb` | MySQL connection to Poracle database |
+| `Jwt:Secret` | `Jwt__Secret` | JWT signing key (minimum 32 characters) |
+| `Discord:ClientId` | `Discord__ClientId` | Discord OAuth2 application client ID |
+| `Discord:ClientSecret` | `Discord__ClientSecret` | Discord OAuth2 application client secret |
+| `Poracle:ApiAddress` | `Poracle__ApiAddress` | Poracle API base URL |
+| `Poracle:ApiSecret` | `Poracle__ApiSecret` | Poracle API shared secret |
+| `Poracle:AdminIds` | `Poracle__AdminIds` | Comma-separated Discord admin user IDs |
+
+## Optional settings
+
+### Authentication
+
+| Setting | Env Variable | Default | Description |
+|---|---|---|---|
+| `Jwt:ExpirationMinutes` | `Jwt__ExpirationMinutes` | `1440` | Token expiry (24 hours) |
+| `Discord:BotToken` | `Discord__BotToken` | — | Enables Discord avatar display |
+| `Discord:GuildId` | `Discord__GuildId` | — | Discord server ID |
+| `Discord:GeofenceForumChannelId` | `Discord__GeofenceForumChannelId` | — | Forum channel for geofence submission threads |
+| `Telegram:Enabled` | `Telegram__Enabled` | `false` | Enable Telegram authentication |
+| `Telegram:BotToken` | `Telegram__BotToken` | — | Telegram bot token |
+| `Telegram:BotUsername` | `Telegram__BotUsername` | — | Telegram bot username |
+
+### Databases
+
+| Setting | Env Variable | Description |
+|---|---|---|
+| `ConnectionStrings:PoracleWebDb` | `ConnectionStrings__PoracleWebDb` | MySQL connection to PoracleWeb database (user geofences). Required for custom geofences feature. |
+| `ConnectionStrings:ScannerDb` | `ConnectionStrings__ScannerDb` | Scanner database connection (RDM). Optional. |
+
+### Koji geofence API
+
+Required for the custom geofences feature.
+
+| Setting | Env Variable | Description |
+|---|---|---|
+| `Koji:ApiAddress` | `Koji__ApiAddress` | Koji geofence server URL (e.g., `http://localhost:8080`) |
+| `Koji:BearerToken` | `Koji__BearerToken` | Koji API bearer token for authentication |
+| `Koji:ProjectId` | `Koji__ProjectId` | Koji project ID for admin-promoted geofences (default: `0`) |
+| `Koji:ProjectName` | `Koji__ProjectName` | Koji project name for `/geofence/poracle/{name}` endpoint |
+
+### Poracle servers
+
+For remote PoracleJS server management. See [Server Management](../features/server-management.md) for full setup.
+
+| Setting | Env Variable | Description |
+|---|---|---|
+| `Poracle:Servers` | `Poracle__Servers__0__Name`, etc. | Array of PoracleJS server configs (name, host, API address, SSH user) |
+| `Poracle:SshKeyPath` | `Poracle__SshKeyPath` | Path to SSH private key inside container (default `/app/ssh_key`) |
+
+### CORS
+
+| Setting | Env Variable | Description |
+|---|---|---|
+| `Cors:AllowedOrigins` | `Cors__AllowedOrigins__0` | Allowed CORS origin (empty = allow all) |
+
+## Configuration sources
+
+| Source | Use case |
+|---|---|
+| `appsettings.Development.json` | Local development (gitignored) |
+| `.env` file | Docker deployment |
+| `docker-compose.yml` | Environment variable mapping |
+| `pweb_settings` table | Runtime Poracle API address override |
+
+!!! note "Secrets"
+    `appsettings.Development.json` is gitignored and holds all connection strings, JWT secret, Discord/Telegram credentials, and Poracle API address/secret. Never commit secrets to the repository.

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -1,0 +1,33 @@
+# CI/CD
+
+Two GitHub Actions workflows run on push to `main` and pull requests.
+
+## ci.yml
+
+Runs on every push and PR:
+
+1. **Backend** — Build .NET 10 solution, run xUnit tests
+2. **Frontend** — Install dependencies, run ESLint, run Prettier check, run Jest tests, build Angular
+
+## docker-publish.yml
+
+Runs on push to `main`:
+
+1. Builds the Docker image
+2. Publishes to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net)
+3. Tags with `latest` and commit SHA
+
+## changelog.yml
+
+Runs on merged PRs:
+
+- Extracts the PR title and categorizes using conventional commit prefixes (`feat`, `fix`, `refactor`, `docs`, etc.)
+- Inserts the entry into the `[Unreleased]` section of `CHANGELOG.md`
+- Commits the update automatically
+
+## release-changelog.yml
+
+Runs on GitHub release events:
+
+- Converts the `[Unreleased]` section to a versioned section with date
+- Updates comparison links

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -1,0 +1,46 @@
+# Code Style
+
+## Frontend
+
+### Prettier
+
+Configured in `.prettierrc`:
+
+| Setting | Value |
+|---|---|
+| Print width | 140 characters |
+| Quotes | Single quotes |
+| Indentation | 2 spaces |
+
+### ESLint
+
+Configured with:
+
+- Angular plugin
+- Perfectionist plugin (sorted class members)
+- Prettier plugin (formatting integration)
+
+### EditorConfig
+
+Configured in `ClientApp/.editorconfig`:
+
+- 2-space indentation
+- UTF-8 encoding
+
+### Commands
+
+```bash
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+
+# Check lint
+npm run lint
+
+# Check formatting
+npm run prettier-check
+
+# Auto-fix lint issues
+npx eslint --fix src/
+
+# Auto-format code
+npm run prettier-format
+```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,32 @@
+# Testing
+
+## Frontend tests (Jest)
+
+```bash
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+npm test
+```
+
+Uses Jest with `jest-preset-angular`. Tests cover:
+
+- Services (`user-geofence.service.spec.ts`, `admin-geofence.service.spec.ts`)
+- Components (`region-selector.component.spec.ts`)
+- Dialogs (`geofence-name-dialog.component.spec.ts`, `geofence-approval-dialog.component.spec.ts`)
+- Utilities (`geo.utils.spec.ts`)
+- Pipes
+
+## Backend tests (xUnit)
+
+```bash
+dotnet test
+```
+
+Uses xUnit with Moq. Tests cover:
+
+- Controllers (`UserGeofenceControllerTests`, `AdminGeofenceControllerTests`, `GeofenceFeedControllerTests`)
+- Services (`UserGeofenceServiceTests`)
+- AutoMapper mappings
+
+## CI
+
+Both test suites run automatically on push/PR to `main` via GitHub Actions. See [CI/CD](ci-cd.md) for workflow details.

--- a/docs/features/alarms.md
+++ b/docs/features/alarms.md
@@ -1,0 +1,61 @@
+# Alarm Management
+
+PoracleWeb provides a browser-based UI for managing Poracle notification filters. Users create alarms that tell Poracle which Pokemon, Raids, Quests, and other events to send as DM notifications.
+
+## Alarm types
+
+| Type | Description |
+|---|---|
+| **Pokemon** | Filter by species, IV, CP, level, PVP rank, gender, size |
+| **Raids** | Filter by raid boss, tier, EX eligibility |
+| **Quests** | Filter by reward type and Pokemon |
+| **Invasions** | Filter by grunt type and shadow Pokemon |
+| **Lures** | Filter by lure type |
+| **Nests** | Filter by nesting Pokemon species |
+| **Gyms** | Filter by gym team changes |
+
+## Creating alarms
+
+Each alarm type has a dedicated page accessible from the sidebar navigation. The creation flow:
+
+1. Click the **+** (add) button
+2. Select the Pokemon/raid/quest target using the selector dialog
+3. Configure filter options (IV range, CP range, level, etc.)
+4. Set a **distance** — how far from your location to receive alerts (in meters)
+5. Optionally select a **template** for notification formatting
+6. Save the alarm
+
+## Alarm cards
+
+Alarms are displayed as a card grid. Each card shows:
+
+- Pokemon sprite or raid/quest icon
+- **Filter pills** — Quick-glance badges showing active filters (IV, CP, Level, PVP, Gender)
+- Distance setting
+- Template name
+- Edit/delete actions
+
+## Bulk operations
+
+Each alarm list page has a **select mode** toggle (checklist icon in the toolbar):
+
+1. Toggle select mode on
+2. Check individual alarms or use **Select All**
+3. The bulk toolbar appears with available actions:
+    - **Update Distance** — Set a new distance for all selected alarms
+    - **Delete** — Remove all selected alarms
+
+!!! tip "Bulk distance uses a dedicated endpoint"
+    Bulk distance updates use `PUT /distance/bulk` which does a targeted SQL update without touching other alarm fields. This is safer than updating each alarm individually.
+
+## Profiles
+
+Users can maintain multiple alarm profiles. Only one profile is active at a time.
+
+- Switch profiles from the **Profiles** page or the user menu
+- Each alarm is associated with a `profile_no`
+- The active profile is tracked by `humans.current_profile_no`
+
+## Quick Picks
+
+Admins can define **Quick Pick** templates — pre-configured alarm sets that users can apply with one click. Useful for onboarding new users or sharing recommended configurations.

--- a/docs/features/custom-geofences.md
+++ b/docs/features/custom-geofences.md
@@ -1,0 +1,170 @@
+# Custom Geofences
+
+Users can draw custom polygon geofences on the "My Geofences" page for precise notification zones (e.g., park boundaries) instead of distance-from-center circles.
+
+## How it works
+
+PoracleWeb acts as the **single geofence source** for PoracleJS. Instead of PoracleJS connecting to Koji directly, PoracleWeb fetches admin geofences from Koji, resolves group names from the Koji parent chain, merges them with user-drawn geofences from its own database, and serves everything via one endpoint. No custom code is needed in PoracleJS or Koji — standard upstream versions work.
+
+1. User draws a polygon on the map, saved to the PoracleWeb database
+2. PoracleWeb serves a **unified geofence feed** via `GET /api/geofence-feed` — admin geofences from Koji (cached 5 minutes) plus user geofences from the local DB
+3. PoracleJS loads **all** geofences from a single PoracleWeb URL (no direct Koji connection needed)
+4. User geofences have `displayInMatches: false` — names are hidden from all DMs for privacy
+5. Admin geofences have `displayInMatches: true` and `group` populated from Koji parent hierarchy
+6. Users can submit geofences for admin review, which creates a Discord forum post with a static map
+7. Admins approve, and the geofence is promoted to Koji as a public area visible to all users
+8. If Koji is unreachable, user geofences are still served (graceful degradation)
+9. If PoracleWeb itself is down, PoracleJS falls back to its built-in `.cache/` directory
+
+## Component diagram
+
+```mermaid
+graph LR
+    KojiServer[(Koji Server<br/>Public areas)] -->|admin geofences<br/>cached 5 min| PoracleWeb
+    subgraph PoracleWeb
+        Feed[GeofenceFeedController<br/>GET /api/geofence-feed<br/>Unified proxy]
+        DB[(poracle_web DB<br/>user geofences)]
+    end
+    PoracleWeb -->|single URL<br/>admin + user geofences| Poracle[PoracleJS<br/>geofence.path]
+    Poracle -.->|failover| Cache[PoracleJS .cache/]
+```
+
+## Detailed internal flow
+
+```mermaid
+graph TB
+    subgraph PoracleWeb
+        UI1[My Geofences Page<br/>Draw / Name / Submit]
+        UI2[Geofence Mgmt<br/>Approve / Reject / Delete]
+        Feed[GeofenceFeedController<br/>GET /api/geofence-feed<br/>Unified proxy]
+        Svc[UserGeofenceService<br/>Create / Delete / Submit / Approve]
+        Koji[KojiService<br/>Fetch admin geofences + approve]
+        Discord[DiscordNotificationService<br/>Forum posts + maps]
+    end
+
+    DB[(poracle_web DB<br/>user_geofences)]
+    KojiServer[(Koji Server<br/>Public areas)]
+    DiscordForum[(Discord Forum<br/>Threads + Tags)]
+    Poracle[PoracleJS<br/>Single URL to PoracleWeb]
+
+    UI1 --> Svc
+    UI2 --> Svc
+    Svc --> DB
+    Svc --> Koji
+    Svc --> Discord
+    Feed --> DB
+    Feed --> Koji
+    Koji --> KojiServer
+    Discord --> DiscordForum
+    Feed -.->|admin + user geofences| Poracle
+```
+
+## Geofence lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Create : User draws polygon
+    Create --> Active : Save to DB + add to area + reload Poracle
+
+    Active --> Active : Alerts work via feed endpoint
+    Active --> Submitted : User clicks Submit for Review
+
+    Submitted --> PendingReview : Discord forum post created with map
+    PendingReview --> PendingReview : Still works privately
+
+    PendingReview --> Approved : Admin approves
+    PendingReview --> Rejected : Admin rejects
+
+    Approved --> [*] : Push to Koji as public area\nLock Discord thread
+    Rejected --> Active : Stays private with review notes\nLock Discord thread
+
+    note right of Active : Private — only owner\ngets alerts.\nName hidden from\nall DMs.
+    note right of Approved : Public — all users\ncan select it on\nthe Areas page.
+```
+
+## Geofence statuses
+
+| Status | Description |
+|---|---|
+| `active` | Private, user-only. Alerts work via the feed endpoint. |
+| `pending_review` | Submitted for admin review. Discord forum post created. Still works privately. |
+| `approved` | Promoted to Koji as a public area. Visible to all users. |
+| `rejected` | Remains private with review notes. User can continue using it. |
+
+## Limits
+
+- Maximum **10** custom geofences per user
+- Polygons limited to **500** points
+
+## Naming rules
+
+- Geofence names (`kojiName` field) are always **lowercase** because Poracle does case-sensitive area matching
+- Names are auto-generated from the user-provided display name (lowercased)
+- Collisions are resolved by appending a numeric suffix
+
+## Caching
+
+- Admin geofences from Koji are cached in memory for **5 minutes** (`IMemoryCache`)
+- Cache is invalidated when a geofence is approved/promoted to Koji
+- User geofences are served directly from the database (no caching)
+
+## Failover
+
+| Failure | Behavior |
+|---|---|
+| Koji unreachable | Feed endpoint logs the error, still serves user geofences from DB |
+| PoracleWeb down | PoracleJS falls back to its built-in `.cache/` directory |
+
+## Setup
+
+### 1. Create the PoracleWeb database
+
+A separate MySQL/MariaDB database for app-owned data:
+
+```sql
+CREATE DATABASE poracle_web;
+```
+
+The `user_geofences` table is created automatically on first run.
+
+### 2. Configure the Koji connection
+
+Set the following in your environment or `appsettings.json`:
+
+- `Koji:ApiAddress` — Koji server URL (e.g., `http://localhost:8080`)
+- `Koji:BearerToken` — Koji API bearer token
+- `Koji:ProjectId` — Koji project ID for promoted geofences
+- `Koji:ProjectName` — Koji project name, used to fetch from `/geofence/poracle/{name}`
+
+### 3. Point PoracleJS to PoracleWeb
+
+Set `geofence.path` in PoracleJS config to a single PoracleWeb URL:
+
+```json
+"geofence": {
+  "path": "http://poracleweb-host:8082/api/geofence-feed"
+}
+```
+
+Remove `kojiOptions.bearerToken` from the PoracleJS geofence config if present (it is harmless if left, but no longer needed).
+
+### 4. Remove group_map.json
+
+Remove `group_map.json` from PoracleJS if it exists — group names are now resolved automatically from the Koji parent chain by PoracleWeb.
+
+### 5. Restart PoracleJS
+
+```bash
+pm2 restart all
+```
+
+### 6. Discord forum channel (optional)
+
+For geofence submission discussions:
+
+1. Set `Discord:GeofenceForumChannelId` to your forum channel ID
+2. Give the bot **View Channel**, **Send Messages in Threads**, and **Manage Threads** permissions
+3. Forum tags (Pending/Approved/Rejected) are auto-created if the bot has **Manage Channels** permission, or create them manually
+
+!!! tip "PoracleJS failover"
+    PoracleJS's built-in `.cache/` directory automatically caches geofence data. If PoracleWeb is temporarily unavailable, PoracleJS falls back to its last cached copy.

--- a/docs/features/server-management.md
+++ b/docs/features/server-management.md
@@ -1,0 +1,97 @@
+# Server Management
+
+Admins can monitor and restart PoracleJS instances remotely from the "Poracle Servers" admin page.
+
+## How it works
+
+1. **Health check** — pings each server's API endpoint. Any HTTP response = online, no response = offline.
+2. **Restart** — executes an SSH command (default: `pm2 restart all`) on the remote server.
+3. Each server can have a **custom restart command** (e.g., for macOS where PM2 isn't in PATH).
+
+## Component diagram
+
+```mermaid
+graph TB
+    subgraph PoracleWeb
+        UI[Poracle Servers Page<br/>Status cards + Restart buttons]
+        Svc[PoracleServerService<br/>Health check + SSH restart]
+    end
+
+    UI --> Svc
+
+    subgraph Servers
+        S1[Main Server<br/>Linux<br/>API :3030]
+        S2[Secondary Server<br/>macOS<br/>API :3035]
+    end
+
+    Svc -->|HTTP health check| S1
+    Svc -->|HTTP health check| S2
+    Svc -->|SSH + pm2 restart all| S1
+    Svc -->|SSH + custom restart cmd| S2
+```
+
+## Restart flow
+
+```mermaid
+flowchart TD
+    A[Admin clicks Restart] --> B{Confirm Dialog}
+    B -->|Cancel| Z[No action]
+    B -->|Confirm| C[POST /api/admin/poracle/servers/host/restart]
+    C --> D[SSH to server with key<br/>30 second timeout]
+    D --> E{Result}
+    E -->|Exit code 0| F[Success: Server restarted<br/>Status refreshed]
+    E -->|Timeout 30s| G[Warning: Kill process tree<br/>Timed out]
+    E -->|SSH error| H[Error: Failed<br/>Check key/host]
+```
+
+## Setup
+
+### 1. SSH key
+
+Mount a private key that has access to your PoracleJS servers:
+
+```yaml
+# docker-compose.yml
+volumes:
+  - /path/to/your/ssh_key:/app/ssh_key:ro
+```
+
+Or in `docker-compose.override.yml`:
+
+```yaml
+services:
+  poracle-web:
+    volumes:
+      - ~/.ssh/id_ed25519:/app/ssh_key:ro
+```
+
+### 2. Server configuration
+
+Add servers via environment variables in `.env`:
+
+```env
+# Server 1 (Linux)
+PORACLE_SERVER_1_NAME=Main
+PORACLE_SERVER_1_HOST=10.0.3.178
+PORACLE_SERVER_1_API=http://10.0.3.178:3030
+PORACLE_SERVER_1_SSH_USER=root
+# PORACLE_SERVER_1_RESTART_CMD=pm2 restart all   # default
+
+# Server 2 (macOS — needs full PATH for PM2)
+PORACLE_SERVER_2_NAME=Secondary
+PORACLE_SERVER_2_HOST=10.0.6.107
+PORACLE_SERVER_2_API=http://10.0.6.107:3035
+PORACLE_SERVER_2_SSH_USER=hokiepokedad
+PORACLE_SERVER_2_RESTART_CMD=PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin pm2 restart all
+```
+
+### 3. SSH access
+
+Ensure the SSH key is authorized on each PoracleJS server (`~/.ssh/authorized_keys`).
+
+### 4. Firewall
+
+The Docker container needs:
+
+- **SSH access** (port 22) to each PoracleJS server
+- **HTTP access** to each server's API port for health checks

--- a/docs/getting-started/development-setup.md
+++ b/docs/getting-started/development-setup.md
@@ -1,0 +1,122 @@
+# Development Setup
+
+## 1. Clone and install dependencies
+
+```bash
+git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
+cd PoracleWeb.NET
+
+# Install frontend dependencies
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+npm install
+cd ../../..
+```
+
+## 2. Configure secrets
+
+Create `Applications/PGAN.Poracle.Web.Api/appsettings.Development.json` (gitignored):
+
+```json
+{
+  "ConnectionStrings": {
+    "PoracleDb": "Server=localhost;Port=3306;Database=poracle;User=root;Password=your_password;AllowZeroDateTime=true;ConvertZeroDateTime=true",
+    "PoracleWebDb": "Server=localhost;Port=3306;Database=poracle_web;User=root;Password=your_password;AllowZeroDateTime=true;ConvertZeroDateTime=true",
+    "ScannerDb": ""
+  },
+  "Jwt": {
+    "Secret": "your-development-secret-key-at-least-32-characters-long"
+  },
+  "Discord": {
+    "ClientId": "your_discord_client_id",
+    "ClientSecret": "your_discord_client_secret",
+    "RedirectUri": "http://localhost:4200/auth/discord/callback",
+    "FrontendUrl": "http://localhost:4200",
+    "BotToken": "your_discord_bot_token",
+    "GuildId": "your_discord_guild_id",
+    "GeofenceForumChannelId": ""
+  },
+  "Telegram": {
+    "Enabled": false,
+    "BotToken": "",
+    "BotUsername": ""
+  },
+  "Poracle": {
+    "ApiAddress": "http://localhost:3030",
+    "ApiSecret": "your_poracle_secret",
+    "AdminIds": "your_discord_user_id"
+  },
+  "Koji": {
+    "ApiAddress": "http://localhost:8080",
+    "BearerToken": "your_koji_bearer_token",
+    "ProjectId": 1,
+    "ProjectName": "your_koji_project_name"
+  }
+}
+```
+
+## 3. Run the application
+
+You need two terminals — one for the backend API and one for the Angular dev server:
+
+=== "Backend API"
+
+    ```bash
+    cd Applications/PGAN.Poracle.Web.Api
+    dotnet run
+    ```
+
+    Starts on **http://localhost:5048**. Swagger/OpenAPI is available in development mode.
+
+=== "Frontend"
+
+    ```bash
+    cd Applications/PGAN.Poracle.Web.App/ClientApp
+    npm start
+    ```
+
+    Starts on **http://localhost:4200**. The Angular dev server proxies API requests to the .NET backend.
+
+Open **http://localhost:4200** in your browser.
+
+## 4. Running tests
+
+```bash
+# Frontend tests (Jest)
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+npm test
+
+# Backend tests (xUnit)
+dotnet test
+```
+
+## 5. Linting and formatting
+
+```bash
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+
+# Check lint
+npm run lint
+
+# Check formatting
+npm run prettier-check
+
+# Auto-fix lint issues
+npx eslint --fix src/
+
+# Auto-format code
+npm run prettier-format
+```
+
+## Build commands
+
+```bash
+# Build entire solution (from solution root)
+dotnet build
+
+# Angular production build
+cd Applications/PGAN.Poracle.Web.App/ClientApp
+npm run build
+
+# Angular watch mode
+npm run watch
+```

--- a/docs/getting-started/discord-oauth.md
+++ b/docs/getting-started/discord-oauth.md
@@ -1,0 +1,68 @@
+# Discord OAuth2 Setup
+
+PoracleWeb uses Discord OAuth2 for user authentication. This page walks through creating and configuring a Discord application.
+
+## Create a Discord application
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application** and give it a name
+3. Under **OAuth2**, add redirect URIs:
+
+    | Environment | Redirect URI |
+    |---|---|
+    | Production | `http://your-domain:8082/auth/discord/callback` |
+    | Development | `http://localhost:4200/auth/discord/callback` |
+
+4. Copy the **Client ID** and **Client Secret**
+
+## Optional: Create a bot
+
+Creating a bot under the same application enables:
+
+- **Avatar display** — User avatars shown in the UI
+- **Geofence forum posts** — Automatic Discord forum threads for geofence submissions
+
+### Bot permissions for geofence forum
+
+If using the geofence submission feature with Discord forum integration, the bot needs these permissions on the forum channel:
+
+| Permission | Purpose |
+|---|---|
+| View Channel | Access the forum channel |
+| Send Messages in Threads | Post status updates in threads |
+| Manage Threads | Lock and archive threads on approval/rejection |
+| Manage Channels | Auto-create forum tags (Pending/Approved/Rejected) |
+
+!!! tip
+    If the bot doesn't have **Manage Channels** permission, create the forum tags (Pending, Approved, Rejected) manually on the channel.
+
+## Configuration
+
+=== "Docker (.env)"
+
+    ```env
+    DISCORD_CLIENT_ID=your_discord_client_id
+    DISCORD_CLIENT_SECRET=your_discord_client_secret
+    DISCORD_BOT_TOKEN=your_discord_bot_token
+    DISCORD_GUILD_ID=your_discord_server_id
+    DISCORD_GEOFENCE_FORUM_CHANNEL_ID=your_forum_channel_id
+    ```
+
+=== "Development (appsettings.Development.json)"
+
+    ```json
+    {
+      "Discord": {
+        "ClientId": "your_discord_client_id",
+        "ClientSecret": "your_discord_client_secret",
+        "RedirectUri": "http://localhost:4200/auth/discord/callback",
+        "FrontendUrl": "http://localhost:4200",
+        "BotToken": "your_discord_bot_token",
+        "GuildId": "your_discord_guild_id",
+        "GeofenceForumChannelId": ""
+      }
+    }
+    ```
+
+!!! warning "Discord API domain"
+    PoracleWeb uses `discordapp.com` (not `discord.com`) for API calls. The `discord.com` domain is blocked by Cloudflare in some server environments. This is already configured in the application — no action needed.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,128 @@
+# Quick Start (Docker)
+
+This is the recommended way to run PoracleWeb in production.
+
+## 1. Create environment file
+
+Copy the example and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your configuration:
+
+```env
+# Database — your existing Poracle MySQL instance
+DB_HOST=host.docker.internal    # Use host IP if not on same machine
+DB_PORT=3306
+DB_NAME=poracle
+DB_USER=root
+DB_PASSWORD=your_db_password
+
+# JWT Secret — generate a random string, minimum 32 characters
+JWT_SECRET=generate-a-long-random-secret-key-at-least-32-chars
+
+# Discord OAuth2 — create an app at https://discord.com/developers/applications
+# Set the redirect URI to: http://your-domain:8082/auth/discord/callback
+DISCORD_CLIENT_ID=your_discord_client_id
+DISCORD_CLIENT_SECRET=your_discord_client_secret
+DISCORD_BOT_TOKEN=your_discord_bot_token      # Optional: enables avatar display
+DISCORD_GUILD_ID=your_discord_server_id        # Optional: for guild-specific features
+
+# Poracle API — your running PoracleJS instance
+PORACLE_API_ADDRESS=http://host.docker.internal:3030
+PORACLE_API_SECRET=your_poracle_api_secret
+PORACLE_ADMIN_IDS=your_discord_user_id         # Comma-separated admin Discord IDs
+
+# Poracle config directory — mount for DTS template previews
+PORACLE_CONFIG_DIR=/path/to/PoracleJS/config
+
+# Optional: PoracleWeb DB for custom geofences (separate from Poracle DB)
+WEB_DB_HOST=host.docker.internal
+WEB_DB_PORT=3306
+WEB_DB_NAME=poracle_web
+WEB_DB_USER=root
+WEB_DB_PASSWORD=your_db_password
+
+# Optional: Koji geofence API (required for custom geofences)
+KOJI_API_ADDRESS=http://host.docker.internal:8080
+KOJI_BEARER_TOKEN=your_koji_bearer_token
+KOJI_PROJECT_ID=1
+KOJI_PROJECT_NAME=your_koji_project_name
+
+# Optional: Discord forum channel for geofence submission threads
+DISCORD_GEOFENCE_FORUM_CHANNEL_ID=
+
+# Optional: Scanner DB for nest/Pokemon data
+# SCANNER_DB_CONNECTION=Server=host.docker.internal;Port=3306;Database=rdmdb;User=root;Password=your_password
+
+# Optional: Telegram authentication
+TELEGRAM_ENABLED=false
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_BOT_USERNAME=
+```
+
+## 2. Start with pre-built image
+
+Pull the latest image from GitHub Container Registry and start:
+
+```bash
+docker pull ghcr.io/pgan-dev/poracleweb.net:latest
+```
+
+Update `docker-compose.yml` to use the registry image:
+
+```yaml
+services:
+  poracle-web:
+    image: ghcr.io/pgan-dev/poracleweb.net:latest
+    # ...rest of config
+```
+
+Then start:
+
+```bash
+docker compose up -d
+```
+
+The app will be available at **http://localhost:8082**.
+
+## 3. Build from source (alternative)
+
+If you want to build the Docker image locally instead of pulling from the registry:
+
+```bash
+# Build and tag the image
+docker build -t poracleweb-local:latest .
+
+# Update docker-compose.yml to use local image:
+#   image: poracleweb-local:latest
+
+# Start the container
+docker compose up -d
+```
+
+To force a clean rebuild:
+
+```bash
+docker build --no-cache -t poracleweb-local:latest .
+docker compose up -d --force-recreate
+```
+
+## Updating
+
+=== "Pre-built image (ghcr.io)"
+
+    ```bash
+    docker pull ghcr.io/pgan-dev/poracleweb.net:latest
+    docker compose up -d --force-recreate
+    ```
+
+=== "Built from source"
+
+    ```bash
+    git pull
+    docker build -t poracleweb-local:latest .
+    docker compose up -d --force-recreate
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,82 @@
+# PoracleWeb.NET
+
+A web application for managing [Poracle](https://github.com/KartulUdworworkin/PoracleJS) Pokemon GO notification alarms. Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| **Backend** | .NET 10, ASP.NET Core Web API, EF Core with MySQL (Oracle provider) |
+| **Frontend** | Angular 21, Angular Material 21 (Material Design 3), Leaflet maps |
+| **Auth** | Discord OAuth2, Telegram Bot Login, JWT bearer tokens |
+| **Testing** | Jest (frontend), xUnit (backend) |
+| **CI/CD** | GitHub Actions, Docker (ghcr.io) |
+
+## Features
+
+- **Alarm Management** — Create, edit, and delete filters for Pokemon, Raids, Quests, Invasions, Lures, Nests, and Gyms
+- **Bulk Operations** — Multi-select alarms with bulk delete and bulk distance update
+- **Quick Picks** — Admin-defined alarm templates users can apply with one click
+- **Area Management** — Interactive Leaflet map for selecting geofence areas
+- **Custom Geofences** — Draw custom polygon geofences on a map, served to PoracleJS via a built-in feed endpoint. Submit for admin review to promote to public areas.
+- **Geofence Admin Review** — Approve or reject user-submitted geofences with Discord forum integration
+- **Profile Switching** — Multiple alarm profiles per user
+- **Discord Notification Preview** — Live preview of DTS templates with Handlebars evaluation
+- **Dark/Light Mode** — Theme toggle with localStorage persistence
+- **Accent Themes** — Customizable toolbar and UI accent colors (Pokemon, Raids, Mystic, Valor, Instinct)
+- **Responsive Design** — Full mobile support with fullscreen dialogs and collapsible sidebar
+- **Onboarding Wizard** — First-run setup guide for new users
+- **Keyboard Shortcuts** — ++question++ for help, ++bracket-left++ / ++bracket-right++ for sidebar collapse
+- **18 Languages** — Pokemon name localization
+- **Poracle Server Management** — Monitor health and restart PoracleJS instances remotely
+- **Admin Panel** — User management, webhook configuration, site settings, geofence submission review
+
+## Prerequisites
+
+| Requirement | Version | Purpose |
+|---|---|---|
+| MySQL | 5.7+ or 8.0+ | Poracle database (existing Poracle installation) |
+| Poracle | PoracleJS | Running instance with REST API enabled |
+| Discord App | — | OAuth2 application for user authentication |
+| Koji | — | Geofence management server (required for custom geofences feature) |
+| .NET SDK | 10.0 | Backend development (not needed for Docker) |
+| Node.js | 22+ | Frontend development (not needed for Docker) |
+| Docker | 20+ | Production deployment |
+
+## Quick Links
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
+
+    ---
+
+    Get up and running with Docker or a development environment
+
+    [:octicons-arrow-right-24: Quick Start](getting-started/quick-start.md)
+
+-   :material-cog:{ .lg .middle } **Configuration**
+
+    ---
+
+    Full reference of all environment variables and settings
+
+    [:octicons-arrow-right-24: Configuration Reference](configuration/reference.md)
+
+-   :material-layers-outline:{ .lg .middle } **Architecture**
+
+    ---
+
+    Solution structure, backend and frontend patterns
+
+    [:octicons-arrow-right-24: Architecture Overview](architecture/overview.md)
+
+-   :material-map-marker-radius:{ .lg .middle } **Custom Geofences**
+
+    ---
+
+    How the unified geofence feed works
+
+    [:octicons-arrow-right-24: Custom Geofences](features/custom-geofences.md)
+
+</div>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting
+
+## MySQL provider incompatibility
+
+**Problem**: Build errors or runtime exceptions related to `Pomelo.EntityFrameworkCore.MySql`.
+
+**Solution**: This project uses `MySql.EntityFrameworkCore` (Oracle's official provider), **not** Pomelo. Pomelo is incompatible with EF Core 10. Connection setup uses `options.UseMySQL(connectionString)` (capital SQL).
+
+---
+
+## NULL string constraint violations
+
+**Problem**: MySQL errors like `Column 'X' cannot be null` when saving entities.
+
+**Solution**: Call `EnsureNotNullDefaults()` before saving. Many Poracle DB columns are `NOT NULL` with empty-string defaults, but EF Core maps them as `string?`. The method sets null strings to `""`.
+
+---
+
+## Discord API calls failing
+
+**Problem**: Discord API calls return errors or time out.
+
+**Solution**: Use `discordapp.com` (not `discord.com`) for API calls. The `discord.com` domain is blocked by Cloudflare in some server environments. PoracleWeb is already configured to use `discordapp.com`.
+
+Also note: Use API **v9** (not v10) — v10 is not supported on the `discordapp.com` domain.
+
+---
+
+## Poracle config defaultTemplateName errors
+
+**Problem**: Deserialization errors when parsing Poracle config.
+
+**Solution**: `defaultTemplateName` can be a number (e.g., `1`) or a string (e.g., `"default"`). Use `JsonElement` or handle both types during deserialization.
+
+---
+
+## Scanner DB connection errors
+
+**Problem**: Errors about missing scanner service or database connection.
+
+**Solution**: The `ScannerDb` connection string is optional. If not configured, `IScannerService` is not registered and scanner endpoints return appropriate responses. This is expected behavior.
+
+---
+
+## Bulk update zeroing out alarm fields
+
+**Problem**: After bulk updating alarms, fields like `clean`, `template`, and filter settings are reset to 0.
+
+**Solution**: Never send partial objects to `PUT /{uid}`. AutoMapper maps all fields — `int` properties default to `0` when absent from JSON. Use the dedicated `PUT /distance/bulk` endpoint for distance changes, or spread the full alarm object:
+
+```typescript
+// ✅ Correct
+this.http.put(`/api/pokemon/${uid}`, { ...alarm, distance });
+
+// ❌ Wrong
+this.http.put(`/api/pokemon/${uid}`, { distance });
+```
+
+---
+
+## Geofence names not matching in Poracle
+
+**Problem**: Custom geofences don't trigger alerts even though they're in the user's area list.
+
+**Solution**: Poracle does **case-sensitive** area matching. Geofence names must always be lowercase. The `kojiName` field in `user_geofences` and entries in `humans.area` must match exactly. `UserGeofenceService.CreateAsync()` enforces this with `ToLowerInvariant()`.
+
+---
+
+## Koji displayInMatches not working
+
+**Problem**: User geofence names appear in DMs even though `displayInMatches` is set to `false`.
+
+**Solution**: Koji's `displayInMatches` custom property is not reliably honored by all Poracle format serializers. Serve user geofences from the PoracleWeb feed endpoint (`/api/geofence-feed`) instead of pushing them to Koji. Only promote to Koji when an admin approves a geofence for public use.
+
+---
+
+## Rate limiting locking out all users
+
+**Problem**: Multiple users report being unable to log in simultaneously.
+
+**Solution**: Auth rate limiting must be **per-IP** (partitioned), not global. Check that `Program.cs` uses `RateLimitPartition.GetFixedWindowLimiter` keyed by `RemoteIpAddress`, not `AddFixedWindowLimiter`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,96 @@
+site_name: PoracleWeb.NET
+site_description: Web application for managing Poracle Pokemon GO notification alarms
+site_url: https://pgan-dev.github.io/PoracleWeb.NET/
+repo_url: https://github.com/PGAN-Dev/PoracleWeb.NET
+repo_name: PGAN-Dev/PoracleWeb.NET
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - mermaid2
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_guess: false
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.mark
+  - pymdownx.keys
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Quick Start (Docker): getting-started/quick-start.md
+      - Development Setup: getting-started/development-setup.md
+      - Discord OAuth2: getting-started/discord-oauth.md
+  - Configuration:
+      - Reference: configuration/reference.md
+      - Docker Compose: configuration/docker.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - Backend Patterns: architecture/backend.md
+      - Frontend Patterns: architecture/frontend.md
+      - Database: architecture/database.md
+  - Features:
+      - Alarm Management: features/alarms.md
+      - Custom Geofences: features/custom-geofences.md
+      - Server Management: features/server-management.md
+  - Development:
+      - Testing: development/testing.md
+      - CI/CD: development/ci-cd.md
+      - Code Style: development/code-style.md
+  - Troubleshooting: troubleshooting.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/PGAN-Dev/PoracleWeb.NET


### PR DESCRIPTION
Closes #29

## Summary

- Add MkDocs Material documentation site with 17 pages across 6 sections (Getting Started, Configuration, Architecture, Features, Development, Troubleshooting)
- Add GitHub Actions workflow for automatic deployment to GitHub Pages on push to `main`
- Slim down README.md to link to the docs site at `pgan-dev.github.io/PoracleWeb.NET`
- All content sourced from existing README.md and CLAUDE.md, reorganized with MkDocs features (admonitions, tabbed content, mermaid diagrams, search, dark/light mode)

## Post-merge setup

Enable GitHub Pages: **Settings > Pages > Source: Deploy from a branch > Branch: `gh-pages`**

## Test plan

- [ ] Verify `mkdocs serve` builds locally without errors
- [ ] Verify docs workflow deploys successfully after merge
- [ ] Verify all mermaid diagrams render correctly
- [ ] Verify GitHub Pages site is accessible at `pgan-dev.github.io/PoracleWeb.NET`