### PR TITLE
style(editorconfig): preserve single-line statements (stop dotnet format exploding compact mappings)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -311,7 +311,7 @@ csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
 # Wrap options
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
-csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = false
 
 ##########################################


### PR DESCRIPTION
### The issue
Running `dotnet format` flags ~98 whitespace "errors" in `AlarmMappingExtensions.cs` and wants to **explode** its compact null-skip one-liners:

```csharp
// current (deliberate, readable column of guards)
if (src.MinIv != null) dest.MinIv = src.MinIv.Value;
// dotnet format wants:
if (src.MinIv != null)
    dest.MinIv = src.MinIv.Value;
```

Applying that turns the file from ~98 mapping lines into ~480 (+480/−98) — a real readability regression. The single-line style is used throughout the mapping/guard code; CI does **not** run `dotnet format`, so this never surfaced.

### Root cause
`.editorconfig` sets `csharp_preserve_single_line_statements = false`, which contradicts the codebase's actual style.

### Fix
Flip it to `true`. `dotnet format` then **preserves** existing single-line statements (it never collapses multi-line → single-line, so this only *reduces* what the tool wants to change). Result: `dotnet format --verify` is clean on `AlarmMappingExtensions.cs` (and the rest of the compact mapping code) with **zero code changes**.

Verified: `dotnet format --verify-no-changes` → 0 whitespace errors on the file after the change. No code touched.

> This is a formatting-policy alignment, not a code change — surfaced while running `dotnet format` during review. Merge at your discretion; the alternative (exploding the code) is strictly worse.