### PR TITLE
fix: raid/egg team selector sends 0 instead of 4 for Any Team

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.html
@@ -11,7 +11,7 @@
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Team</mat-label>
           <mat-select [formControl]="commonForm.controls.team">
-            <mat-option [value]="0">
+            <mat-option [value]="4">
               <img src="https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/gym/0.png" class="team-option-icon" /> Any Team
             </mat-option>
             <mat-option [value]="1">

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.html
@@ -19,7 +19,7 @@
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Team</mat-label>
           <mat-select [formControl]="form.controls.team">
-            <mat-option [value]="0">
+            <mat-option [value]="4">
               <img src="https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/gym/0.png" class="team-option-icon" /> Any Team
             </mat-option>
             <mat-option [value]="1">


### PR DESCRIPTION
## Summary

- The "Any Team" `<mat-option>` in raid add and edit dialogs used `[value]="0"` (uncontested gym) instead of `[value]="4"` (all teams)
- This caused all raid/egg alarms created with "Any Team" selected to only match raids on gray/uncontested gyms, effectively silencing notifications
- 17 raid and 12 egg alarms in production were affected and have been manually patched in the database

## Test plan

- [ ] Open the Add Raid/Egg dialog → Team dropdown defaults to "Any Team" → verify the created alarm has `team=4` in the database
- [ ] Edit an existing raid/egg alarm → "Any Team" shows as selected for alarms with `team=4` → save and verify `team=4` is preserved
- [ ] Create alarms with specific teams (Mystic=1, Valor=2, Instinct=3) → verify correct values stored

Fixes #63