### PR TITLE
ci(changelog): auto-merge the release changelog cut via a GitHub App token

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -34,9 +34,29 @@ jobs:
             sed -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/${{ github.repository }}/compare/v$VERSION...HEAD\n[$VERSION]: https://github.com/${{ github.repository }}/compare/v$PREV_VERSION...v$VERSION|" CHANGELOG.md
           fi
 
+      # Flags whether the auto-merge PAT is configured. Secrets can't be read in `if:`
+      # conditions directly, so surface it as a step output the later steps can gate on.
+      - name: Detect auto-merge token
+        id: token
+        env:
+          CHANGELOG_PAT: ${{ secrets.CHANGELOG_PAT }}
+        run: |
+          if [ -n "$CHANGELOG_PAT" ]; then
+            echo "has_pat=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pat=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CHANGELOG_PAT secret not set — opening the changelog PR with GITHUB_TOKEN, which does not trigger the required CI checks. The PR will need a manual (admin) merge. See the workflow header for setup."
+          fi
+
       - name: Open PR with changelog update
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          # A PAT makes the PR author a real user, so the push/PR events trigger the required
+          # status checks (Backend/Frontend/Changelog). GITHUB_TOKEN-authored PRs do NOT trigger
+          # workflows (GitHub's recursion guard), which leaves required checks permanently pending
+          # and the PR blocked. Falls back to GITHUB_TOKEN (manual-merge) when the PAT is absent.
+          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
           commit-message: "docs: cut changelog for ${{ github.event.release.tag_name }}"
           title: "docs: cut changelog for ${{ github.event.release.tag_name }}"
           body: |
@@ -49,3 +69,23 @@ jobs:
           base: main
           labels: docs,automated
           delete-branch: true
+
+      # Approve from the github-actions[bot] identity. The PR was authored by the PAT user, so
+      # this is a distinct identity and satisfies the "1 approval" branch-protection rule.
+      - name: Approve the changelog PR
+        if: steps.token.outputs.has_pat == 'true' && steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr review "$PR" --approve \
+            --body "Automated changelog cut — approving the mechanical [Unreleased] → version promotion. Source entries were already reviewed on their own PRs."
+
+      # Squash-merge once the required checks pass (they run because the PR is PAT-authored).
+      - name: Enable auto-merge
+        if: steps.token.outputs.has_pat == 'true' && steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_PAT }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR" --squash --auto --delete-branch

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -34,29 +34,40 @@ jobs:
             sed -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/${{ github.repository }}/compare/v$VERSION...HEAD\n[$VERSION]: https://github.com/${{ github.repository }}/compare/v$PREV_VERSION...v$VERSION|" CHANGELOG.md
           fi
 
-      # Flags whether the auto-merge PAT is configured. Secrets can't be read in `if:`
-      # conditions directly, so surface it as a step output the later steps can gate on.
-      - name: Detect auto-merge token
-        id: token
+      # Flags whether the GitHub App is configured. Secrets can't be read in `if:` conditions
+      # directly, so surface it as a step output the later steps can gate on.
+      - name: Detect app config
+        id: cfg
         env:
-          CHANGELOG_PAT: ${{ secrets.CHANGELOG_PAT }}
+          APP_ID: ${{ secrets.CHANGELOG_APP_ID }}
         run: |
-          if [ -n "$CHANGELOG_PAT" ]; then
-            echo "has_pat=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$APP_ID" ]; then
+            echo "has_app=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_pat=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::CHANGELOG_PAT secret not set — opening the changelog PR with GITHUB_TOKEN, which does not trigger the required CI checks. The PR will need a manual (admin) merge. See the workflow header for setup."
+            echo "has_app=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CHANGELOG_APP_ID/CHANGELOG_APP_PRIVATE_KEY not set — opening the changelog PR with GITHUB_TOKEN, which does not trigger the required CI checks. The PR will need a manual (admin) merge. See the workflow header for setup."
           fi
