### PR TITLE
fix: JWT profile desync when PoracleNG changes active profile (#167)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -155,7 +155,7 @@ dotnet_style_qualification_for_event = true:warning
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
 dotnet_style_readonly_field = true:warning

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/IJwtService.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/IJwtService.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Api.Configuration;
+
+/// <summary>
+/// Centralized JWT token generation. Replaces duplicated token-creation logic
+/// across AuthController, ProfileController, ProfileOverviewController, and AdminController.
+/// </summary>
+public interface IJwtService
+{
+    /// <summary>
+    /// Generates a fresh JWT from a <see cref="UserInfo"/> object. All claims are built
+    /// from the model — no stale claims are carried over from an existing token.
+    /// </summary>
+    string GenerateToken(UserInfo user);
+
+    /// <summary>
+    /// Generates a JWT for an impersonated user. Includes an <c>impersonatedBy</c> claim
+    /// identifying the admin who initiated the impersonation.
+    /// </summary>
+    string GenerateImpersonationToken(UserInfo user, string impersonatedBy);
+
+    /// <summary>
+    /// Generates a JWT by copying claims from an existing <see cref="ClaimsPrincipal"/>
+    /// and replacing <c>profileNo</c>. Framework-injected claims (<c>exp</c>, <c>nbf</c>,
+    /// <c>iat</c>, <c>iss</c>, <c>aud</c>) are filtered out to avoid duplication.
+    /// </summary>
+    string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo);
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/JwtService.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/JwtService.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Api.Configuration;
+
+public sealed class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
+{
+    private readonly JwtSettings _settings = jwtSettings.Value;
+
+    /// <summary>
+    /// Registered JWT claim types that must NOT be copied from an existing token —
+    /// they are set automatically by the <see cref="JwtSecurityToken"/> constructor.
+    /// Copying them produces duplicate claims and carries over stale expiry/issuer values.
+    /// </summary>
+    private static readonly HashSet<string> RegisteredClaimTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "exp", "nbf", "iat", "iss", "aud",
+        JwtRegisteredClaimNames.Exp,
+        JwtRegisteredClaimNames.Nbf,
+        JwtRegisteredClaimNames.Iat,
+        JwtRegisteredClaimNames.Iss,
+        JwtRegisteredClaimNames.Aud,
+    };
+
+    public string GenerateToken(UserInfo user)
+    {
+        var claims = BuildClaims(user);
+        return this.WriteToken(claims);
+    }
+
+    public string GenerateImpersonationToken(UserInfo user, string impersonatedBy)
+    {
+        var claims = BuildClaims(user);
+        claims.Add(new Claim("impersonatedBy", impersonatedBy));
+        return this.WriteToken(claims);
+    }
+
+    public string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo)
+    {
+        var claims = new List<Claim>();
+        foreach (var claim in existingPrincipal.Claims)
+        {
+            if (string.Equals(claim.Type, "profileNo", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Skip framework-injected registered claims to avoid duplicates
+            if (RegisteredClaimTypes.Contains(claim.Type))
+            {
+                continue;
+            }
+
+            claims.Add(new Claim(claim.Type, claim.Value));
+        }
+
+        claims.Add(new Claim("profileNo", profileNo.ToString(CultureInfo.InvariantCulture)));
+        return this.WriteToken(claims);
+    }
+
+    private static List<Claim> BuildClaims(UserInfo user)
+    {
+        var claims = new List<Claim>
+        {
+            new("userId", user.Id),
+            new("username", user.Username),
+            new("type", user.Type),
+            new("isAdmin", user.IsAdmin.ToString().ToLowerInvariant()),
+            new("enabled", user.Enabled.ToString().ToLowerInvariant()),
+            new("profileNo", user.ProfileNo.ToString(CultureInfo.InvariantCulture)),
+        };
+
+        if (!string.IsNullOrEmpty(user.AvatarUrl))
+        {
+            claims.Add(new Claim("avatarUrl", user.AvatarUrl));
+        }
+
+        if (user.ManagedWebhooks is { Length: > 0 })
+        {
+            claims.Add(new Claim("managedWebhooks", string.Join(',', user.ManagedWebhooks)));
+        }
+
+        return claims;
+    }
+
+    private string WriteToken(List<Claim> claims)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._settings.Secret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: this._settings.Issuer,
+            audience: this._settings.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(this._settings.ExpirationMinutes),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
@@ -139,6 +139,9 @@ public static class ServiceCollectionExtensions
             }
         });
 
