### PR TITLE
fix: normalize invasion grunt_type to lowercase and default empty to everything

### DIFF
--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -15,15 +15,15 @@ public class InvasionService(IInvasionRepository repository) : IInvasionService
     public async Task<Invasion> CreateAsync(string userId, Invasion model)
     {
         model.Id = userId;
-        if (model.GruntType != null)
-        {
-            model.GruntType = model.GruntType.ToLowerInvariant();
-        }
-
+        model.GruntType = NormalizeGruntType(model.GruntType);
         return await this._repository.CreateAsync(model);
     }
 
-    public async Task<Invasion> UpdateAsync(Invasion model) => await this._repository.UpdateAsync(model);
+    public async Task<Invasion> UpdateAsync(Invasion model)
+    {
+        model.GruntType = NormalizeGruntType(model.GruntType);
+        return await this._repository.UpdateAsync(model);
+    }
 
     public async Task<bool> DeleteAsync(int uid) => await this._repository.DeleteAsync(uid);
 
@@ -40,12 +40,15 @@ public class InvasionService(IInvasionRepository repository) : IInvasionService
         foreach (var model in models)
         {
             model.Id = userId;
-            if (model.GruntType != null)
-            {
-                model.GruntType = model.GruntType.ToLowerInvariant();
-            }
+            model.GruntType = NormalizeGruntType(model.GruntType);
         }
 
         return await this._repository.BulkCreateAsync(models);
+    }
+
+    private static string NormalizeGruntType(string? gruntType)
+    {
+        var normalized = gruntType?.ToLowerInvariant();
+        return string.IsNullOrEmpty(normalized) ? "everything" : normalized;
     }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -84,4 +84,72 @@ public class InvasionServiceTests
         this._repository.Setup(r => r.CountByUserAsync("u", 1)).ReturnsAsync(12);
         Assert.Equal(12, await this._sut.CountByUserAsync("u", 1));
     }
+
+    [Fact]
+    public async Task CreateAsyncLowercasesGruntType()
+    {
+        this._repository.Setup(r => r.CreateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.CreateAsync("u1", new Invasion { GruntType = "Mixed_Case_Grunt" });
+        Assert.Equal("mixed_case_grunt", result.GruntType);
+    }
+
+    [Fact]
+    public async Task CreateAsyncDefaultsEmptyGruntTypeToEverything()
+    {
+        this._repository.Setup(r => r.CreateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.CreateAsync("u1", new Invasion { GruntType = "" });
+        Assert.Equal("everything", result.GruntType);
+    }
+
+    [Fact]
+    public async Task CreateAsyncDefaultsNullGruntTypeToEverything()
+    {
+        this._repository.Setup(r => r.CreateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.CreateAsync("u1", new Invasion { GruntType = null });
+        Assert.Equal("everything", result.GruntType);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncLowercasesGruntType()
+    {
+        var invasion = new Invasion { Uid = 1, GruntType = "UPPER_GRUNT" };
+        this._repository.Setup(r => r.UpdateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.UpdateAsync(invasion);
+        Assert.Equal("upper_grunt", result.GruntType);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncDefaultsEmptyGruntTypeToEverything()
+    {
+        var invasion = new Invasion { Uid = 1, GruntType = "" };
+        this._repository.Setup(r => r.UpdateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.UpdateAsync(invasion);
+        Assert.Equal("everything", result.GruntType);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncDefaultsNullGruntTypeToEverything()
+    {
+        var invasion = new Invasion { Uid = 1, GruntType = null };
+        this._repository.Setup(r => r.UpdateAsync(It.IsAny<Invasion>())).ReturnsAsync((Invasion i) => i);
+        var result = await this._sut.UpdateAsync(invasion);
+        Assert.Equal("everything", result.GruntType);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsyncNormalizesGruntTypes()
+    {
+        this._repository.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Invasion>>()))
+            .ReturnsAsync((IEnumerable<Invasion> items) => items);
+        var models = new List<Invasion>
+        {
+            new() { GruntType = "UPPER" },
+            new() { GruntType = "" },
+            new() { GruntType = null },
+        };
+        var results = (await this._sut.BulkCreateAsync("u1", models)).ToList();
+        Assert.Equal("upper", results[0].GruntType);
+        Assert.Equal("everything", results[1].GruntType);
+        Assert.Equal("everything", results[2].GruntType);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `NormalizeGruntType()` helper to `InvasionService` that lowercases values and defaults null/empty to `"everything"`
- Applied to `CreateAsync`, `UpdateAsync`, and `BulkCreateAsync` — previously `UpdateAsync` had no normalization at all, and empty strings were never handled
- Fixes compatibility with PoracleNG's Go processor which requires `"everything"` (not `""`) to match all grunt types, and lowercases incoming webhook data before comparing

Fixes #71, fixes #72

## Test plan
- [x] 7 new unit tests covering all combinations (lowercase, empty→everything, null→everything) for create, update, and bulk create
- [x] 497 backend tests pass
- [x] 461 frontend tests pass