### PR TITLE
fix(mobile): remove 56px gap above sticky Pokemon search bar

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.scss
@@ -70,7 +70,7 @@
 
   &.sticky {
     position: sticky;
-    top: 56px;
+    top: 0;
     z-index: 10;
   }
 }
@@ -542,15 +542,32 @@
 // ─── Responsive ─────────────────────────────────────────────────────────────────
 @media (max-width: 599px) {
   .filter-bar {
-    padding: 8px 16px;
+    padding: 8px 12px;
+    gap: 8px;
   }
   .search-field {
-    flex-basis: 100%;
+    flex: 1 1 100%;
+    min-width: 0;
     max-width: none;
+    order: 1;
+  }
+  .quick-filters {
+    order: 3;
+    flex-basis: 100%;
+    gap: 6px;
+  }
+  .quick-filters button {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 12px;
+    padding: 0 8px;
+    height: 32px;
   }
   .filter-meta {
-    flex-basis: 100%;
+    order: 2;
+    flex: 1 1 100%;
     justify-content: space-between;
+    margin-left: 0;
   }
   .bulk-toolbar {
     padding: 8px 16px;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Mobile**: Pokemon list search/filter bar no longer leaves a 56px gap above itself when sticky. `top` changed from `56px` to `0` since `mat-sidenav-content` is the scroll container and already sits below the app toolbar. Tightened the mobile (`max-width: 599px`) layout so the search field, quick-filter pills, and meta row stack cleanly at 390px viewports. ([#213](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/213))
+
 ## [2.7.0] - 2026-04-13
 
 ### Changed


### PR DESCRIPTION
## Summary
- Closes #213
- `.filter-bar.sticky` had `top: 56px` to clear the app toolbar, but the scroll container is `mat-sidenav-content` which already starts below the toolbar, so on mobile a dead 56px band sat above the search bar whenever it stuck.
- Changed `top: 56px` → `top: 0` and tightened the `max-width: 599px` layout (explicit `order`, `flex: 1 1 100%`, `min-width: 0`, smaller quick-filter buttons) so the search field, pills, and meta row stack cleanly at 390px.

## Test plan
- [x] Docker image rebuilt from this worktree; verified compiled CSS contains `top:0`
- [x] Reproduced at 390×844 via Playwright: scrolled `mat-sidenav-content` to 500px; sticky bar sits flush under the app toolbar, no gap
- [x] `npm run prettier-check` clean
- [x] `npm run lint` — no new warnings
- [x] `npm test` — 575/575 pass
- [x] `dotnet test` — 965/965 pass
- [x] `dotnet format --verify-no-changes` — no formatting changes
- [x] Manual smoke on a real phone to confirm scroll feel