### PR TITLE
feat: add Max Battles quick pick support

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.html
@@ -278,6 +278,43 @@
           </div>
         </form>
       }
+
+      @case ('maxbattle') {
+        <form [formGroup]="maxBattleForm">
+          <div class="form-row">
+            <mat-form-field>
+              <mat-label>Pokemon ID</mat-label>
+              <input matInput type="number" formControlName="pokemonId" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Level</mat-label>
+              <input matInput type="number" formControlName="level" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field>
+              <mat-label>Gmax</mat-label>
+              <input matInput type="number" formControlName="gmax" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Form</mat-label>
+              <input matInput type="number" formControlName="form" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field>
+              <mat-label>Move</mat-label>
+              <input matInput type="number" formControlName="move" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Evolution</mat-label>
+              <input matInput type="number" formControlName="evolution" />
+            </mat-form-field>
+          </div>
+        </form>
+      }
     }
   </div>
 </mat-dialog-content>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -37,8 +37,8 @@ export class QuickPickAdminDialogComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly quickPickService = inject(QuickPickService);
   private readonly snackBar = inject(MatSnackBar);
-  readonly alarmTypes = ['monster', 'raid', 'egg', 'quest', 'invasion', 'lure', 'nest', 'gym'];
-  readonly categories = ['Common', 'PvP', 'Size', 'Raids', 'Quests', 'Invasions', 'Custom'];
+  readonly alarmTypes = ['monster', 'raid', 'egg', 'quest', 'invasion', 'lure', 'nest', 'gym', 'maxbattle'];
+  readonly categories = ['Common', 'PvP', 'Size', 'Raids', 'Quests', 'Invasions', 'Max Battles', 'Custom'];
   readonly data = inject<QuickPickDefinition | null>(MAT_DIALOG_DATA, {
     optional: true,
   });
