### PR TITLE
ci: gate dependabot auto-merge at job level to stop phantom failures

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -13,12 +13,13 @@ permissions:
 
 jobs:
   auto-merge:
+    # Skip the job entirely on push events so GitHub records the run as "skipped"
+    # (neutral, green in status UI) instead of "failure" with 0 jobs. The prior
+    # approach of claiming push with in-step gates still produced failed runs
+    # because the job itself never spawned for non-dependabot pushes.
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Skip non-PR events
-        if: github.event_name != 'pull_request_target' || github.actor != 'dependabot[bot]'
-        run: echo "Not a Dependabot PR event, skipping."
-
       - name: Fetch Dependabot metadata
         id: meta
         if: github.actor == 'dependabot[bot]'


### PR DESCRIPTION
## Summary
The dependabot auto-merge workflow has been producing failed runs with 0 jobs on every push (see https://github.com/PGAN-Dev/PoracleWeb.NET/actions/runs/24414745287 and prior runs). Two previous commits (`bdb23f7`, `4a9d906`) tried to fix this with in-step gating and by adding `push:` to the trigger to "claim" phantom runs — but the job itself never spawned for non-dependabot pushes, so GitHub recorded "failure".

Moving the gate to the job level (`if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'`) makes non-dependabot events skip the job cleanly. The run shows "skipped" (neutral, green) instead of "failure".

The redundant in-step `if: github.actor == 'dependabot[bot]'` checks on subsequent steps are left untouched — harmless defense-in-depth.

## Test plan
- [ ] After merge, confirm the next `push` to `main` produces a skipped (not failed) `Dependabot auto-merge` run.
- [ ] On the next Dependabot PR, confirm the job still fires and auto-merge still gets enabled for eligible bumps.