### PR TITLE
fix(quick-picks): correct stale distanceKm default-value test (fixes red main CI)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.spec.ts
@@ -79,7 +79,10 @@ describe('QuickPickApplyDialogComponent', () => {
     it('should have a delivery form with default values', () => {
       const form = component.deliveryForm.getRawValue();
       expect(form.clean).toBe(false);
-      expect(form.distanceKm).toBe(0);
+      // Since #301, distanceKm is pre-seeded from AlertDefaultsService.defaultDistanceKm() (default 1 km),
+      // matching every add-dialog, so the radius is ready if the user switches to Distance mode. In Areas
+      // mode it is irrelevant — apply() sends 0 m for 'areas' regardless of this value.
+      expect(form.distanceKm).toBe(1);
       expect(form.distanceMode).toBe('areas');
       expect(form.template).toBe('');
     });


### PR DESCRIPTION
The Frontend (Angular) CI has been **red on `main`** since #301 merged (commit `275110c`). #301 changed the quick-pick apply dialog — and every add-dialog — to seed the delivery form's `distanceKm` from `AlertDefaultsService.defaultDistanceKm()` (default **1 km**) so the radius is pre-filled when a user switches to Distance mode. The `quick-pick-apply-dialog` spec still asserted the **pre-#301** default of `0`, so it failed.

The component is correct and consistent with all sibling add-dialogs (pokemon/raid/lure seed `distanceKm` identically; in Areas mode `apply()` sends `0 m` regardless). Only the assertion was stale — updated to expect `1` with an explanatory comment.

**Verified:** full Jest suite green (**792/792**), prettier + eslint clean. This unblocks the red `main` CI (and every open PR that inherits it).