### PR TITLE
fix: default GymCreate.Team to 4 (any team) (#74)

### DIFF
--- a/Core/Pgan.PoracleWebNet.Core.Models/GymCreate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/GymCreate.cs
@@ -17,10 +17,7 @@ public class GymCreate
     }
 
     [Range(0, 4)]
-    public int Team
-    {
-        get; set;
-    }
+    public int Team { get; set; } = 4;
 
     [Range(0, 1)]
     public int SlotChanges


### PR DESCRIPTION
## Summary
- Default `GymCreate.Team` to `4` (any team), matching `RaidCreate` and `EggCreate` defaults
- Fixes #74 — C# `int` defaults to `0` which Poracle interprets as "Neutral/uncontested gyms only", silently filtering out most gym team changes
- Also identified and fixed (via DB update) a pre-existing data issue where `gym_id = ''` instead of `NULL` caused PoracleNG to treat every gym alarm as a specific-gym filter matching nothing

## Root Cause Analysis
Two issues combined to completely break gym alerts:

1. **`GymCreate.Team = 0`** (C# default) — New gym alarms defaulted to tracking only Neutral gyms. The frontend explicitly sends team values per-alarm so this was a safety-net issue, not the primary cause.

2. **`gym_id = ''` instead of `NULL`** — Gym alarms created through PoracleWeb had `gym_id` stored as empty string rather than `NULL`. PoracleNG's matching code treats any non-null `gym_id` as "track this specific gym", so `""` meant "track gym with ID empty string" → matched zero webhooks. This was confirmed via Prometheus metrics showing 21,000+ matching attempts with 0 successful matches. Fixed via `UPDATE gym SET gym_id = NULL WHERE gym_id = ''` on production.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 497 passed
- [x] `npm test` — 461 passed
- [x] `npx eslint src/` — clean
- [x] `npm run prettier-check` — clean
- [x] Verified fix on production: sent test gym webhook to PoracleNG processor, confirmed "Gym Test Varina Gym 2 changed Mystic -> Valor areas(Varina) and 1 humans cared" with Discord message delivered