### PR TITLE
feat: show gym name on raid and egg alarm cards

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
@@ -93,6 +93,9 @@
                     <mat-icon class="star-icon">star</mat-icon>
                   }
                 </div>
+                @if (raid.gymId && gymNames()[raid.gymId]) {
+                  <span class="gym-target"><mat-icon>place</mat-icon> {{ gymNames()[raid.gymId] }}</span>
+                }
               </div>
               <div class="card-top-actions">
                 @if (raid.clean === 1) {
@@ -175,6 +178,9 @@
                     <mat-icon class="star-icon">star</mat-icon>
                   }
                 </div>
+                @if (egg.gymId && gymNames()[egg.gymId]) {
+                  <span class="gym-target"><mat-icon>place</mat-icon> {{ gymNames()[egg.gymId] }}</span>
+                }
               </div>
               <div class="card-top-actions">
                 @if (egg.clean === 1) {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.scss
@@ -111,6 +111,19 @@
   margin: 0;
   font-size: 18px;
 }
+.gym-target {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 12px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.54));
+  margin-top: 2px;
+}
+.gym-target mat-icon {
+  font-size: 14px;
+  width: 14px;
+  height: 14px;
+}
 .level-stars {
   display: flex;
   gap: 0;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
@@ -17,6 +17,7 @@ import { EggService } from '../../core/services/egg.service';
 import { IconService } from '../../core/services/icon.service';
 import { MasterDataService } from '../../core/services/masterdata.service';
 import { RaidService } from '../../core/services/raid.service';
+import { ScannerService } from '../../core/services/scanner.service';
 import { AlarmInfoComponent } from '../../shared/components/alarm-info/alarm-info.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 import { DistanceDialogComponent } from '../../shared/components/distance-dialog/distance-dialog.component';
@@ -46,9 +47,11 @@ export class RaidListComponent implements OnInit {
   private readonly iconService = inject(IconService);
   private readonly masterData = inject(MasterDataService);
   private readonly raidService = inject(RaidService);
+  private readonly scannerService = inject(ScannerService);
   private readonly snackBar = inject(MatSnackBar);
 
   readonly eggs = signal<Egg[]>([]);
+  readonly gymNames = signal<Record<string, string>>({});
   readonly loading = signal(true);
   readonly raids = signal<Raid[]>([]);
   readonly selectedIds = signal(new Set<number>());
@@ -290,6 +293,7 @@ export class RaidListComponent implements OnInit {
           this.raids.set(raids);
           this.eggs.set(eggs);
           this.loading.set(false);
+          this.resolveGymNames([...raids, ...eggs]);
         },
       });
   }
@@ -351,6 +355,19 @@ export class RaidListComponent implements OnInit {
           },
         });
       }
+    });
+  }
+
+  private resolveGymNames(items: (Raid | Egg)[]): void {
+    const ids = [...new Set(items.filter(i => i.gymId).map(i => i.gymId!))];
+    if (ids.length === 0) return;
+    const lookups = Object.fromEntries(ids.map(id => [id, this.scannerService.getGymById(id)]));
+    forkJoin(lookups).subscribe(results => {
+      const names: Record<string, string> = {};
+      for (const [id, result] of Object.entries(results)) {
+        if (result?.name) names[id] = result.name;
+      }
+      this.gymNames.set(names);
     });
   }
 }


### PR DESCRIPTION
## Summary
- Resolve and display gym names on raid and egg alarm cards, matching the existing gym alarm list pattern

## Changes
- Inject `ScannerService` into `raid-list.component.ts`
- Add `gymNames` signal, resolve unique `gymId` values via `scannerService.getGymById()`
- Display gym name with place icon on both raid and egg cards
- Add `.gym-target` CSS styling

Closes #89

## Test plan
- [x] 461 frontend tests pass
- [x] ESLint clean
- [x] Prettier formatted
- [ ] Manual: verify gym name shows on raid/egg cards with gym_id set