### PR TITLE
fix: DTS preview renders nested Handlebars if-blocks incorrectly

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/template-selector/template-selector.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/template-selector/template-selector.component.ts
@@ -165,16 +165,17 @@ export class TemplateSelectorComponent implements OnInit {
     if (!text) return '';
 
     let result = text;
-    let safety = 20;
+    let safety = 50;
 
     while (safety-- > 0) {
-      const ifMatch = result.match(/\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/);
+      // Find the innermost {{#if}} block (one with no nested {{#if}} inside)
+      const ifMatch = result.match(/\{\{#if\s+(\w+)\}\}((?:(?!\{\{#if\s)[\s\S])*?)\{\{\/if\}\}/);
       if (!ifMatch) break;
 
       const [fullMatch, condName, inner] = ifMatch;
       const condValue = state[condName] ?? false;
 
-      // Split on {{else}}
+      // Split on {{else}} — only top-level else (no nested blocks remain at this point)
       const elseParts = inner.split(/\{\{else\}\}/);
       const trueBranch = elseParts[0] || '';
       const falseBranch = elseParts[1] || '';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.2] - 2026-03-25
-
-## [1.0.1] - 2026-03-25
-
 ## [1.0.2] - 2026-03-24
 
 ### Fixed
@@ -248,8 +244,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker deployment with Watchtower auto-updates
 
 [Unreleased]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v1.0.2...HEAD
-[1.0.2]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v1.0.2...v1.0.2
-[1.0.1]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v1.0.1...v1.0.1
 [1.0.2]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v0.6.4...v1.0.0


### PR DESCRIPTION
## Summary
- Template preview showed both PVP and IV title branches concatenated together due to regex not handling nested `{{#if}}` blocks
- Fix uses innermost-first matching pattern to resolve nested blocks correctly
- Also cleans up duplicate changelog entries from prior merge

Closes #59

## Test plan
- [ ] Open Pokemon add/edit dialog, verify DTS preview title shows only IV branch when PVP Ranking toggle is OFF
- [ ] Toggle PVP Ranking ON, verify title shows only PVP branch