### PR TITLE
chore: ignore Playwright MCP artifacts at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ avatar-cache.json
 *.http
 *.mjs
 screenshot-*.png
+# Playwright MCP server output + loose screenshots at the repo root
+# (tracked PNGs all live under ClientApp/public/assets, so this is root-only)
+.playwright-mcp/
+/*.png
 Applications/Pgan.PoracleWebNet.Api/cookies.txt
 beta-discord-messages.txt
 


### PR DESCRIPTION
## Summary

Loose `.png` screenshots from Playwright MCP runs (`login.png`, `raid-add-dialog-420.png`, `rsvp-desktop*.png`, `rsvp-zoom.png`) and the `.playwright-mcp/` output directory kept showing up as untracked at the repo root, polluting `git status` between sessions.

## Fix

Add two patterns to `.gitignore`:

- `.playwright-mcp/` — Playwright MCP's persistent output directory
- `/*.png` — root-only, so it catches scattered screenshots without touching the tracked PNGs under `Applications/Pgan.PoracleWebNet.App/ClientApp/public/assets/help/` and elsewhere

Verified no tracked PNGs exist at the repo root (`git ls-files "*.png" | awk -F/ 'NF==1'` is empty), so the `/*.png` rule is safe.

## Test plan

- [ ] After merge: `git status` from a fresh checkout stays clean even with Playwright artifacts present
- [ ] Tracked PNGs under `ClientApp/public/assets/` are unaffected (they're not at the repo root)