+        // Register JWT service (shared token generation across controllers)
+        services.AddSingleton<IJwtService, JwtService>();
+
         // Register settings
         services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
         services.Configure<DiscordSettings>(configuration.GetSection("Discord"));

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -1,10 +1,5 @@
-using System.Globalization;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -19,7 +14,7 @@ public partial class AdminController(
     IPoracleHumanProxy humanProxy,
     IPoracleServerService poracleServerService,
     IOptions<PoracleSettings> poracleSettings,
-    IOptions<JwtSettings> jwtSettings,
+    IJwtService jwtService,
     ILogger<AdminController> logger) : BaseApiController
 {
     private readonly IHumanService _humanService = humanService;
@@ -28,7 +23,7 @@ public partial class AdminController(
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly IPoracleServerService _poracleServerService = poracleServerService;
     private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
-    private readonly JwtSettings _jwtSettings = jwtSettings.Value;
+    private readonly IJwtService _jwtService = jwtService;
     private readonly ILogger<AdminController> _logger = logger;
 
     [HttpGet("users")]
@@ -438,32 +433,18 @@ public partial class AdminController(
 
         var avatarUrl = Services.AvatarCacheService.GetAvatarOrDefault(request.UserId, human.Type);
 
-        var claims = new List<Claim>
+        var userInfo = new UserInfo
         {
-            new("userId", human.Id),
-            new("username", human.Name ?? human.Id),
-            new("type", human.Type ?? "discord:user"),
-            new("isAdmin", "false"),
-            new("enabled", (human.Enabled == 1 && human.AdminDisable == 0).ToString().ToLowerInvariant()),
-            new("profileNo", human.CurrentProfileNo.ToString(CultureInfo.InvariantCulture)),
-            new("impersonatedBy", this.UserId),
+            Id = human.Id,
+            Username = human.Name ?? human.Id,
+            Type = human.Type ?? "discord:user",
+            IsAdmin = false,
+            Enabled = human.Enabled == 1 && human.AdminDisable == 0,
+            ProfileNo = human.CurrentProfileNo,
+            AvatarUrl = avatarUrl,
         };
 
-        if (!string.IsNullOrEmpty(avatarUrl))
-        {
-            claims.Add(new Claim("avatarUrl", avatarUrl));
-        }
-
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._jwtSettings.Secret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var token = new JwtSecurityToken(
-            issuer: this._jwtSettings.Issuer,
-            audience: this._jwtSettings.Audience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(this._jwtSettings.ExpirationMinutes),
-            signingCredentials: credentials);
-
-        var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+        var jwt = this._jwtService.GenerateImpersonationToken(userInfo, this.UserId);
         LogAdminImpersonating(this._logger, this.UserId, request.UserId);
         return this.Ok(new
         {
@@ -507,32 +488,18 @@ public partial class AdminController(
 
         var avatarUrl = Services.AvatarCacheService.GetAvatarOrDefault(id, human.Type);
 
-        var claims = new List<Claim>
+        var userInfo = new UserInfo
         {
-            new("userId", human.Id),
-            new("username", human.Name ?? human.Id),
-            new("type", human.Type ?? "discord:user"),
-            new("isAdmin", "false"),
-            new("enabled", (human.Enabled == 1 && human.AdminDisable == 0).ToString().ToLowerInvariant()),
-            new("profileNo", human.CurrentProfileNo.ToString(CultureInfo.InvariantCulture)),
-            new("impersonatedBy", this.UserId),
+            Id = human.Id,
+            Username = human.Name ?? human.Id,
+            Type = human.Type ?? "discord:user",
+            IsAdmin = false,
+            Enabled = human.Enabled == 1 && human.AdminDisable == 0,
+            ProfileNo = human.CurrentProfileNo,
+            AvatarUrl = avatarUrl,
         };
 
-        if (!string.IsNullOrEmpty(avatarUrl))
-        {
-            claims.Add(new Claim("avatarUrl", avatarUrl));
-        }
-
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._jwtSettings.Secret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var token = new JwtSecurityToken(
-            issuer: this._jwtSettings.Issuer,
-            audience: this._jwtSettings.Audience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(this._jwtSettings.ExpirationMinutes),
-            signingCredentials: credentials);
-
-        var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+        var jwt = this._jwtService.GenerateImpersonationToken(userInfo, this.UserId);
 
         LogAdminImpersonatingUser(this._logger, this.UserId, id);
 

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -8,7 +6,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -23,7 +20,7 @@ public partial class AuthController(
     IPoracleHumanProxy humanProxy,
     ISiteSettingService siteSettingService,
     IWebhookDelegateService webhookDelegateService,
-    IOptions<JwtSettings> jwtSettings,
+    IJwtService jwtService,
     IOptions<DiscordSettings> discordSettings,
     IOptions<TelegramSettings> telegramSettings,
     IOptions<PoracleSettings> poracleSettings,
@@ -38,7 +35,7 @@ public partial class AuthController(
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly ISiteSettingService _siteSettingService = siteSettingService;
     private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
-    private readonly JwtSettings _jwtSettings = jwtSettings.Value;
+    private readonly IJwtService _jwtService = jwtService;
     private readonly DiscordSettings _discordSettings = discordSettings.Value;
     private readonly TelegramSettings _telegramSettings = telegramSettings.Value;
     private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
@@ -217,7 +214,7 @@ public partial class AuthController(
             Services.AvatarCacheService.Save();
         }
 
-        var jwt = this.GenerateJwtToken(userInfo);
+        var jwt = this._jwtService.GenerateToken(userInfo);
 
         // Redirect browser to Angular with token in URL fragment to avoid server-side leakage
         return this.Redirect($"{frontendUrl}/auth/discord/callback#token={jwt}");
@@ -325,7 +322,7 @@ public partial class AuthController(
             ManagedWebhooks = managedWebhooks
         };
 
-        var jwt = this.GenerateJwtToken(userInfo);
+        var jwt = this._jwtService.GenerateToken(userInfo);
 
         return this.Ok(new
         {
@@ -360,6 +357,7 @@ public partial class AuthController(
         var human = await this._humanService.GetByIdAsync(this.UserId);
         var adminDisable = human != null && human.AdminDisable == 1;
         var enabled = human == null || (human.Enabled == 1 && human.AdminDisable == 0);
+        var dbProfileNo = human?.CurrentProfileNo ?? this.ProfileNo;
 
         var userInfo = new UserInfo
         {
@@ -369,10 +367,20 @@ public partial class AuthController(
             IsAdmin = this.IsAdmin,
             AdminDisable = adminDisable,
             Enabled = enabled,
-            ProfileNo = human?.CurrentProfileNo ?? this.ProfileNo,
+            ProfileNo = dbProfileNo,
             AvatarUrl = this.User.FindFirstValue("avatarUrl"),
             ManagedWebhooks = this.ManagedWebhooks.Length > 0 ? this.ManagedWebhooks : null
         };
+
+        // Detect JWT/DB profile desync — PoracleNG can change current_profile_no
+        // out-of-band via the active_hours scheduler or bot !profile commands.
+        // When mismatched, issue a refreshed JWT so subsequent API calls use the
+        // correct profile and alarms don't land on the wrong profile.
+        if (human != null && dbProfileNo != this.ProfileNo)
+        {
+            LogProfileResync(this._logger, this.UserId, this.ProfileNo, dbProfileNo);
+            userInfo.Token = this._jwtService.GenerateToken(userInfo);
+        }
 
         return this.Ok(userInfo);
     }
@@ -417,41 +425,6 @@ public partial class AuthController(
     {
         message = "Logged out successfully."
     });
-
-    private string GenerateJwtToken(UserInfo user)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._jwtSettings.Secret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-
-        var claims = new List<Claim>
-        {
-            new("userId", user.Id),
-            new("username", user.Username),
-            new("type", user.Type),
-            new("isAdmin", user.IsAdmin.ToString().ToLowerInvariant()),
-            new("enabled", user.Enabled.ToString().ToLowerInvariant()),
-            new("profileNo", user.ProfileNo.ToString(CultureInfo.InvariantCulture)),
-        };
-
-        if (!string.IsNullOrEmpty(user.AvatarUrl))
-        {
-            claims.Add(new Claim("avatarUrl", user.AvatarUrl));
-        }
-
-        if (user.ManagedWebhooks is { Length: > 0 })
-        {
-            claims.Add(new Claim("managedWebhooks", string.Join(',', user.ManagedWebhooks)));
-        }
-
-        var token = new JwtSecurityToken(
-            issuer: this._jwtSettings.Issuer,
-            audience: this._jwtSettings.Audience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(this._jwtSettings.ExpirationMinutes),
-            signingCredentials: credentials);
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
 
     /// <summary>
     /// Calls PoracleJS getAdministrationRoles once and returns (isAdmin, managedWebhooks).
@@ -685,4 +658,7 @@ public partial class AuthController(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Auth attempt blocked: {Method} login is disabled by site setting.")]
     private static partial void LogAuthMethodDisabled(ILogger logger, string method);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Profile resync for {UserId}: JWT had profile {JwtProfileNo}, DB has {DbProfileNo}. Issuing refreshed token.")]
+    private static partial void LogProfileResync(ILogger logger, string userId, int jwtProfileNo, int dbProfileNo);
 }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -1,11 +1,5 @@
-using System.Globalization;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -17,12 +11,12 @@ public class ProfileController(
     IProfileService profileService,
     IHumanService humanService,
     IPoracleHumanProxy humanProxy,
-    IOptions<JwtSettings> jwtSettings) : BaseApiController
+    IJwtService jwtService) : BaseApiController
 {
     private readonly IProfileService _profileService = profileService;
     private readonly IHumanService _humanService = humanService;
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
-    private readonly JwtSettings _jwtSettings = jwtSettings.Value;
+    private readonly IJwtService _jwtService = jwtService;
 
     [HttpGet]
     public async Task<IActionResult> GetAll()
@@ -114,7 +108,7 @@ public class ProfileController(
         await this._humanProxy.SwitchProfileAsync(this.UserId, profileNo);
 
         // Issue a new JWT with the updated profileNo so all subsequent API calls use it
-        var newToken = this.GenerateTokenWithProfile(profileNo);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, profileNo);
 
         return this.Ok(new
         {
@@ -183,34 +177,6 @@ public class ProfileController(
         await this._humanProxy.DeleteProfileAsync(this.UserId, profileNo);
 
         return this.NoContent();
-    }
-
-    private string GenerateTokenWithProfile(int profileNo)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._jwtSettings.Secret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-
-        // Copy all existing claims but replace profileNo
-        var claims = new List<Claim>();
-        foreach (var claim in this.User.Claims)
-        {
-            if (claim.Type == "profileNo")
-            {
-                continue;
-            }
-
-            claims.Add(new Claim(claim.Type, claim.Value));
-        }
-        claims.Add(new Claim("profileNo", profileNo.ToString(CultureInfo.InvariantCulture)));
-
-        var token = new JwtSecurityToken(
-            issuer: this._jwtSettings.Issuer,
-            audience: this._jwtSettings.Audience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(this._jwtSettings.ExpirationMinutes),
-            signingCredentials: credentials);
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
     internal static (bool IsValid, string? Error) ValidateActiveHours(string? activeHours)

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
@@ -1,11 +1,5 @@
-using System.Globalization;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 
@@ -16,11 +10,11 @@ public class ProfileOverviewController(
     IProfileOverviewService profileOverviewService,
     IProfileService profileService,
     IPoracleHumanProxy humanProxy,
-    IOptions<JwtSettings> jwtSettings) : BaseApiController
+    IJwtService jwtService) : BaseApiController
 {
     private readonly IProfileOverviewService _profileOverviewService = profileOverviewService;
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
-    private readonly JwtSettings _jwtSettings = jwtSettings.Value;
+    private readonly IJwtService _jwtService = jwtService;
     private readonly IProfileService _profileService = profileService;
 
     [HttpGet]
@@ -77,7 +71,7 @@ public class ProfileOverviewController(
         }
 
         // Issue a new JWT so the current profile stays correct
-        var newToken = this.GenerateTokenWithProfile(this.ProfileNo);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo);
 
         return this.Ok(new
         {
@@ -122,7 +116,7 @@ public class ProfileOverviewController(
         var alarmsCopied = await this._profileOverviewService.ImportAlarmsAsync(
             this.UserId, newProfileNo, request.Alarms);
 
-        var newToken = this.GenerateTokenWithProfile(this.ProfileNo);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo);
 
         return this.Ok(new
         {
@@ -132,32 +126,6 @@ public class ProfileOverviewController(
         });
     }
 
-    private string GenerateTokenWithProfile(int profileNo)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(this._jwtSettings.Secret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-
-        var claims = new List<Claim>();
-        foreach (var claim in this.User.Claims)
-        {
-            if (claim.Type == "profileNo")
-            {
-                continue;
-            }
-
-            claims.Add(new Claim(claim.Type, claim.Value));
-        }
-        claims.Add(new Claim("profileNo", profileNo.ToString(CultureInfo.InvariantCulture)));
-
-        var token = new JwtSecurityToken(
-            issuer: this._jwtSettings.Issuer,
-            audience: this._jwtSettings.Audience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(this._jwtSettings.ExpirationMinutes),
-            signingCredentials: credentials);
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
 }
 
 public record ProfileOverviewDuplicateRequest(string Name);

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/models/index.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/models/index.ts
@@ -291,6 +291,7 @@ export interface UserInfo {
   managedWebhooks?: string[] | null;
   profileName: string | null;
   profileNo: number;
+  token?: string | null;
   type: string;
   username: string;
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.spec.ts
@@ -178,6 +178,31 @@ describe('AuthService', () => {
       // token should NOT be cleared for non-401 errors
       expect(localStorage.getItem('poracle_token')).toBe('some-token');
     });
+
+    it('should store refreshed token and signal resync when backend detects mismatch', async () => {
+      localStorage.setItem('poracle_token', 'old-token');
+      const promise = service.loadCurrentUser();
+
+      const req = httpMock.expectOne(`${API}/api/auth/me`);
+      req.flush({ ...mockUser, profileNo: 3, token: 'refreshed-jwt' });
+
+      const result = await promise;
+      expect(result?.profileNo).toBe(3);
+      expect(localStorage.getItem('poracle_token')).toBe('refreshed-jwt');
+      expect(service.profileResynced()).toBe(true);
+    });
+
+    it('should not call setToken and should clear resync signal when no token in response', async () => {
+      localStorage.setItem('poracle_token', 'original-token');
+      const promise = service.loadCurrentUser();
+
+      const req = httpMock.expectOne(`${API}/api/auth/me`);
+      req.flush(mockUser);
+
+      await promise;
+      expect(localStorage.getItem('poracle_token')).toBe('original-token');
+      expect(service.profileResynced()).toBe(false);
+    });
   });
 
   describe('computed signals', () => {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.ts
@@ -13,6 +13,7 @@ const ADMIN_TOKEN_KEY = 'poracle_admin_token';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly _isImpersonating = signal(!!localStorage.getItem(ADMIN_TOKEN_KEY));
+  private readonly _profileResynced = signal(false);
   private readonly config = inject(ConfigService);
   private readonly currentUser = signal<UserInfo | null>(null);
 
@@ -26,6 +27,7 @@ export class AuthService {
   readonly isImpersonating = this._isImpersonating.asReadonly();
   readonly isLoggedIn = computed(() => !!this.currentUser());
   readonly managedWebhooks = computed(() => this.currentUser()?.managedWebhooks ?? []);
+  readonly profileResynced = this._profileResynced.asReadonly();
   readonly user = this.currentUser.asReadonly();
 
   constructor() {
@@ -35,6 +37,10 @@ export class AuthService {
     } else {
       this.userLoaded$.next(null);
     }
+  }
+
+  clearProfileResynced(): void {
+    this._profileResynced.set(false);
   }
 
   getTelegramConfig(): Observable<TelegramConfig> {
@@ -83,6 +89,15 @@ export class AuthService {
           resolve(null);
         },
         next: user => {
+          // Handle JWT profile resync — when PoracleNG changes the active profile
+          // out-of-band (active_hours scheduler, bot commands), the backend detects
+          // the mismatch and returns a refreshed token with the correct profileNo.
+          if (user.token) {
+            this.setToken(user.token);
+            this._profileResynced.set(true);
+          } else {
+            this._profileResynced.set(false);
+          }
           this.currentUser.set(user);
           this.userLoaded$.next(user);
           resolve(user);

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
@@ -326,6 +326,13 @@ export class DashboardComponent implements OnInit {
     // Re-check on each visit so wizard reappears after navigating away
     this.showOnboarding.set(!localStorage.getItem('poracle-onboarding-complete'));
     this.loadDashboardData();
+
+    // Notify user if PoracleNG changed their active profile (via active_hours or bot command)
+    if (this.authService.profileResynced()) {
+      const name = this.profileName();
+      this.snackBar.open(this.i18n.instant('DASHBOARD.PROFILE_RESYNCED', { name }), this.i18n.instant('TOAST.OK'), { duration: 5000 });
+      this.authService.clearProfileResynced();
+    }
   }
 
   openLocationDialog(): void {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Du har ingen aktive alarmer endnu. Start med at tilføje Pokemon- eller Raid-alarmer!",
     "TIP_NO_ALARMS_ACTION": "Tilføj Pokemon-alarm",
     "SWITCH_PROFILE_SUCCESS": "Skiftet til \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Kunne ikke skifte profil"
+    "SWITCH_PROFILE_FAILED": "Kunne ikke skifte profil",
+    "PROFILE_RESYNCED": "Profil skiftet til \"{{name}}\" efter tidsplan"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Du er klar!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Du hast noch keine aktiven Alarme. Füge zuerst Pokemon- oder Raid-Alarme hinzu!",
     "TIP_NO_ALARMS_ACTION": "Pokemon-Alarm hinzufügen",
     "SWITCH_PROFILE_SUCCESS": "Gewechselt zu \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Profilwechsel fehlgeschlagen"
+    "SWITCH_PROFILE_FAILED": "Profilwechsel fehlgeschlagen",
+    "PROFILE_RESYNCED": "Profil wurde planmäßig auf \"{{name}}\" gewechselt"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Alles fertig!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -146,7 +146,8 @@
     "TIP_NO_ALARMS": "You have no active alarms yet. Start by adding Pokemon or Raid alerts!",
     "TIP_NO_ALARMS_ACTION": "Add Pokemon Alarm",
     "SWITCH_PROFILE_SUCCESS": "Switched to \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Failed to switch profile"
+    "SWITCH_PROFILE_FAILED": "Failed to switch profile",
+    "PROFILE_RESYNCED": "Profile switched to \"{{name}}\" by schedule"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "You're All Set!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "No tienes alarmas activas todavía. ¡Empieza añadiendo alertas de Pokemon o Raid!",
     "TIP_NO_ALARMS_ACTION": "Añadir alarma Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Cambiado a \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Error al cambiar de perfil"
+    "SWITCH_PROFILE_FAILED": "Error al cambiar de perfil",
+    "PROFILE_RESYNCED": "Perfil cambiado a \"{{name}}\" por horario"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "¡Todo listo!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Tu n'as pas encore d'alarmes actives. Commence par ajouter des alertes Pokemon ou Raid !",
     "TIP_NO_ALARMS_ACTION": "Ajouter une alarme Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Basculé vers \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Échec du changement de profil"
+    "SWITCH_PROFILE_FAILED": "Échec du changement de profil",
+    "PROFILE_RESYNCED": "Profil basculé sur \"{{name}}\" par planification"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Tout est prêt !",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Non hai ancora allarmi attivi. Inizia aggiungendo avvisi per Pokemon o Raid!",
     "TIP_NO_ALARMS_ACTION": "Aggiungi Allarme Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Passato a \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Cambio profilo fallito"
+    "SWITCH_PROFILE_FAILED": "Cambio profilo fallito",
+    "PROFILE_RESYNCED": "Profilo cambiato a \"{{name}}\" da programmazione"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Tutto Pronto!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Je hebt nog geen actieve alarmen. Begin met het toevoegen van Pokemon of Raid meldingen!",
     "TIP_NO_ALARMS_ACTION": "Pokemon Alarm Toevoegen",
     "SWITCH_PROFILE_SUCCESS": "Gewisseld naar \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Profiel wisselen mislukt"
+    "SWITCH_PROFILE_FAILED": "Profiel wisselen mislukt",
+    "PROFILE_RESYNCED": "Profiel gewisseld naar \"{{name}}\" volgens schema"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Je bent klaar!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Nie masz jeszcze żadnych aktywnych alarmów. Zacznij od dodania alertów Pokemon lub rajdów!",
     "TIP_NO_ALARMS_ACTION": "Dodaj alarm Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Przełączono na \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Nie udało się przełączyć profilu"
+    "SWITCH_PROFILE_FAILED": "Nie udało się przełączyć profilu",
+    "PROFILE_RESYNCED": "Profil przełączony na \"{{name}}\" według harmonogramu"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Wszystko gotowe!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Você não tem alarmes ativos ainda. Comece adicionando alertas de Pokemon ou Raid!",
     "TIP_NO_ALARMS_ACTION": "Adicionar Alarme Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Trocado para \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Falha ao trocar perfil"
+    "SWITCH_PROFILE_FAILED": "Falha ao trocar perfil",
+    "PROFILE_RESYNCED": "Perfil alterado para \"{{name}}\" por agendamento"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Tudo Pronto!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Ainda não tens alarmes ativos. Começa por adicionar alertas de Pokemon ou Raids!",
     "TIP_NO_ALARMS_ACTION": "Adicionar Alarme Pokemon",
     "SWITCH_PROFILE_SUCCESS": "Mudado para \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Falha ao trocar perfil"
+    "SWITCH_PROFILE_FAILED": "Falha ao trocar perfil",
+    "PROFILE_RESYNCED": "Perfil alterado para \"{{name}}\" por agendamento"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Está Tudo Pronto!",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -145,7 +145,8 @@
     "TIP_NO_ALARMS": "Du har inga aktiva larm ännu. Börja med att lägga till Pokemon- eller Raid-larm!",
     "TIP_NO_ALARMS_ACTION": "Lägg till Pokemon-larm",
     "SWITCH_PROFILE_SUCCESS": "Bytt till \"{{name}}\"",
-    "SWITCH_PROFILE_FAILED": "Kunde inte byta profil"
+    "SWITCH_PROFILE_FAILED": "Kunde inte byta profil",
+    "PROFILE_RESYNCED": "Profil byttes till \"{{name}}\" enligt schema"
   },
   "ONBOARDING": {
     "TITLE_COMPLETE": "Du är redo!",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Alarms silently landing on the wrong profile after PoracleNG auto-switches via active_hours scheduler** ([#167](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/167)): When PoracleNG's active-hours scheduler (or a bot `!profile` command) changed `current_profile_no` out-of-band, the JWT's `profileNo` claim went stale. All subsequent alarm CRUD was scoped to the old profile — users unknowingly created, edited, and deleted alarms on a profile they were no longer viewing. Fixed by adding a profile-resync check to `GET /api/auth/me`: the endpoint now compares the JWT's `profileNo` claim against `humans.current_profile_no` from the database and returns a refreshed JWT when they diverge. The frontend's `AuthService.loadCurrentUser()` picks up the new token transparently, and the dashboard shows a snackbar ("Profile switched to X by schedule") so the user knows which profile they're on.
+
+### Changed
+- **Extracted `IJwtService`**: JWT token generation was duplicated across `AuthController`, `ProfileController`, `ProfileOverviewController`, and `AdminController` (4 independent implementations). Consolidated into a shared `IJwtService` / `JwtService` singleton registered in DI. `GenerateTokenWithReplacedProfile` now filters out registered JWT claims (`exp`, `nbf`, `iat`, `iss`, `aud`) to prevent stale claim duplication — a latent bug in the previous copy-all-claims approach.
+
 ## [2.4.1] - 2026-04-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ Pgan.PoracleWebNet.slnx
   - **Validation**: `ProfileController.ValidateActiveHours` (internal static) validates the JSON structure: day 1-7, hours 0-23, mins 0-59, max 28 entries, accepts both string and int types for hours/mins fields (PoracleNG stores these inconsistently).
   - **Frontend**: `ProfileService.updateActiveHours()` sends the updated schedule. `ActiveHoursChipComponent` renders compact amber schedule pills on profile cards. `ActiveHoursEditorDialogComponent` provides a day picker (circular buttons + Weekdays/Weekends/Every Day presets), time picker, grouped rules list, and mini weekly preview grid.
   - **Location warning**: `LocationWarningComponent` shows an inline red warning when active hours are set but the profile has 0,0 coordinates, since PoracleNG uses the profile's location for timezone calculations and 0,0 defaults to UTC.
+- **JWT profile resync**: PoracleNG can change `current_profile_no` out-of-band (active-hours scheduler, bot `!profile` command). `GET /api/auth/me` detects when the JWT's `profileNo` claim differs from the DB value and returns a refreshed JWT with the corrected profile number, preventing alarm CRUD from targeting a stale profile. The dashboard shows a snackbar notification when this resync occurs.
 
 ### Rate Limiting
 - Auth endpoints use **per-IP** partitioned rate limiting (not global).
@@ -337,6 +338,12 @@ PoracleNG stores `hours` and `mins` fields in `active_hours` JSON entries incons
 
 ### Webhook ID URL Encoding
 Webhook IDs in Poracle are URLs (e.g., `http://host:port/path`). When constructing proxy API paths that include a webhook ID as a path segment, the ID must be encoded with `Uri.EscapeDataString()` to escape slashes and other special characters. Both `PoracleTrackingProxy` and `PoracleHumanProxy` apply this encoding.
+
+### JWT Profile Desync
+PoracleNG can change `current_profile_no` outside of PoracleWeb — the active-hours scheduler switches profiles on a cron, and bot commands like `!profile` update the DB directly. When this happens the JWT's `profileNo` claim goes stale, causing all alarm reads and writes to target the wrong profile. The `/api/auth/me` endpoint detects the mismatch by comparing the JWT claim against the live `current_profile_no` from `IHumanService` and returns a refreshed token (via the `Token` property on `UserInfo`) when they diverge. Frontend callers (`AuthService.loadCurrentUser`) must always check for and store the returned token.
+
+### JWT Generation (IJwtService)
+JWT token generation is centralized in `IJwtService` / `JwtService` (singleton). Three methods: `GenerateToken(UserInfo)` for fresh tokens, `GenerateImpersonationToken(UserInfo, impersonatedBy)` for admin impersonation, and `GenerateTokenWithReplacedProfile(ClaimsPrincipal, profileNo)` for profile switches. The latter filters out registered JWT claims (`exp`, `nbf`, `iat`, `iss`, `aud`) before copying to prevent stale claim duplication. All controllers (`AuthController`, `ProfileController`, `ProfileOverviewController`, `AdminController`) use this service — no inline JWT generation.
 
 ## Build & Run
 
@@ -482,6 +489,7 @@ dotnet ef migrations script \
 | Area Controller | `Applications/Pgan.PoracleWebNet.Api/Controllers/AreaController.cs` |
 | Profile Controller | `Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs` |
 | DI Registration | `Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs` |
+| IJwtService / JwtService | `Applications/Pgan.PoracleWebNet.Api/Configuration/IJwtService.cs`, `JwtService.cs` |
 | Settings Classes | `Applications/Pgan.PoracleWebNet.Api/Configuration/` (JwtSettings, DiscordSettings, KojiSettings, PoracleServerSettings, etc.) |
 | Settings Migration Service | `Applications/Pgan.PoracleWebNet.Api/Services/SettingsMigrationStartupService.cs` |
 | Angular App Root | `Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/` |

--- a/Core/Pgan.PoracleWebNet.Core.Models/UserInfo.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/UserInfo.cs
@@ -26,4 +26,14 @@ public class UserInfo
     {
         get; set;
     }
+
+    /// <summary>
+    /// Optional refreshed JWT token. Returned by <c>/api/auth/me</c> when the JWT's
+    /// <c>profileNo</c> claim is stale (e.g. PoracleNG changed the active profile via
+    /// the active_hours scheduler or a bot command). Null when no resync is needed.
+    /// </summary>
+    public string? Token
+    {
+        get; set;
+    }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -16,19 +16,15 @@ public class AdminControllerTests : ControllerTestBase
     private readonly Mock<IPoracleHumanProxy> _humanProxy = new();
     private readonly Mock<IPoracleServerService> _poracleServerService = new();
     private readonly Mock<IWebhookDelegateService> _webhookDelegateService = new();
+    private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<ILogger<AdminController>> _logger = new();
     private readonly AdminController _sut;
 
     public AdminControllerTests()
     {
         var poracleSettings = Options.Create(new PoracleSettings { AdminIds = "admin1,admin2" });
-        var jwtSettings = Options.Create(new JwtSettings
-        {
-            Secret = "a-very-long-secret-key-for-jwt-testing-at-least-32-bytes",
-            Issuer = "test",
-            Audience = "test",
-            ExpirationMinutes = 60
-        });
+        this._jwtService.Setup(j => j.GenerateImpersonationToken(It.IsAny<UserInfo>(), It.IsAny<string>()))
+            .Returns("test-impersonation-jwt");
         this._sut = new AdminController(
             this._humanService.Object,
             this._webhookDelegateService.Object,
@@ -36,7 +32,7 @@ public class AdminControllerTests : ControllerTestBase
             this._humanProxy.Object,
             this._poracleServerService.Object,
             poracleSettings,
-            jwtSettings,
+            this._jwtService.Object,
             this._logger.Object);
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Controllers;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Tests.Controllers;
+
+/// <summary>
+/// Tests for AuthController.Me() — specifically the JWT/DB profile resync behavior.
+/// </summary>
+public class AuthControllerMeTests : ControllerTestBase
+{
+    private readonly Mock<IHumanService> _humanService = new();
+    private readonly Mock<IJwtService> _jwtService = new();
+    private readonly AuthController _sut;
+
+    public AuthControllerMeTests()
+    {
+        this._jwtService.Setup(j => j.GenerateToken(It.IsAny<UserInfo>()))
+            .Returns("refreshed-jwt-token");
+
+        var config = new ConfigurationBuilder().Build();
+        this._sut = new AuthController(
+            this._humanService.Object,
+            new Mock<IPoracleApiProxy>().Object,
+            new Mock<IPoracleHumanProxy>().Object,
+            new Mock<ISiteSettingService>().Object,
+            new Mock<IWebhookDelegateService>().Object,
+            this._jwtService.Object,
+            Options.Create(new DiscordSettings()),
+            Options.Create(new TelegramSettings()),
+            Options.Create(new PoracleSettings()),
+            config,
+            new Mock<ILogger<AuthController>>().Object);
+    }
+
+    [Fact]
+    public async Task Me_ReturnsRefreshedToken_WhenProfileNoMismatch()
+    {
+        SetupUser(this._sut, profileNo: 2);
+        this._humanService.Setup(s => s.GetByIdAsync("123456789"))
+            .ReturnsAsync(new Human { CurrentProfileNo = 1, Enabled = 1 });
+
+        var result = await this._sut.Me();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var userInfo = Assert.IsType<UserInfo>(ok.Value);
+        Assert.Equal(1, userInfo.ProfileNo);
+        Assert.Equal("refreshed-jwt-token", userInfo.Token);
+        this._jwtService.Verify(j => j.GenerateToken(It.Is<UserInfo>(u => u.ProfileNo == 1)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Me_DoesNotIncludeToken_WhenProfileNoMatches()
+    {
+        SetupUser(this._sut, profileNo: 1);
+        this._humanService.Setup(s => s.GetByIdAsync("123456789"))
+            .ReturnsAsync(new Human { CurrentProfileNo = 1, Enabled = 1 });
+
+        var result = await this._sut.Me();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var userInfo = Assert.IsType<UserInfo>(ok.Value);
+        Assert.Equal(1, userInfo.ProfileNo);
+        Assert.Null(userInfo.Token);
+        this._jwtService.Verify(j => j.GenerateToken(It.IsAny<UserInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Me_UsesDbProfileNo_WhenHumanExists()
+    {
+        SetupUser(this._sut, profileNo: 3);
+        this._humanService.Setup(s => s.GetByIdAsync("123456789"))
+            .ReturnsAsync(new Human { CurrentProfileNo = 5, Enabled = 1 });
+
+        var result = await this._sut.Me();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var userInfo = Assert.IsType<UserInfo>(ok.Value);
+        Assert.Equal(5, userInfo.ProfileNo);
+        Assert.NotNull(userInfo.Token);
+    }
+
+    [Fact]
+    public async Task Me_FallsBackToJwtProfileNo_WhenHumanNotFound()
+    {
+        SetupUser(this._sut, profileNo: 2);
+        this._humanService.Setup(s => s.GetByIdAsync("123456789"))
+            .ReturnsAsync((Human?)null);
+
+        var result = await this._sut.Me();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var userInfo = Assert.IsType<UserInfo>(ok.Value);
+        Assert.Equal(2, userInfo.ProfileNo);
+        Assert.Null(userInfo.Token);
+        this._jwtService.Verify(j => j.GenerateToken(It.IsAny<UserInfo>()), Times.Never);
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Moq;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Api.Controllers;
@@ -16,10 +15,13 @@ public class ProfileControllerTests : ControllerTestBase
     private readonly Mock<IPoracleHumanProxy> _humanProxy = new();
     private readonly ProfileController _sut;
 
+    private readonly Mock<IJwtService> _jwtService = new();
+
     public ProfileControllerTests()
     {
-        var jwtSettings = Options.Create(new JwtSettings { Secret = "test-secret-key-that-is-long-enough", Issuer = "test", Audience = "test" });
-        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, jwtSettings);
+        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>()))
+            .Returns("test-jwt-token");
+        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, this._jwtService.Object);
         SetupUser(this._sut);
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileOverviewControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileOverviewControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Moq;
 using Pgan.PoracleWebNet.Api.Configuration;
 using Pgan.PoracleWebNet.Api.Controllers;
@@ -15,20 +14,17 @@ public class ProfileOverviewControllerTests : ControllerTestBase
     private readonly Mock<IProfileOverviewService> _service = new();
     private readonly ProfileOverviewController _sut;
 
+    private readonly Mock<IJwtService> _jwtService = new();
+
     public ProfileOverviewControllerTests()
     {
-        var jwtSettings = Options.Create(new JwtSettings
-        {
-            Audience = "test",
-            ExpirationMinutes = 60,
-            Issuer = "test",
-            Secret = "test-secret-key-that-is-at-least-32-characters-long",
-        });
+        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>()))
+            .Returns("test-jwt-token");
         this._sut = new ProfileOverviewController(
             this._service.Object,
             this._profileService.Object,
             this._humanProxy.Object,
-            jwtSettings);
+            this._jwtService.Object);
         SetupUser(this._sut);
     }
 


### PR DESCRIPTION
## Summary

- **Fixes alarms landing on the wrong profile** when PoracleNG changes `current_profile_no` out-of-band (active_hours scheduler, bot `!profile` commands, restarts). `GET /api/auth/me` now detects when the JWT's `profileNo` claim doesn't match the DB and returns a refreshed token. The frontend stores it transparently and the dashboard shows a snackbar notification.
- **Extracts `IJwtService`** to consolidate JWT generation from 4 duplicate implementations across AuthController, ProfileController, ProfileOverviewController, and AdminController (-175 lines of duplication). Fixes a latent bug where `GenerateTokenWithReplacedProfile` copied stale `exp`/`nbf`/`iat` claims from the existing JWT.
- **Fixes `.editorconfig`** `dotnet_style_require_accessibility_modifiers` from `always` to `for_non_interface_members` — interface members should not have access modifiers.

## Test plan

- [x] 898 backend tests pass (4 new `AuthControllerMeTests`)
- [x] 581 frontend tests pass (2 new `auth.service.spec.ts` resync tests)
- [x] `dotnet format --verify-no-changes` clean (new files only — pre-existing warnings in unrelated files unchanged)
- [x] ESLint clean
- [x] Prettier clean
- [ ] Manual: set up active_hours on a profile, wait for PoracleNG to switch, verify dashboard shows snackbar and subsequent alarm creation targets the correct profile
- [ ] Manual: verify profile switch via UI still works (issues new JWT via `IJwtService`)
- [ ] Manual: verify admin impersonation still works (uses `GenerateImpersonationToken`)

Fixes #167