### PR TITLE
fix: remove decorative circle from page headers

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(255, 152, 0, 0.08) 0%, rgba(255, 152, 0, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 
 .page-header-text {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(33, 150, 243, 0.08) 0%, rgba(33, 150, 243, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 
 .page-header-text {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(96, 125, 139, 0.08) 0%, rgba(96, 125, 139, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 .page-header-text {
   flex: 1;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(123, 31, 162, 0.08) 0%, rgba(123, 31, 162, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 .page-header-text {
   flex: 1;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(156, 39, 176, 0.08) 0%, rgba(156, 39, 176, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 .page-header-text {
   flex: 1;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.scss
@@ -5,9 +5,6 @@
   padding: 16px 24px;
   gap: 16px;
   background: linear-gradient(135deg, rgba(244, 67, 54, 0.08) 0%, rgba(244, 67, 54, 0.02) 100%);
-  position: relative;
-  overflow: hidden;
-
 }
 .page-header-text {
   flex: 1;


### PR DESCRIPTION
## Summary
- Remove the `::after` pseudo-element radial-gradient circles from page headers on 6 list pages (areas, geofences, raids, quests, invasions, profiles)
- These decorative circles were inconsistent across pages and most pages hid them

Closes #61

## Test plan
- [ ] Verify areas, geofences, raids, quests, invasions, and profiles pages no longer show a circle in the upper right of the page header
- [ ] Verify page headers still display their gradient background correctly