### PR TITLE
fix(admin-settings): remove duplicate allowed_languages setting row (#308)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -230,12 +230,6 @@ const SETTING_GROUPS: SettingGroup[] = [
         showWhen: 'enable_roles',
         type: 'text',
       },
-      {
-        descriptionKey: 'ADMIN_SETTINGS.ADMIN_ALLOWED_LANGUAGES_DESC',
-        key: 'allowed_languages',
-        labelKey: 'ADMIN_SETTINGS.ADMIN_ALLOWED_LANGUAGES_LABEL',
-        type: 'text',
-      },
     ],
   },
   {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Tillad kun brugere med specifikke Discord-roller at logge ind. Kræver Bot-token og Guild-ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Tilladte rolle-ID'er",
     "ALLOWED_ROLE_IDS_DESC": "Kommaseparerede Discord-rolle-ID'er, der giver adgang (f.eks. \"123456789,987654321\"). Lad stå tomt for at tillade alle.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Tilladte sprog",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Kommasepareret liste over sprogkoder, som brugere kan vælge (f.eks. \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Registreringskommando",
     "REGISTER_COMMAND_DESC": "Poracle-bot-kommando, som brugere kører for at registrere sig (f.eks. \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Placeringskommando",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Nur Benutzer mit bestimmten Discord-Rollen dürfen sich anmelden. Erfordert Bot-Token und Guild-ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Zulässige Rollen-IDs",
     "ALLOWED_ROLE_IDS_DESC": "Kommagetrennte Discord-Rollen-IDs, die Zugriff gewähren (z. B. „123456789,987654321“). Leer lassen, um alle zuzulassen.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Erlaubte Sprachen",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Kommagetrennte Liste der Sprachcodes, die Benutzer auswählen können (z. B. „en,de,fr“).",
     "REGISTER_COMMAND_LABEL": "Registrierungsbefehl",
     "REGISTER_COMMAND_DESC": "Poracle-Bot-Befehl, den Benutzer zur Registrierung ausführen (z. B. „$!register“).",
     "LOCATION_COMMAND_LABEL": "Standortbefehl",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1528,8 +1528,6 @@
     "ENABLE_ROLES_DESC": "Only allow users with specific Discord roles to log in. Requires Bot Token and Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Allowed Role IDs",
     "ALLOWED_ROLE_IDS_DESC": "Comma-separated Discord role IDs that grant access (e.g. \"123456789,987654321\"). Leave empty to allow all.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Allowed Languages",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Comma-separated list of language codes users can select (e.g. \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Register Command",
     "REGISTER_COMMAND_DESC": "The Poracle bot command users run to register (e.g. \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Location Command",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Permitir iniciar sesión solo a usuarios con roles de Discord específicos. Requiere Bot Token y Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "IDs de roles permitidos",
     "ALLOWED_ROLE_IDS_DESC": "IDs de roles de Discord separados por comas que conceden acceso (ej. «123456789,987654321»). Deja en blanco para permitir todos.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Idiomas permitidos",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Lista de códigos de idioma separados por comas que los usuarios pueden seleccionar (ej. «en,de,fr»).",
     "REGISTER_COMMAND_LABEL": "Comando de registro",
     "REGISTER_COMMAND_DESC": "Comando del bot Poracle que los usuarios ejecutan para registrarse (ej. «$!register»).",
     "LOCATION_COMMAND_LABEL": "Comando de ubicación",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Autoriser uniquement les utilisateurs avec des rôles Discord spécifiques à se connecter. Nécessite un Bot Token et un Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "IDs de rôles autorisés",
     "ALLOWED_ROLE_IDS_DESC": "IDs de rôles Discord séparés par des virgules qui accordent l'accès (ex. « 123456789,987654321 »). Laissez vide pour autoriser tous.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Langues autorisées",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Liste de codes de langue séparés par des virgules que les utilisateurs peuvent sélectionner (ex. « en,de,fr »).",
     "REGISTER_COMMAND_LABEL": "Commande d'enregistrement",
     "REGISTER_COMMAND_DESC": "Commande du bot Poracle que les utilisateurs exécutent pour s'enregistrer (ex. « $!register »).",
     "LOCATION_COMMAND_LABEL": "Commande de localisation",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Consenti l'accesso solo agli utenti con specifici ruoli Discord. Richiede Bot Token e Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "ID ruoli consentiti",
     "ALLOWED_ROLE_IDS_DESC": "ID ruoli Discord separati da virgole che concedono l'accesso (es. \"123456789,987654321\"). Lascia vuoto per consentirli tutti.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Lingue consentite",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Elenco separato da virgole di codici lingua selezionabili dagli utenti (es. \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Comando di registrazione",
     "REGISTER_COMMAND_DESC": "Comando del bot Poracle che gli utenti eseguono per registrarsi (es. \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Comando di posizione",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Laat alleen gebruikers met specifieke Discord-rollen inloggen. Vereist Bot Token en Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Toegestane rol-ID's",
     "ALLOWED_ROLE_IDS_DESC": "Door komma's gescheiden Discord-rol-ID's die toegang verlenen (bijv. \"123456789,987654321\"). Laat leeg om alle toe te staan.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Toegestane talen",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Door komma's gescheiden lijst met taalcodes die gebruikers kunnen selecteren (bijv. \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Registratiecommando",
     "REGISTER_COMMAND_DESC": "Poracle-bot-commando dat gebruikers uitvoeren om zich te registreren (bijv. \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Locatiecommando",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Zezwalaj na logowanie tylko użytkownikom z określonymi rolami Discord. Wymaga Bot Token i Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Dozwolone ID ról",
     "ALLOWED_ROLE_IDS_DESC": "ID ról Discord oddzielone przecinkami przyznające dostęp (np. „123456789,987654321”). Pozostaw puste, aby zezwolić wszystkim.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Dozwolone języki",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Lista oddzielonych przecinkami kodów języków, które użytkownicy mogą wybierać (np. „en,de,fr”).",
     "REGISTER_COMMAND_LABEL": "Komenda rejestracji",
     "REGISTER_COMMAND_DESC": "Komenda bota Poracle uruchamiana przez użytkowników w celu rejestracji (np. „$!register”).",
     "LOCATION_COMMAND_LABEL": "Komenda lokalizacji",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Permitir apenas o login de usuários com funções Discord específicas. Requer Bot Token e Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "IDs de funções permitidas",
     "ALLOWED_ROLE_IDS_DESC": "IDs de funções Discord separados por vírgulas que concedem acesso (ex.: \"123456789,987654321\"). Deixe em branco para permitir todos.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Idiomas permitidos",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Lista separada por vírgulas de códigos de idioma que os usuários podem selecionar (ex.: \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Comando de registro",
     "REGISTER_COMMAND_DESC": "Comando do bot Poracle que os usuários executam para se registrarem (ex.: \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Comando de localização",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Permitir apenas o login de utilizadores com funções Discord específicas. Requer Bot Token e Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "IDs de funções permitidas",
     "ALLOWED_ROLE_IDS_DESC": "IDs de funções Discord separados por vírgulas que concedem acesso (ex.: \"123456789,987654321\"). Deixe em branco para permitir todos.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Idiomas permitidos",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Lista separada por vírgulas de códigos de idioma que os utilizadores podem selecionar (ex.: \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Comando de registo",
     "REGISTER_COMMAND_DESC": "Comando do bot Poracle que os utilizadores executam para se registarem (ex.: \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Comando de localização",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -1530,8 +1530,6 @@
     "ENABLE_ROLES_DESC": "Tillåt endast användare med specifika Discord-roller att logga in. Kräver Bot Token och Guild ID.",
     "ALLOWED_ROLE_IDS_LABEL": "Tillåtna roll-ID:n",
     "ALLOWED_ROLE_IDS_DESC": "Kommaseparerade Discord-roll-ID:n som ger åtkomst (t.ex. \"123456789,987654321\"). Lämna tomt för att tillåta alla.",
-    "ADMIN_ALLOWED_LANGUAGES_LABEL": "Tillåtna språk",
-    "ADMIN_ALLOWED_LANGUAGES_DESC": "Kommaseparerad lista över språkkoder som användare kan välja (t.ex. \"en,de,fr\").",
     "REGISTER_COMMAND_LABEL": "Registreringskommando",
     "REGISTER_COMMAND_DESC": "Poracle-bot-kommando som användare kör för att registrera sig (t.ex. \"$!register\").",
     "LOCATION_COMMAND_LABEL": "Platskommando",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Duplicate `allowed_languages` admin setting** ([#308](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/308)): the admin settings page rendered two separate rows that both wrote to the same `allowed_languages` key — "Allowed UI Languages" in the Features group and "Allowed Languages" in the Administration group. Because `admin-settings.component.ts` keys its value map by the setting `key`, the two rows collapsed onto a single entry: editing one visibly changed the other, and on save one could silently clobber the other with an empty value. Removed the redundant Administration-group row (and its now-unused `ADMIN_SETTINGS.ADMIN_ALLOWED_LANGUAGES_LABEL` / `ADMIN_ALLOWED_LANGUAGES_DESC` keys across all 11 locales), keeping the single Features-group "Allowed UI Languages" control whose description matches the actual behavior (filtering the UI language selector).
+
 ## [2.9.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
Closes #308.

## Problem
The admin settings page rendered **two different rows that both wrote to `key: 'allowed_languages'`**:

- **Features** group → "Allowed UI Languages" (`ALLOWED_LANGUAGES_LABEL`)
- **Administration** group → "Allowed Languages" (`ADMIN_ALLOWED_LANGUAGES_LABEL`)

`admin-settings.component.ts` keys its value map by the setting `key` (`settingMap` / `settingKey(s)`), so the two rows collapsed onto a single entry. Editing one visibly changed the other (as reported on Discord), and on save one could silently clobber the value with an empty string. This also contributed to the separate "I set `de,en` but the UI selector still shows all languages" confusion.

## Fix
- Removed the redundant **Administration**-group row.
- Deleted the now-unused `ADMIN_SETTINGS.ADMIN_ALLOWED_LANGUAGES_LABEL` / `ADMIN_ALLOWED_LANGUAGES_DESC` keys across all **11** locale files.
- Kept the single Features-group **"Allowed UI Languages"** control, whose description matches the actual behavior (filtering the UI language selector in `i18n.service.ts`).

## Validation
- No remaining `ADMIN_ALLOWED_LANGUAGES` references in `Applications/` or `Core/`.
- All 11 locale files re-validated as parseable JSON.
- Prettier check + ESLint pass on the changed files.

Diff is pure deletions (28 lines) plus a CHANGELOG entry.

## Notes
Companion issues from the same Discord report (filed separately, not in this PR): #309 (backslash URL in `location.service.setLanguage`) and #310 (notification-language selector not rendered).