### PR TITLE
docs: add community/support section (GitHub issues + discussions, no Discord)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A web application for managing Pokemon GO notification alarms through the Poracl
 - **Testing**: Jest (frontend), xUnit (backend)
 - **CI/CD**: GitHub Actions, Docker (ghcr.io)
 
+## Community & Support
+
+There is **no Discord server** for PoracleWeb.NET at this time. All support, bug reports, feature requests, and community discussion happen directly on GitHub:
+
+- **[Issues](https://github.com/PGAN-Dev/PoracleWeb.NET/issues)** — bug reports and feature requests
+- **[Discussions](https://github.com/PGAN-Dev/PoracleWeb.NET/discussions)** — questions, ideas, and general conversation
+- **[Pull Requests](https://github.com/PGAN-Dev/PoracleWeb.NET/pulls)** — contributions welcome
+
 ## Quick Start (Docker)
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,14 @@ A web application for managing Pokemon GO notification alarms through the Poracl
 
 </div>
 
+## Community & Support
+
+There is **no Discord server** for PoracleWeb.NET at this time. All support, bug reports, feature requests, and community discussion happen directly on GitHub:
+
+- **[Issues](https://github.com/PGAN-Dev/PoracleWeb.NET/issues)** — bug reports and feature requests
+- **[Discussions](https://github.com/PGAN-Dev/PoracleWeb.NET/discussions)** — questions, ideas, and general conversation
+- **[Pull Requests](https://github.com/PGAN-Dev/PoracleWeb.NET/pulls)** — contributions welcome
+
 ## Credits
 
 PoracleWeb.NET stands on the shoulders of these projects and their authors:


### PR DESCRIPTION
Adds a Community & Support section to README.md and docs/index.md clarifying that support happens via GitHub issues and discussions — no Discord server exists.