### PR TITLE
ci: batch dependency bumps into the release changelog cut

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,7 +34,13 @@ jobs:
           set -euo pipefail
 
           # 1) Exempt non-user-facing PR types (mirrors the previous skip set).
-          if printf '%s' "$TITLE" | grep -qiE '^(docs|style|chore|ci|test|build)(\(.*\))?[!]?:'; then
+          #
+          # `deps:` is exempt here but is NOT undocumented: release-changelog.yml batches every
+          # merged `deps:` PR since the previous tag into a "### Dependencies" section when it
+          # cuts the release. Requiring a per-PR entry instead would mean a bot committing to
+          # each Dependabot branch, which makes concurrent Dependabot PRs conflict on CHANGELOG.md
+          # and makes Dependabot stop rebasing them (it abandons PRs modified by others).
+          if printf '%s' "$TITLE" | grep -qiE '^(deps|docs|style|chore|ci|test|build)(\(.*\))?[!]?:'; then
             echo "Exempt PR type — skipping changelog check."
             echo "  title: $TITLE"
             exit 0

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -34,6 +34,70 @@ jobs:
             sed -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/${{ github.repository }}/compare/v$VERSION...HEAD\n[$VERSION]: https://github.com/${{ github.repository }}/compare/v$PREV_VERSION...v$VERSION|" CHANGELOG.md
           fi
 
+      # Collect dependency bumps into the freshly-cut version section.
+      #
+      # Dependabot PRs are exempt from the per-PR changelog check (see changelog.yml) so they can
+      # be batched here instead. The alternative — a bot committing an entry onto each Dependabot
+      # branch — makes concurrent Dependabot PRs conflict on the same lines of CHANGELOG.md, and
+      # Dependabot stops rebasing any PR another actor has modified.
+      - name: Add Dependencies section for merged deps PRs
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+
+          # Range: previous tag (exclusive) through this release's tag. `git describe` walks back
+          # from the tag's parent to the preceding tag; with no preceding tag (first release) the
+          # range degrades to the whole history, which is what we want.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then END="$TAG"; else END="HEAD"; fi
+          PREV_TAG="$(git describe --tags --abbrev=0 "$END^" 2>/dev/null || true)"
+          if [ -n "$PREV_TAG" ]; then RANGE="$PREV_TAG..$END"; else RANGE="$END"; fi
+          echo "Collecting dependency commits over $RANGE"
+
+          # Squash merges land as `deps: bump the angular group ... (#338)`. Only `deps:` is
+          # collected: that prefix is configured for the nuget and npm ecosystems in
+          # dependabot.yml. `ci:` (Actions) and `build:` (Docker base images) are deliberately
+          # excluded — they are not runtime dependencies of the shipped product.
+          entries="$(git log --no-merges --pretty=%s "$RANGE" \
+            | grep -E '^deps(\(.*\))?!?: ' \
+            | sed -E 's/^deps(\(.*\))?!?: //' \
+            | sed -E "s|\(#([0-9]+)\)\$|([#\1](https://github.com/$REPO/pull/\1))|" \
+            | sed -E 's/^(.)/\U\1/' \
+            | sort -u \
+            | sed 's/^/- /' || true)"
+
+          if [ -z "$entries" ]; then
+            echo "No dependency commits in range — no Dependencies section to add."
+            exit 0
+          fi
+
+          echo "Adding:"
+          printf '%s\n' "$entries"
+
+          # Append the section at the end of the new version's block, i.e. immediately before the
+          # next `## [version]` heading or the link-definition footer, whichever comes first.
+          block="### Dependencies"$'\n'"$entries"$'\n'
+          # index() rather than a regex: the version is interpolated, and `[2.12.0]` in a regex
+          # is a character class, not a literal — that silently never matches the heading.
+          awk -v ver="$VERSION" -v block="$block" '
+            !done && index($0, "## [" ver "]") == 1 { inver = 1; prev = $0; print; next }
+            inver && (/^## \[/ || /^\[[^]]+\]: /) {
+              if (prev != "") print ""
+              print block
+              inver = 0; done = 1
+            }
+            { prev = $0; print }
+            END {
+              if (inver) {
+                if (prev != "") print ""
+                print block
+              }
+            }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+
       # Flags whether the GitHub App is configured. Secrets can't be read in `if:` conditions
       # directly, so surface it as a step output the later steps can gate on.
       - name: Detect app config
@@ -74,6 +138,8 @@ jobs:
             Automated CHANGELOG update for release ${{ github.event.release.tag_name }}.
 
             Promotes the `[Unreleased]` section to `[${{ github.event.release.tag_name }}]` and opens a fresh `[Unreleased]` section.
+
+            Also appends a `### Dependencies` section listing every `deps:` PR merged since the previous tag.
 
             Triggered by release [${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}).
           branch: changelog/${{ github.event.release.tag_name }}


### PR DESCRIPTION
Dependabot PRs have not been auto-merging. The auto-merge workflow was doing its job — it approved and armed auto-merge on every eligible PR — but they all sat at `BLOCKED`.

## Cause

`main` requires three status checks: `Frontend (Angular)`, `Backend (.NET)`, and `Changelog entry present`.

Dependabot uses a `deps:` commit prefix for the npm and nuget ecosystems (`.github/dependabot.yml`), and `deps` was not in the exempt list in `changelog.yml`. Dependabot never writes a CHANGELOG entry, so that check failed on every one of those PRs — and auto-merge waits indefinitely on a required check that can never pass.

The github-actions ecosystem uses `prefix: ci`, which *was* exempt. That is why #347 (`ci: bump actions/checkout`) passes the changelog check while #349 (`deps: bump the eslint group`) fails it. Same workflow, different title prefix.

## Approach

Exempting `deps:` on its own would drop dependency bumps from the changelog entirely, which we do not want.

Instead, `release-changelog.yml` now collects every `deps:` squash commit between the previous tag and the release tag and appends them as a `### Dependencies` section in the version block it cuts:

```
## [2.12.0] - 2026-08-14

### Added
- Generic external SSO / OIDC login provider (#327)

### Dependencies
- Bump the angular group across 1 directory with 13 updates ([#338](../../pull/338))
```

Collecting at release time, rather than having a bot commit an entry onto each Dependabot branch, avoids two problems:

- 14 concurrent Dependabot PRs would all edit the same few lines of `CHANGELOG.md` and conflict with each other constantly.
- Dependabot stops rebasing any PR that another actor has modified.

`ci:` (Actions) and `build:` (Docker base images) stay exempt and are deliberately **not** collected — they are not runtime dependencies of the shipped product.

## Verification

Ran the extraction and insertion against the real repo history and `CHANGELOG.md`. This caught a bug in the first draft: `"^## \[" ver "\]"` makes `[2.12.0]` a regex *character class*, so the version heading never matched and the section silently vanished. Switched to `index()`.

Edge cases tested and correct, including blank-line placement:

- empty version section (heading immediately followed by the next heading)
- version block sitting directly above the `[Unreleased]: url` link footer
- no link footer, section running to EOF

Both workflow files parse as valid YAML, and the new step is ordered before the PR-creation step so its changes are picked up.

## Notes

- No CHANGELOG entry on this PR: `ci:` is exempt, and this is build plumbing.
- The currently blocked Dependabot PRs need a `@dependabot rebase` **after** this merges. `changelog.yml` runs on `pull_request`, so it evaluates the workflow file from the merge ref — rebasing before this lands would still run the old logic.
- #366 (ef-core group) additionally has a genuine `Backend (.NET)` failure. That is a real build break and is not addressed here.