### PR TITLE
feat: distinct banner for admin-disabled users with support links

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -178,6 +178,7 @@ public partial class AuthController(
             Username = username,
             Type = "discord:user",
             IsAdmin = isAdmin,
+            AdminDisable = human.AdminDisable == 1,
             Enabled = human.Enabled == 1 && human.AdminDisable == 0,
             ProfileNo = human.CurrentProfileNo,
             AvatarUrl = avatarUrl,
@@ -281,6 +282,7 @@ public partial class AuthController(
             Username = username!,
             Type = "telegram:user",
             IsAdmin = isAdmin,
+            AdminDisable = human.AdminDisable == 1,
             Enabled = human.Enabled == 1 && human.AdminDisable == 0,
             ProfileNo = human.CurrentProfileNo,
             AvatarUrl = photoUrl,
@@ -310,6 +312,7 @@ public partial class AuthController(
     {
         // Read enabled status from DB (not JWT) so it reflects real-time changes
         var human = await this._humanService.GetByIdAsync(this.UserId);
+        var adminDisable = human != null && human.AdminDisable == 1;
         var enabled = human == null || (human.Enabled == 1 && human.AdminDisable == 0);
 
         var userInfo = new UserInfo
@@ -318,6 +321,7 @@ public partial class AuthController(
             Username = this.Username,
             Type = this.User.FindFirstValue("type") ?? string.Empty,
             IsAdmin = this.IsAdmin,
+            AdminDisable = adminDisable,
             Enabled = enabled,
             ProfileNo = human?.CurrentProfileNo ?? this.ProfileNo,
             AvatarUrl = this.User.FindFirstValue("avatarUrl"),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.html
@@ -10,7 +10,16 @@
     </button>
   </div>
 }
-@if (auth.user()?.enabled === false) {
+@if (auth.user()?.adminDisable) {
+  <div class="disabled-banner admin-disabled">
+    <mat-icon>block</mat-icon>
+    <span
+      >Your account has been <strong>disabled</strong> by the system or an administrator. To get help, ask in
+      <a href="https://discord.com/channels/237964415822069760/280486070628384778" target="_blank">#support</a> or
+      <a href="https://discord.com/channels/237964415822069760/722557616982720593" target="_blank">create a ticket</a>.</span
+    >
+  </div>
+} @else if (auth.user()?.enabled === false) {
   <div class="disabled-banner">
     <mat-icon>pause_circle</mat-icon>
     <span>Your alerts are <strong>paused</strong>. You will not receive notifications.</span>
@@ -78,10 +87,12 @@
         </div>
       </div>
       <mat-divider></mat-divider>
-      <button mat-menu-item (click)="toggleAlerts()">
-        <mat-icon>{{ auth.user()?.enabled ? 'notifications_active' : 'notifications_off' }}</mat-icon>
-        <span>{{ auth.user()?.enabled ? 'Pause Alerts' : 'Resume Alerts' }}</span>
-      </button>
+      @if (!auth.user()?.adminDisable) {
+        <button mat-menu-item (click)="toggleAlerts()">
+          <mat-icon>{{ auth.user()?.enabled ? 'notifications_active' : 'notifications_off' }}</mat-icon>
+          <span>{{ auth.user()?.enabled ? 'Pause Alerts' : 'Resume Alerts' }}</span>
+        </button>
+      }
       <mat-divider></mat-divider>
       <button mat-menu-item routerLink="/profiles">
         <mat-icon>swap_horiz</mat-icon>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.scss
@@ -46,6 +46,16 @@
     height: 20px;
     flex-shrink: 0;
   }
+
+  a {
+    color: #fff;
+    font-weight: 500;
+    text-decoration: underline;
+  }
+
+  &.admin-disabled {
+    background-color: #d32f2f;
+  }
 }
 
 @media (max-width: 599px) {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/models/index.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/models/index.ts
@@ -232,6 +232,7 @@ export interface DashboardCounts {
 // ─── Auth / User Info ──────────────────────────────────────────────────────────
 
 export interface UserInfo {
+  adminDisable: boolean;
   avatarUrl: string | null;
   enabled: boolean;
   id: string;

--- a/Core/Pgan.PoracleWebNet.Core.Models/UserInfo.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/UserInfo.cs
@@ -9,6 +9,10 @@ public class UserInfo
     {
         get; set;
     }
+    public bool AdminDisable
+    {
+        get; set;
+    }
     public bool Enabled { get; set; } = true;
     public int ProfileNo
     {


### PR DESCRIPTION
## Summary
Closes #82

- Adds `adminDisable` boolean to the `UserInfo` API response so the frontend can distinguish between self-paused and admin-disabled users
- Admin-disabled users see a dedicated red banner with links to [#support](https://discord.com/channels/237964415822069760/280486070628384778) and [#create-a-ticket](https://discord.com/channels/237964415822069760/722557616982720593) instead of a broken Resume button
- Self-paused users continue to see the existing "paused" banner with a working Resume button
- The Pause/Resume toggle in the user menu is hidden for admin-disabled users

## Test plan
- [ ] Verify admin-disabled user sees the new banner with support links (no Resume button)
- [ ] Verify self-paused user still sees the original banner with working Resume button
- [ ] Verify active user sees no banner
- [ ] Verify support and ticket links open correct Discord channels
- [ ] Verify Pause/Resume menu item is hidden for admin-disabled users
- [ ] Backend: 497 xUnit tests passing
- [ ] Frontend: 461 Jest tests passing