### PR TITLE
fix: consistent full-width layout for areas and geofences pages

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
@@ -38,7 +38,6 @@
   flex-direction: column;
   gap: 12px;
   padding: 0 24px 80px;
-  max-width: 800px;
 }
 
 // ─── Method Cards (Areas vs Location explainer) ──────


### PR DESCRIPTION
## Summary

- Remove `max-width: 800px` from `.areas-page` in `area-list.component.scss`

The Areas page was constrained to 800px while My Geofences used full-width, creating an inconsistent map experience. Both pages now use full-width layout since maps benefit from wider viewport space.

Closes #107

## Test plan

- [ ] Areas page map renders full-width
- [ ] My Geofences page map renders full-width (unchanged)
- [ ] Both pages look consistent when navigating between them
- [ ] Areas page content (method cards, chip list) still looks good at full width