### PR TITLE
fix: use 'PoracleWeb.NET' branding consistently (fixes #175)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# PoracleWeb Configuration
+# PoracleWeb.NET Configuration
 # This file works for both Docker and standalone mode.
 # Copy to .env and fill in your values: cp .env.example .env
 # Or run: ./scripts/setup.sh
@@ -6,7 +6,7 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 # PORT
 # ═══════════════════════════════════════════════════════════════════════════════
-# The port PoracleWeb listens on
+# The port PoracleWeb.NET listens on
 PORT=8082
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -21,7 +21,7 @@ DB_USER=root
 DB_PASSWORD=your_db_password
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# DATABASE — PoracleWeb (separate database for app-owned data)
+# DATABASE — PoracleWeb.NET (separate database for app-owned data)
 # ═══════════════════════════════════════════════════════════════════════════════
 # This is NOT the Poracle DB — it stores user geofences, settings, etc.
 # Create it manually: CREATE DATABASE poracle_web; — tables are auto-created on startup.
@@ -73,7 +73,7 @@ TELEGRAM_ENABLED=false
 # ═══════════════════════════════════════════════════════════════════════════════
 # PORACLE API — your running PoracleNG instance
 # ═══════════════════════════════════════════════════════════════════════════════
-# This is how PoracleWeb talks to Poracle. Must be reachable from wherever PoracleWeb runs.
+# This is how PoracleWeb.NET talks to Poracle. Must be reachable from wherever PoracleWeb.NET runs.
 PORACLE_API_ADDRESS=http://localhost:3030
 PORACLE_API_SECRET=your_poracle_api_secret
 
@@ -101,7 +101,7 @@ PORACLE_ADMIN_IDS=your_discord_user_id
 # KOJI — Geofence API (required for custom geofences feature)
 # ═══════════════════════════════════════════════════════════════════════════════
 # Used for: fetching regions, promoting approved geofences to public areas.
-# PoracleWeb serves ALL geofences (admin from Koji + user from DB) via /api/geofence-feed.
+# PoracleWeb.NET serves ALL geofences (admin from Koji + user from DB) via /api/geofence-feed.
 KOJI_API_ADDRESS=http://localhost:8080
 KOJI_BEARER_TOKEN=your_koji_bearer_token
 KOJI_PROJECT_ID=1
@@ -110,7 +110,7 @@ KOJI_PROJECT_NAME=YourProjectName
 # ═══════════════════════════════════════════════════════════════════════════════
 # CORS — required in production
 # ═══════════════════════════════════════════════════════════════════════════════
-# Set to the URL you access PoracleWeb from. Not required in development mode.
+# Set to the URL you access PoracleWeb.NET from. Not required in development mode.
 # CORS_ORIGIN=http://192.168.1.50:8082
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/Applications/Pgan.PoracleWebNet.Api/Services/SettingsMigrationStartupService.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Services/SettingsMigrationStartupService.cs
@@ -20,6 +20,7 @@ public partial class SettingsMigrationStartupService(
             using var scope = scopeFactory.CreateScope();
             var migrationService = scope.ServiceProvider.GetRequiredService<ISettingsMigrationService>();
             await migrationService.MigrateAsync();
+            await migrationService.SeedDefaultsAsync();
             LogMigrationCompleted(logger);
         }
         catch (Exception ex)

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/styles.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/styles.scss
@@ -2,7 +2,7 @@
 @import 'leaflet/dist/leaflet.css';
 @import 'leaflet-draw/dist/leaflet.draw.css';
 
-// Custom M3 theme for PoracleWeb
+// Custom M3 theme for PoracleWeb.NET
 // Primary: #1976D2 (Material Blue)
 // Tertiary/Accent: #00BCD4 (Teal)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to PoracleWeb are documented in this file.
+All notable changes to PoracleWeb.NET are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ISettingsMigrationService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ISettingsMigrationService.cs
@@ -2,5 +2,11 @@ namespace Pgan.PoracleWebNet.Core.Abstractions.Services;
 
 public interface ISettingsMigrationService
 {
-    public Task MigrateAsync();
+    Task MigrateAsync();
+
+    /// <summary>
+    /// Ensures default site settings exist. Does not overwrite existing values.
+    /// Called on every startup (after migration) so fresh installs get sensible defaults.
+    /// </summary>
+    Task SeedDefaultsAsync();
 }

--- a/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
@@ -388,6 +388,43 @@ public partial class SettingsMigrationService(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Invalid qp_applied key format: '{Key}'")]
     private static partial void LogInvalidAppliedStateKey(ILogger logger, string key);
 
+    // ── Default seeding ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Default site settings seeded on fresh installs. Each entry is only
+    /// written when the key does not yet exist in the database, so admin
+    /// overrides are never clobbered.
+    /// </summary>
+    private static readonly (string Key, string Value, string Category, string ValueType)[] DefaultSettings =
+    [
+        ("custom_title", "PoracleWeb.NET", "branding", "string"),
+    ];
+
+    public async Task SeedDefaultsAsync()
+    {
+        foreach (var (key, value, category, valueType) in DefaultSettings)
+        {
+            var existing = await this._siteSettingService.GetByKeyAsync(key);
+            if (existing != null)
+            {
+                continue;
+            }
+
+            await this._siteSettingService.CreateOrUpdateAsync(new SiteSetting
+            {
+                Key = key,
+                Value = value,
+                Category = category,
+                ValueType = valueType,
+            });
+
+            LogDefaultSeeded(this._logger, key, value);
+        }
+    }
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Settings migration completed: {SiteSettings} site settings, {WebhookDelegates} webhook delegates, {QuickPickDefinitions} quick pick definitions, {QuickPickAppliedStates} quick pick applied states, {Failed} failed")]
     private static partial void LogMigrationCompleted(ILogger logger, int siteSettings, int webhookDelegates, int quickPickDefinitions, int quickPickAppliedStates, int failed);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Seeded default setting '{Key}' = '{Value}'")]
+    private static partial void LogDefaultSeeded(ILogger logger, string key, string value);
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Helpers/AreaListJsonTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Helpers/AreaListJsonTests.cs
@@ -35,7 +35,7 @@ public class AreaListJsonTests
     [Fact]
     public void ParseFallsBackToCommaSeparatedForLegacyRows()
     {
-        // Older PoracleWeb rows stored areas as CSV rather than JSON. Must still parse.
+        // Older PoracleWeb.NET rows stored areas as CSV rather than JSON. Must still parse.
         var result = AreaListJson.Parse("downtown,west end,uptown");
         Assert.Equal(3, result.Count);
         Assert.Contains("downtown", result);
@@ -80,7 +80,7 @@ public class AreaListJsonTests
     public void ParseStillFallsBackToCsvForNonBracketedInput()
     {
         // Guard against the previous fix being too aggressive — unbracketed input that can't
-        // parse as JSON is still assumed to be CSV (the legacy PoracleWeb format).
+        // parse as JSON is still assumed to be CSV (the legacy PoracleWeb.NET format).
         var result = AreaListJson.Parse("downtown,west end");
         Assert.Equal(2, result.Count);
     }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/SettingsMigrationServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/SettingsMigrationServiceTests.cs
@@ -140,6 +140,33 @@ public class SettingsMigrationServiceTests
             ss.Key == "succeeding_key")), Times.Once);
     }
 