@@ -67,6 +67,15 @@ export class QuickPickAdminDialogComponent implements OnInit {
 
   lureForm = this.fb.group({
     lureId: [0],
+  });
+
+  maxBattleForm = this.fb.group({
+    evolution: [9000],
+    form: [0],
+    gmax: [0],
+    level: [9000],
+    move: [9000],
+    pokemonId: [9000],
   });
 
   mainForm = this.fb.group({
@@ -144,6 +153,8 @@ export class QuickPickAdminDialogComponent implements OnInit {
         return this.gymForm;
       case 'egg':
         return this.eggForm;
+      case 'maxbattle':
+        return this.maxBattleForm;
       default:
         return null;
     }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
@@ -43,6 +43,7 @@ export class QuickPickListComponent implements OnInit {
     lure: '#e91e63',
     monster: '#4caf50',
     nest: '#8bc34a',
+    maxbattle: '#ff5722',
     quest: '#9c27b0',
   };
 

--- a/Core/Pgan.PoracleWebNet.Core.Models/QuickPickDefinition.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/QuickPickDefinition.cs
@@ -10,7 +10,7 @@ public class QuickPickDefinition
     public string Description { get; set; } = string.Empty;
     public string Icon { get; set; } = "bolt";
     public string Category { get; set; } = "Common";
-    public string AlarmType { get; set; } = "monster"; // monster, raid, egg, quest, invasion, lure, nest, gym
+    public string AlarmType { get; set; } = "monster"; // monster, raid, egg, quest, invasion, lure, nest, gym, maxbattle
     public int SortOrder
     {
         get; set;

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -17,6 +17,7 @@ public partial class QuickPickService(
     ILureService lureService,
     INestService nestService,
     IGymService gymService,
+    IMaxBattleService maxBattleService,
     IMasterDataService masterDataService,
     ILogger<QuickPickService> logger) : IQuickPickService
 {
@@ -30,6 +31,7 @@ public partial class QuickPickService(
     private readonly ILureService _lureService = lureService;
     private readonly INestService _nestService = nestService;
     private readonly IGymService _gymService = gymService;
+    private readonly IMaxBattleService _maxBattleService = maxBattleService;
     private readonly IMasterDataService _masterDataService = masterDataService;
     private readonly ILogger<QuickPickService> _logger = logger;
 
@@ -160,6 +162,7 @@ public partial class QuickPickService(
             "lure" => await this.ApplyLureAsync(userId, profileNo, definition, request),
             "nest" => await this.ApplyNestAsync(userId, profileNo, definition, request),
             "gym" => await this.ApplyGymAsync(userId, profileNo, definition, request),
+            "maxbattle" => await this.ApplyMaxBattleAsync(userId, profileNo, definition, request),
             _ => throw new InvalidOperationException($"Unknown alarm type '{definition.AlarmType}'."),
         };
         var appliedState = new QuickPickAppliedState
@@ -227,6 +230,9 @@ public partial class QuickPickService(
                     break;
                 case "gym":
                     await this._gymService.DeleteAsync(userId, uid);
+                    break;
+                case "maxbattle":
+                    await this._maxBattleService.DeleteAsync(userId, uid);
                     break;
                 default:
                     break;
@@ -599,6 +605,64 @@ public partial class QuickPickService(
         return [created.Uid];
     }
 
+    // --- MaxBattle ---
+
+    private async Task<List<int>> ApplyMaxBattleAsync(
+        string userId, int profileNo, QuickPickDefinition definition, QuickPickApplyRequest request)
+    {
+        var pokemonId = GetFilterInt(definition.Filters, "pokemonId");
+        var level = GetFilterInt(definition.Filters, "level");
+
+        if (pokemonId == 9000 && level == 9000)
+        {
+            // Level-based: create one alarm per level (1-5 normal, 7-8 gmax)
+            var maxBattles = new List<MaxBattle>();
+            foreach (var lvl in new[] { 1, 2, 3, 4, 5, 7, 8 })
+            {
+                var mb = BuildMaxBattle(definition.Filters, profileNo, request);
+                mb.PokemonId = 9000;
+                mb.Level = lvl;
+                mb.Gmax = lvl >= 7 ? 1 : 0;
+                maxBattles.Add(mb);
+            }
+
+            var created = await this._maxBattleService.BulkCreateAsync(userId, maxBattles);
+            return [.. created.Select(m => m.Uid)];
+        }
+        else
+        {
+            // Specific Pokemon or specific level — single row
+            var maxBattle = BuildMaxBattle(definition.Filters, profileNo, request);
+            var created = await this._maxBattleService.CreateAsync(userId, maxBattle);
+            return [created.Uid];
+        }
+    }
+
+    private static MaxBattle BuildMaxBattle(Dictionary<string, object?> filters, int profileNo, QuickPickApplyRequest request)
+    {
+        var json = JsonSerializer.Serialize(filters, JsonOptions);
+        var maxBattle = JsonSerializer.Deserialize<MaxBattle>(json, JsonOptions) ?? new MaxBattle();
+
+        maxBattle.ProfileNo = profileNo;
+
+        if (request.Distance.HasValue)
+        {
+            maxBattle.Distance = request.Distance.Value;
+        }
+
+        if (request.Clean.HasValue)
+        {
+            maxBattle.Clean = request.Clean.Value;
+        }
+
+        if (request.Template != null)
+        {
+            maxBattle.Template = request.Template;
+        }
+
+        return maxBattle;
+    }
+
     // --- Utility ---
 
     private static int GetFilterInt(Dictionary<string, object?> filters, string key)
@@ -648,6 +712,7 @@ public partial class QuickPickService(
                 "lure" => await this._lureService.GetByUidAsync(userId, uid) != null,
                 "nest" => await this._nestService.GetByUidAsync(userId, uid) != null,
                 "gym" => await this._gymService.GetByUidAsync(userId, uid) != null,
+                "maxbattle" => await this._maxBattleService.GetByUidAsync(userId, uid) != null,
                 _ => false,
             };
             if (exists)
@@ -674,6 +739,7 @@ public partial class QuickPickService(
                 "lure" => await this._lureService.GetByUidAsync(userId, uid) != null,
                 "nest" => await this._nestService.GetByUidAsync(userId, uid) != null,
                 "gym" => await this._gymService.GetByUidAsync(userId, uid) != null,
+                "maxbattle" => await this._maxBattleService.GetByUidAsync(userId, uid) != null,
                 _ => false,
             };
             if (exists)

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
@@ -19,6 +19,7 @@ public class QuickPickServiceSecurityTests
     private readonly Mock<ILureService> _lureService = new();
     private readonly Mock<INestService> _nestService = new();
     private readonly Mock<IGymService> _gymService = new();
+    private readonly Mock<IMaxBattleService> _maxBattleService = new();
     private readonly Mock<IMasterDataService> _masterDataService = new();
     private readonly Mock<ILogger<QuickPickService>> _logger = new();
     private readonly QuickPickService _sut;
@@ -34,6 +35,7 @@ public class QuickPickServiceSecurityTests
             this._lureService.Object,
             this._nestService.Object,
             this._gymService.Object,
+            this._maxBattleService.Object,
             this._masterDataService.Object,
             this._logger.Object);
 


### PR DESCRIPTION
## Summary

Adds `maxbattle` alarm type to the Quick Pick system. Closes #140.

- **Backend**: `QuickPickService` gains `IMaxBattleService` injection and `maxbattle` cases in Apply/Remove/Count/GetValid switches. `ApplyMaxBattleAsync` creates 7 alarms (levels 1-5 with gmax=0, levels 7-8 with gmax=1) when all-levels mode is used.
- **Frontend**: Admin quick pick dialog gets `maxbattle` alarm type option, `Max Battles` category, and form fields. List component gets color mapping.
- **Tests**: `QuickPickServiceSecurityTests` updated with `IMaxBattleService` mock.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 621 passed
- [x] `ng build --production` — success
- [x] `npm run lint` — warnings only
- [x] `npx jest` — 487 passed
- [ ] Manual: create a Max Battles quick pick in admin
- [ ] Manual: apply it as a user, verify 7 alarms created
- [ ] Manual: remove it, verify alarms deleted