### PR TITLE
fix: MkDocs build — remove unsupported option, pin mkdocs<2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install mkdocs-material mkdocs-mermaid2-plugin
+        run: pip install "mkdocs>=1.6,<2" mkdocs-material mkdocs-mermaid2-plugin
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,6 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
-      pygments_lang_guess: false
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.mark


### PR DESCRIPTION
## Summary

- Remove `pygments_lang_guess` option from `pymdownx.highlight` config (not supported by current pymdownx version, caused build failure)
- Pin `mkdocs>=1.6,<2` in the docs workflow to avoid MkDocs 2.0 breaking changes

## Test plan

- [ ] Verify docs workflow passes and deploys successfully