+    // ── SeedDefaultsAsync ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SeedDefaultsAsyncSeedsCustomTitleWhenMissing()
+    {
+        this._siteSettingService.Setup(s => s.GetByKeyAsync("custom_title"))
+            .ReturnsAsync((SiteSetting?)null);
+        this._siteSettingService.Setup(s => s.CreateOrUpdateAsync(It.IsAny<SiteSetting>()))
+            .ReturnsAsync((SiteSetting s) => s);
+
+        await this._sut.SeedDefaultsAsync();
+
+        this._siteSettingService.Verify(s => s.CreateOrUpdateAsync(It.Is<SiteSetting>(ss =>
+            ss.Key == "custom_title" && ss.Value == "PoracleWeb.NET")), Times.Once);
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsyncDoesNotOverwriteExistingCustomTitle()
+    {
+        this._siteSettingService.Setup(s => s.GetByKeyAsync("custom_title"))
+            .ReturnsAsync(new SiteSetting { Key = "custom_title", Value = "My Custom Title" });
+
+        await this._sut.SeedDefaultsAsync();
+
+        this._siteSettingService.Verify(s => s.CreateOrUpdateAsync(It.IsAny<SiteSetting>()), Times.Never);
+    }
+
     private void SetupNotMigrated() => this._siteSettingService.Setup(s => s.GetByKeyAsync("migration_completed"))
             .ReturnsAsync((SiteSetting?)null);
 }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -335,7 +335,7 @@
 
 <!-- Hero -->
 <section class="hero">
-  <h1 class="hero__title">PoracleWeb</h1>
+  <h1 class="hero__title">PoracleWeb.NET</h1>
   <p class="hero__tagline">Pokemon GO DM Alert Configuration</p>
   <div class="hero__badges">
     <span class="hero__badge">Angular 21</span>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PoracleWeb — Development convenience commands
