### PR TITLE
ci(docs): redeploy docs on release publish + manual dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+  # Rebuild when a release is published so the mkdocs-material version badge
+  # (fetched at build time from the GitHub Releases API) stays current even
+  # when a release touches only code/CHANGELOG and not docs/.
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

The mkdocs-material header version badge on the gh-pages site shows **v2.10.0** despite v2.11.1 being the latest release.

The badge is fetched from the GitHub Releases API **at `mkdocs gh-deploy` time** and baked into the static HTML — it is not live. `docs.yml` only triggered on `docs/**` or `mkdocs.yml` changes, so the code/CHANGELOG-only releases v2.11.0 and v2.11.1 never rebuilt the site. The last docs deploy ran at 17:57 on 2026-06-05, before both v2.11.x releases were published.

## Fix

Add two triggers to `docs.yml`:
- `release: { types: [published] }` — refresh docs + badge on every future release
- `workflow_dispatch` — allow on-demand rebuilds

After merge, the Deploy docs workflow will run on `main` and refresh the badge to the current latest release.