### PR TITLE
fix: team icon broken on raid cards for Any Team (team=4)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
@@ -211,7 +211,8 @@ export class RaidListComponent implements OnInit {
   }
 
   getGymIcon(team: number): string {
-    return `https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/gym/${team}.png`;
+    const icon = team === 4 ? 0 : team;
+    return `https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/gym/${icon}.png`;
   }
 
   getLevelColor(level: number): string {


### PR DESCRIPTION
## Summary

- `getGymIcon()` used `team` value directly in the icon URL (`gym/${team}.png`)
- `team=4` (all teams) tried to load `gym/4.png` which doesn't exist — only 0-3 exist
- Map `team=4` to `gym/0.png` (gray gym icon) for display

## Test plan

- [ ] Raid/egg cards with "Any Team" (team=4) show the gray gym icon
- [ ] Cards with specific teams (1-3) still show correct team icons

Fixes #66