+
+      # An App installation token makes the PR author the app bot, so push/PR events trigger the
+      # required status checks (Backend/Frontend/Changelog). GITHUB_TOKEN-authored PRs do NOT
+      # trigger workflows (GitHub's recursion guard), which leaves required checks permanently
+      # pending and the PR blocked. App tokens are short-lived and auto-minted per run — no PAT
+      # rotation. Requires a GitHub App (Contents: write, Pull requests: write) installed on this
+      # repo, with its App ID and a private key stored as the secrets below.
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.cfg.outputs.has_app == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
 
       - name: Open PR with changelog update
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          # A PAT makes the PR author a real user, so the push/PR events trigger the required
-          # status checks (Backend/Frontend/Changelog). GITHUB_TOKEN-authored PRs do NOT trigger
-          # workflows (GitHub's recursion guard), which leaves required checks permanently pending
-          # and the PR blocked. Falls back to GITHUB_TOKEN (manual-merge) when the PAT is absent.
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # App token when configured; otherwise GITHUB_TOKEN (PR opens but needs a manual merge).
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           commit-message: "docs: cut changelog for ${{ github.event.release.tag_name }}"
           title: "docs: cut changelog for ${{ github.event.release.tag_name }}"
           body: |
@@ -70,10 +81,10 @@ jobs:
           labels: docs,automated
           delete-branch: true
 
-      # Approve from the github-actions[bot] identity. The PR was authored by the PAT user, so
-      # this is a distinct identity and satisfies the "1 approval" branch-protection rule.
+      # Approve from the github-actions[bot] identity. The PR was authored by the app bot, so this
+      # is a distinct identity and satisfies the "1 approval" branch-protection rule.
       - name: Approve the changelog PR
-        if: steps.token.outputs.has_pat == 'true' && steps.cpr.outputs.pull-request-number
+        if: steps.cfg.outputs.has_app == 'true' && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
@@ -81,11 +92,11 @@ jobs:
           gh pr review "$PR" --approve \
             --body "Automated changelog cut — approving the mechanical [Unreleased] → version promotion. Source entries were already reviewed on their own PRs."
 
-      # Squash-merge once the required checks pass (they run because the PR is PAT-authored).
+      # Squash-merge once the required checks pass (they run because the PR is app-authored).
       - name: Enable auto-merge
-        if: steps.token.outputs.has_pat == 'true' && steps.cpr.outputs.pull-request-number
+        if: steps.cfg.outputs.has_app == 'true' && steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.CHANGELOG_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           gh pr merge "$PR" --squash --auto --delete-branch


### PR DESCRIPTION
## Problem

Every automated **changelog-cut PR** (opened by `release-changelog.yml` after a release is published) gets stuck `BLOCKED` and needs a manual admin merge — e.g. v2.11.0's #321.

Root cause: the PR is created with `GITHUB_TOKEN`. GitHub's recursion guard means **events from `GITHUB_TOKEN` don't trigger workflows**, so the three required status checks (`Backend (.NET)`, `Frontend (Angular)`, `Changelog entry present`) never run → never report → the PR can't satisfy branch protection. It also can't self-approve the required review.

## Fix — GitHub App token

1. Mint a short-lived **GitHub App installation token** at runtime via `actions/create-github-app-token`, and **open the PR with it**. A real (non-`GITHUB_TOKEN`) author makes the push/PR events trigger the required checks, which then pass (docs-only change; the changelog check is exempt via the `docs:` title).
2. **Auto-approve** from the `github-actions[bot]` identity — distinct from the app-bot author, so it satisfies the "1 approval" rule.
3. **Enable squash auto-merge** — merges as soon as the now-running checks go green.

Why an App over a PAT: the token is minted per run and short-lived, so **there's nothing to rotate**, and its permissions are scoped to exactly Contents + Pull requests on this repo.

### Graceful fallback
If the app secrets aren't set, the PR is still opened with `GITHUB_TOKEN` (today's behavior), a warning is logged, and the approve/merge steps are skipped — so nothing breaks before setup; it just still needs a manual merge.

## ⚠️ Required manual setup (one-time)

A repo/org admin must create and install a GitHub App, then store its credentials as Actions secrets:

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New). It does not need a webhook (uncheck Active). Repository permissions:
   - **Contents: Read and write**
   - **Pull requests: Read and write**
2. **Generate a private key** for the app (downloads a `.pem`).
3. **Install the app** on `PGAN-Dev/PoracleWeb.NET` (App → Install App → select the repo).
4. Add two Actions secrets on the repo (Settings → Secrets and variables → Actions):
   - **`CHANGELOG_APP_ID`** — the app's numeric App ID
   - **`CHANGELOG_APP_PRIVATE_KEY`** — the full contents of the `.pem` private key

"Allow auto-merge" is already enabled on the repo, so no other settings change is needed.

> The app bot (e.g. `your-app[bot]`) will appear as the author of changelog-cut PRs.

Workflow-only change; YAML validated.
