### PR TITLE
chore(config): use generic placeholder URLs in the OIDC example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,15 +78,16 @@ TELEGRAM_ENABLED=false
 # ═══════════════════════════════════════════════════════════════════════════════
 # EXTERNAL SSO / OIDC (optional — delegate login to your own OAuth2/OIDC provider)
 # ═══════════════════════════════════════════════════════════════════════════════
-# Point PoracleWeb at any OAuth2/OIDC provider (e.g. PogoAlerts) for single sign-on.
+# Point PoracleWeb at any OAuth2/OIDC provider (Keycloak, Authentik, Auth0, Okta, …) for SSO.
 # The provider's userinfo endpoint must return a claim holding the user's Poracle id
 # (a Discord/Telegram id) — set OIDC_IDENTITY_CLAIM to that claim name.
 # Enabled is auto-inferred when ClientId + the three URLs are all set; set explicitly to override.
+# Replace the example URLs below with your provider's actual endpoints.
 # OIDC_ENABLED=true
-# OIDC_PROVIDER_NAME=PogoAlerts
-# OIDC_AUTHORIZATION_URL=https://pogoalerts.net/login
-# OIDC_TOKEN_URL=https://pogoalerts.net/api/oauth/token
-# OIDC_USERINFO_URL=https://pogoalerts.net/api/oauth/userinfo
+# OIDC_PROVIDER_NAME=My SSO
+# OIDC_AUTHORIZATION_URL=https://sso.example.com/authorize
+# OIDC_TOKEN_URL=https://sso.example.com/oauth/token
+# OIDC_USERINFO_URL=https://sso.example.com/oauth/userinfo
 # OIDC_CLIENT_ID=your_oidc_client_id
 # OIDC_CLIENT_SECRET=your_oidc_client_secret
 # OIDC_SCOPES=openid profile email


### PR DESCRIPTION
## Summary

The `EXTERNAL SSO / OIDC` sample in `.env.example` hardcoded PGAN's **pogoalerts.net** endpoints as the example provider. PoracleWeb's OIDC login is **fully provider-agnostic** and the project is open source, so the example shouldn't be branded to one specific deployment.

## Changes (`.env.example` only)

- Example provider name `PogoAlerts` → `My SSO`.
- Example URLs `https://pogoalerts.net/...` → neutral placeholders `https://sso.example.com/authorize` · `/oauth/token` · `/oauth/userinfo`.
- Generalized the intro to name common providers (Keycloak, Authentik, Auth0, Okta) and added a note to substitute your provider's real endpoints.
- The per-provider **reference matrix** (token-auth method / offline scope / identity claim) is unchanged — it carries no URLs and documents real providers (including PogoAlerts as the reference implementation).

No code, behavior, or default changes — comments-only edit to the example env file.