### PR TITLE
ci: pin npm 11 to unblock Dependabot frontend PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: Applications/Pgan.PoracleWebNet.App/ClientApp/package-lock.json
 
+      # Node 22 ships npm 10.9.7, whose `npm ci` rejects lockfiles that omit nested
+      # optional-peer entries (chokidar@4 / readdirp@4 under @angular-devkit/*) that
+      # newer npm versions prune. Pinning npm 11 here matches what Dependabot uses
+      # to regenerate lockfiles, so `npm ci` stays in sync with that resolution.
+      - name: Pin npm 11
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Frontend CI `npm ci` failures on Dependabot PRs**: CI used Node 22's bundled npm 10.9.7, which strictly requires nested `chokidar@4.0.3` / `readdirp@4.1.2` lockfile entries that `@angular-devkit/*` packages declare as optional peers. Dependabot regenerates `package-lock.json` with a newer npm that prunes those entries, producing lockfiles npm 10.9.7's `npm ci` rejected with `EUSAGE`. Pinned npm 11 in the `frontend` CI job so the install resolution matches what Dependabot produces. Affects PRs #248, #250, #256, #261, #262.
+
 ### Changed
 - **Scanner types renamed from `Rdm*` to generic `Scanner*`** ([#232](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/232)): the scanner DB context and entities were named `RdmScannerContext` / `Rdm{Gym,Pokestop,Station,Weather}Entity` / `RdmScannerService`, but the schema is backend-agnostic. Renamed to `ScannerDbContext` / `Scanner*Entity` / `ScannerService` and updated example connection strings and prose to reference **Golbat** (the currently supported scanner backend). No behavior change; `IScannerService` interface unchanged; no migrations or `[Table]` mappings affected. Impacts only consumers that reference the implementation types directly — standard DI registration uses the `IScannerService` interface and is unaffected.
 - `IScannerService.PointInPolygon` (static) and `ScannerService.EscapeLikePattern` (static) were moved to dedicated `GeometryHelpers` and `LikeEscape` utility classes in `Core.Services`. The interface no longer carries unrelated geometry helpers; the LIKE-escape helper is reusable by any future repository that needs dialect-safe wildcard escaping.


### PR DESCRIPTION
## Summary

Fixes CI failures on 5 open Dependabot frontend PRs (#248, #250, #256, #261, #262).

## Root cause

- CI workflow uses `node-version: '22'` → bundled **npm 10.9.7**.
- `@angular-devkit/architect` and 3 sibling packages declare `chokidar` as an *optional peer* (`^4.0.0`). When the lockfile is generated, nested entries are written for `chokidar@4.0.3` and `readdirp@4.1.2` under those packages.
- Dependabot regenerates `package-lock.json` with a newer npm (11.x) that prunes those nested optional-peer entries.
- npm 10.9.7's `npm ci` strictly requires the entries to be present, fails with `EUSAGE: Missing: chokidar@4.0.3 from lock file`.

Reproduction: `npm ci` against any of the 5 PR head SHAs with npm 10.9.7 fails; the same checkout with npm 11.x succeeds.

## Fix

Add a `Pin npm 11` step in the `frontend` job that runs `npm install -g npm@11` between `setup-node` and `npm ci`. This aligns CI's install resolution with Dependabot's so lockfiles produced by Dependabot are accepted.

## Follow-up after merge

- Comment `@dependabot rebase` on PRs #248, #250, #256, #261, #262 to re-run their CI on top of the fix.
- Backend PR #266 (EF Core) is failing for an unrelated reason (NU1605 downgrade conflict) — separately resolvable by merging #268/#269 first then rebasing #266.

## Test plan

- [ ] CI on this PR passes Frontend (Angular) job
- [ ] After merge: comment `@dependabot rebase` on #248 and confirm Frontend (Angular) goes green
- [ ] Repeat for #250, #256, #261, #262