### PR TITLE
ci: fix unquoted colon in auto-merge-deps workflow body

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -53,7 +53,7 @@ jobs:
             steps.meta.outputs.update-type == 'version-update:semver-patch' ||
             steps.meta.outputs.dependency-group != ''
           )
-        run: gh pr review --approve "$PR_URL" --body "Auto-approved: low-risk bump, gated on CI."
+        run: gh pr review --approve "$PR_URL" --body 'Auto-approved low-risk bump, gated on CI.'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #275. After that PR landed, `auto-merge-deps.yml` *still* never fires on `pull_request_target` events — confirmed by reopening #272 and watching only the four sibling workflows fire (Auto-label PRs, CI, Update Changelog, Build PR Preview Image). The auto-merge workflow never showed up.

## Root cause

The approval `run:` command body string contains an unquoted colon:

```yaml
run: gh pr review --approve "$PR_URL" --body "Auto-approved: low-risk bump, gated on CI."
```

The colon inside `Auto-approved:` sits in an unquoted YAML scalar. PyYAML rejects this with `mapping values are not allowed here` at line 56, column 68. GitHub Actions' parser is more lenient — it accepts the file enough to fire push-event runs — but it silently fails to register the `pull_request_target` trigger and never resolves the friendly `name:` field (the API has been reporting the workflow's name as `.github/workflows/auto-merge-deps.yml`, the path, instead of `Dependabot auto-merge`).

Sibling `pr-labeler.yml` has no colons in unquoted scalars and works correctly — that's what made the side-by-side suspicious.

## Fix

Drop the colon from the body message. Nesting YAML quotes around the whole `run:` line would also work but is brittle.

## Test plan

- [ ] After merge: close+reopen a Dependabot PR and confirm a `pull_request_target` run appears in `gh run list --workflow auto-merge-deps.yml`
- [ ] Confirm `gh api repos/.../actions/workflows` now reports `name: "Dependabot auto-merge"` (not the path)
- [ ] Confirm a grouped/patch Dependabot PR gets auto-approved without manual intervention
