### PR TITLE
chore: cut changelog for v2.7.0 + switch release workflow to PR

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -20,7 +21,6 @@ jobs:
       - name: Update CHANGELOG.md for release
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          # Strip 'v' prefix if present
           VERSION="${VERSION#v}"
           DATE=$(date +%Y-%m-%d)
 
@@ -30,15 +30,21 @@ jobs:
           # Update comparison links
           PREV_VERSION=$(grep -oP '^\[[\d.]+\]' CHANGELOG.md | head -2 | tail -1 | tr -d '[]')
           if [ -n "$PREV_VERSION" ]; then
-            # Add new version link before the previous latest
             sed -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/${{ github.repository }}/compare/v$VERSION...HEAD\n[$VERSION]: https://github.com/${{ github.repository }}/compare/v$PREV_VERSION...v$VERSION|" CHANGELOG.md
           fi
 
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          git diff --cached --quiet || (git commit -m "docs: cut changelog for v${VERSION}" && git push)
+      - name: Open PR with changelog update
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: cut changelog for ${{ github.event.release.tag_name }}"
+          title: "docs: cut changelog for ${{ github.event.release.tag_name }}"
+          body: |
+            Automated CHANGELOG update for release ${{ github.event.release.tag_name }}.
+
+            Promotes the `[Unreleased]` section to `[${{ github.event.release.tag_name }}]` and opens a fresh `[Unreleased]` section.
+
+            Triggered by release [${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}).
+          branch: changelog/${{ github.event.release.tag_name }}
+          base: main
+          labels: docs,automated
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ avatar-cache.json
 screenshot-*.png
 Applications/Pgan.PoracleWebNet.Api/cookies.txt
 beta-discord-messages.txt
+
+# ASP.NET DataProtection runtime keys — never commit
+Data/dataprotection-keys/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-04-13
+
 ### Changed
 - Bump the microsoft group with 10 updates ([PR #190](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/190))
 - bump the angular group across 1 directory with 13 updates ([PR #189](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/189))
@@ -473,7 +475,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rate limiting (per-IP) on auth endpoints
 - Docker deployment with Watchtower auto-updates
 
-[Unreleased]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.4.1...v2.6.0
 [2.5.0]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.4.0...v2.5.0
 [2.4.1]: https://github.com/PGAN-Dev/PoracleWeb.NET/compare/v2.3.0...v2.4.1


### PR DESCRIPTION
## Summary

Two fixes in one PR — triggered by the failed `Cut Changelog Release` workflow run on the v2.7.0 release.

### Fix 1: Workflow can't push to protected main

The `release-changelog.yml` workflow previously tried to commit the CHANGELOG update directly to `main`. Branch protection rejected it (`github-actions[bot]` is not a bypass actor):

> remote: GH006: Protected branch update failed for refs/heads/main.
> remote: - Changes must be made through a pull request.

Switched to `peter-evans/create-pull-request@v7` so the automated CHANGELOG update arrives as a PR that goes through the normal protected-branch merge flow. Needs a one-click merge per release, but keeps branch protection uniform.

### Fix 2: Manually cut v2.7.0 CHANGELOG

Since the automated run for v2.7.0 failed before I fixed the workflow, this PR also includes the manual edit that the workflow would have made: promote `[Unreleased]` → `[2.7.0] - 2026-04-13` and update compare links.

### Bonus: Gitignore dataprotection keys

Accidentally noticed `Data/dataprotection-keys/` was not gitignored. Added the rule — ASP.NET runtime key material must never be checked in.

## Test plan

- [x] Local changelog edits look correct (promoted to `[2.7.0]`, new Unreleased at top, compare links updated).
- [x] Workflow yaml valid.
- [x] Merge this PR, then on next release the workflow should open a PR titled `docs: cut changelog for vX.Y.Z`.