+# PoracleWeb.NET — Development convenience commands
 # Run from anywhere: ./scripts/dev.sh <command>
 set -euo pipefail
 
@@ -17,7 +17,7 @@ else
 fi
 
 usage() {
-  echo -e "${BOLD}PoracleWeb Dev${RESET} — development commands from the project root"
+  echo -e "${BOLD}PoracleWeb.NET Dev${RESET} — development commands from the project root"
   echo ""
   echo "Usage: ./scripts/dev.sh <command>"
   echo ""

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PoracleWeb — Docker convenience commands
+# PoracleWeb.NET — Docker convenience commands
 # Run from anywhere: ./scripts/docker.sh <command>
 set -euo pipefail
 
@@ -14,7 +14,7 @@ else
 fi
 
 usage() {
-  echo -e "${BOLD}PoracleWeb Docker${RESET} — Docker commands from the project root"
+  echo -e "${BOLD}PoracleWeb.NET Docker${RESET} — Docker commands from the project root"
   echo ""
   echo "Usage: ./scripts/docker.sh <command>"
   echo ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PoracleWeb — Interactive first-time setup
+# PoracleWeb.NET — Interactive first-time setup
 # Creates and configures your .env file from .env.example
 set -euo pipefail
 
@@ -47,7 +47,7 @@ set_env() {
 
 # ─────────────────────────────────────────────────────────────────────────────
 
-echo -e "${BOLD}PoracleWeb Setup${RESET}"
+echo -e "${BOLD}PoracleWeb.NET Setup${RESET}"
 echo "This will create and configure your .env file."
 echo "Press Enter to accept the default value shown in brackets."
 
@@ -99,8 +99,8 @@ set_env "DB_NAME" "$DB_NAME"
 set_env "DB_USER" "$DB_USER"
 set_env "DB_PASSWORD" "$DB_PASSWORD"
 
-header "5. PoracleWeb database"
-info "  A separate database for PoracleWeb's own data."
+header "5. PoracleWeb.NET database"
+info "  A separate database for PoracleWeb.NET's own data."
 info "  Uses the same server by default — only change if different."
 WEB_DB_HOST=$(ask WEB_DB_HOST "Host" "$DB_HOST")
 WEB_DB_PORT=$(ask WEB_DB_PORT "Port" "$DB_PORT")


### PR DESCRIPTION
## Summary
- Seed `custom_title = "PoracleWeb.NET"` as the default site setting on fresh installs via `SeedDefaultsAsync()`, called on every startup after migrations
- Existing deployments with a `custom_title` already set are **not affected** — the seed only writes when the key is missing
- Fix docs hero title from "PoracleWeb" to "PoracleWeb.NET" (`docs/overrides/home.html`)
- Update branding in scripts (`setup.sh`, `dev.sh`, `docker.sh`), `.env.example`, `CHANGELOG.md`, and code comments

## Why this was needed
The login page title comes from the `custom_title` site setting in `poracle_web.site_settings`. Fresh installs had no default — the Angular fallback was "DM Alerts" (via i18n). Deployments migrated from the PHP PoracleWeb had `custom_title = "PoracleWeb"` carried over by the `SettingsMigrationService`. Neither showed the correct "PoracleWeb.NET" name.

## What changed
| File | Change |
|------|--------|
| `ISettingsMigrationService.cs` | Added `SeedDefaultsAsync()` interface method |
| `SettingsMigrationService.cs` | Implemented `SeedDefaultsAsync()` with `DefaultSettings` array |
| `SettingsMigrationStartupService.cs` | Calls `SeedDefaultsAsync()` after `MigrateAsync()` on every startup |
| `SettingsMigrationServiceTests.cs` | 2 new tests: seeds when missing, skips when existing |
| `docs/overrides/home.html` | Hero title: "PoracleWeb" → "PoracleWeb.NET" |
| `CHANGELOG.md` | Header branding fix |
| `.env.example` | Comment branding fixes |
| `scripts/*` | Banner/header branding fixes |
| `styles.scss` | Comment branding fix |
| `AreaListJsonTests.cs` | Comment branding fixes |

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 901 passed, 0 failed
- [x] `npx jest --ci` (ClientApp) — 585 passed, 0 failed
- [x] `npx prettier --check` (changed files) — all pass
- [x] `npx eslint src/` — clean
- [x] Verify `SeedDefaultsAsync` seeds `custom_title` when missing (new test)
- [x] Verify `SeedDefaultsAsync` does not overwrite existing `custom_title` (new test)