### PR TITLE
fix: surface base/regional-default Pokémon forms in the form picker (#323)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
@@ -123,5 +123,43 @@ describe('MasterDataService', () => {
     it('should return empty array for pokemon with no forms', () => {
       expect(service.getFormsForPokemon(1)).toEqual([]);
     });
+
+    it('should keep the base "Normal" form when a regional variant exists', () => {
+      service.loadData().subscribe();
+
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '618': 'Stunfisk' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock
+        .expectOne(req => req.url.includes('master-latest-poracle'))
+        .flush({
+          monsters: {
+            '618_0': { id: 618, name: 'Stunfisk', form: { id: 0, name: '' } },
+            '618_2246': { id: 618, name: 'Stunfisk', form: { id: 2246, name: 'Normal' } },
+            '618_2345': { id: 618, name: 'Stunfisk', form: { id: 2345, name: 'Galarian' } },
+          },
+        });
+
+      expect(service.getFormsForPokemon(618)).toEqual([
+        { id: 2345, name: 'Galarian' },
+        { id: 2246, name: 'Normal' },
+      ]);
+    });
+
+    it('should drop a lone "Normal" form covered by "All Forms"', () => {
+      service.loadData().subscribe();
+
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '1': 'Bulbasaur' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock
+        .expectOne(req => req.url.includes('master-latest-poracle'))
+        .flush({
+          monsters: {
+            '1_0': { id: 1, name: 'Bulbasaur', form: { id: 0, name: '' } },
+            '1_123': { id: 1, name: 'Bulbasaur', form: { id: 123, name: 'Normal' } },
+          },
+        });
+
+      expect(service.getFormsForPokemon(1)).toEqual([]);
+    });
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
@@ -159,7 +159,10 @@ export class MasterDataService {
 
         const grouped = new Map<number, { id: number; name: string }[]>();
         for (const entry of Object.values(monsters)) {
-          if (!entry.form || entry.form.id === 0 || entry.form.name === 'Normal') continue;
+          // Skip only the synthetic id-0 "any" pseudo-form. Real forms (including the
+          // base "Normal"/regional-default form, e.g. Unova Stunfisk) are kept so they
+          // can be tracked distinctly from regional variants like Galarian.
+          if (!entry.form || entry.form.id === 0) continue;
           const pokemonId = entry.id;
           if (!grouped.has(pokemonId)) {
             grouped.set(pokemonId, []);
@@ -168,6 +171,16 @@ export class MasterDataService {
           // Avoid duplicates
           if (!forms.some(f => f.id === entry.form!.id)) {
             forms.push({ id: entry.form.id, name: entry.form.name });
+          }
+        }
+
+        // Drop a lone "Normal" form: when a species' only real form is its base/regional
+        // default, the synthetic "All Forms" option already covers it, so listing it adds
+        // noise. Keep "Normal" only when sibling variants (Galarian, Alolan, etc.) exist
+        // so users can target the base form on its own.
+        for (const [pokemonId, forms] of grouped) {
+          if (forms.length === 1 && forms[0].name === 'Normal') {
+            grouped.delete(pokemonId);
           }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Base/regional-default Pokémon forms (e.g. Unova Stunfisk) were missing from the form picker** ([#323](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/323)): the *Form & Gender* form picker in the Pokémon add/edit dialogs is built from the WatWowMap masterfile in `MasterDataService.loadForms()`, which discarded every form named `Normal` (alongside the synthetic id-0 "any" pseudo-form). For most Pokémon that's harmless, but for a species with a regional variant the `Normal` entry **is** the original/base form (Stunfisk lists `Normal` id `2246` for Unova and `Galarian` id `2345`), so dropping it left only "All Forms" and "Galarian" — there was no way to alert on Unova Stunfisk alone (e.g. for PVP) without also catching Galarian. The loader now keeps all real forms (`form.id !== 0`, including `Normal`) and only drops a `Normal` form when it's a species' **lone** form — where the existing "All Forms" option already covers it — so base regional forms become selectable when a sibling variant exists, while species with just a base form stay uncluttered. Combined with the multi-select picker (#318), users can now target the base form, a regional variant, or both. Unit tests cover the keep-when-sibling and drop-when-lone cases.
+
 ## [2.11.0] - 2026-06-05
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes #323 — base/regional-default Pokémon forms (e.g. **Unova Stunfisk**) were missing from the *Form & Gender* picker in the Pokémon add/edit dialogs.

The picker is built from the WatWowMap masterfile in `MasterDataService.loadForms()`, which discarded every form named `Normal` (alongside the synthetic id-0 "any" pseudo-form). For most Pokémon that's harmless, but for a species with a regional variant the `Normal` entry **is** the original/base form. Stunfisk lists `Normal` id `2246` (Unova) and `Galarian` id `2345`, so dropping `Normal` left only "All Forms" and "Galarian" — there was no way to alert on Unova Stunfisk alone (e.g. for PVP) without also catching Galarian.

## Change

- The loader now keeps all real forms (`form.id !== 0`, including `Normal`).
- It drops a `Normal` form **only when it's a species' lone form** — where the existing "All Forms" option already covers it — so single-form species stay uncluttered.
- Result: base regional forms become selectable when a sibling variant exists. Combined with the multi-select picker (#318), users can target the base form, a regional variant, or both.

Frontend-only; no backend, mapping, DB, or PoracleNG change.

## Tests

`masterdata.service.spec.ts` gains two cases:
- keep `Normal` when a regional sibling exists (Stunfisk → `Normal` + `Galarian`)
- drop a lone `Normal` form (covered by "All Forms")

All 14 `MasterDataService` tests pass; prettier clean.
