### PR TITLE
fix: quick pick 'all invasions' fails — sends null grunt_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fort Change tracking alarms**: New alarm type to monitor pokestop and gym changes — track name changes, relocations, image updates, removals, and new forts with fort type filtering, distance/area delivery, and clean mode support ([#119](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/119), [PR #135](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/135))
 - **Login method gating**: `enable_discord` and `enable_telegram` site settings now control login button visibility and block auth attempts when disabled ([#117](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/117), [PR #136](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/136))
 - **Dedicated Discord settings section** in admin page ([PR #116](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/116))
+
+### Fixed
+- **Quick pick "all invasions" fails**: Sending `grunt_type: null` to PoracleNG caused a 400 error — normalize null to empty string in `InvasionService.CreateAsync` so "any grunt type" works correctly ([#139](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/139))
 ## [2.1.3] - 2026-04-04
 
 ## [2.1.3] - 2026-04-04

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -25,6 +25,7 @@ public class InvasionService(IPoracleTrackingProxy proxy) : IInvasionService
     public async Task<Invasion> CreateAsync(string userId, Invasion model)
     {
         model.Id = userId;
+        model.GruntType ??= string.Empty;
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -53,6 +53,17 @@ public class InvasionServiceTests
     }
 
     [Fact]
+    public async Task CreateAsyncNormalizesNullGruntType()
+    {
+        this._proxy.Setup(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([5], 0, 0, 1));
+
+        var model = new Invasion { GruntType = null };
+        var result = await this._sut.CreateAsync("u1", model);
+        Assert.Equal(string.Empty, result.GruntType);
+    }
+
+    [Fact]
     public async Task UpdateAsyncDelegates()
     {
         var i = new Invasion { Uid = 1 };


### PR DESCRIPTION
## Summary
- Quick pick "all invasions" sent `grunt_type: null` to PoracleNG, which returned 400 Bad Request
- PoracleNG expects an empty string `""` for "any grunt type", not null
- Normalize `null` to `""` in `InvasionService.CreateAsync` so all callers are protected

Closes #139

## Changes
- `InvasionService.cs`: Added `model.GruntType ??= string.Empty;` before serialization (1 line)
- `InvasionServiceTests.cs`: Added `CreateAsyncNormalizesNullGruntType` test
- `CHANGELOG.md`: Added fix entry

## Test plan
- [x] 622/622 backend tests pass (1 new)
- [x] Build: 0 errors
- [ ] Manual: apply "all invasions" quick pick and verify it creates successfully