### PR TITLE
ci: consolidate the .NET dependabot groups into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,28 @@ updates:
     commit-message:
       prefix: deps
     groups:
-      microsoft:
+      # One group for the whole .NET platform. These packages ship as a single versioned set:
+      # Microsoft.EntityFrameworkCore 10.0.x transitively requires Microsoft.Extensions.* at
+      # >= the same 10.0.x, so any grouping that splits them produces a PR that cannot restore.
+      #
+      # The previous `microsoft` / `aspnetcore` / `ef-core` split did exactly that, and the
+      # patterns overlapped besides -- `Microsoft.*` is a superset of both `Microsoft.AspNetCore.*`
+      # and `Microsoft.EntityFrameworkCore*`. It yielded three PRs carving up one package set,
+      # of which only the widest could build. See #366: EF Core went to 10.0.10 while
+      # Microsoft.Extensions.* stayed at 10.0.8, giving `NU1605: Detected package downgrade`
+      # (a hard error under the .NET 10 SDK, not a warning).
+      #
+      # MySql.EntityFrameworkCore belongs here too: it version-locks to
+      # Microsoft.EntityFrameworkCore.Relational and drags the same Extensions floor with it.
+      dotnet:
         patterns:
           - 'Microsoft.*'
           - 'System.*'
-      aspnetcore:
-        patterns:
-          - 'Microsoft.AspNetCore.*'
-          - 'Microsoft.Extensions.*'
-      ef-core:
-        patterns:
-          - 'Microsoft.EntityFrameworkCore*'
           - 'MySql.EntityFrameworkCore'
+        exclude-patterns:
+          # Test-only and versioned independently of the platform (18.x, not 10.0.x).
+          # Kept in the `test` group so a runtime bump and a test-tooling bump stay separable.
+          - 'Microsoft.NET.Test.Sdk'
       test:
         patterns:
           - 'xunit*'


### PR DESCRIPTION
Follow-up to #368. With the changelog check no longer masking them, two Dependabot PRs turned out to have genuine build failures. #366 traces to how the .NET groups are defined.

## Cause

The three .NET groups have overlapping patterns:

| Group | Patterns | PR |
|---|---|---|
| `microsoft` | `Microsoft.*`, `System.*` | #362 — 12 pkgs |
| `aspnetcore` | `Microsoft.AspNetCore.*`, `Microsoft.Extensions.*` | #363 — 7 pkgs |
| `ef-core` | `Microsoft.EntityFrameworkCore*`, `MySql.EntityFrameworkCore` | #366 — 5 pkgs |

`Microsoft.*` is a superset of both other pattern sets, so Dependabot cuts three PRs that carve up one package set. **#362 is a strict superset of #363 and #366.**

The .NET platform packages ship as a single versioned set — `Microsoft.EntityFrameworkCore` 10.0.x transitively requires `Microsoft.Extensions.*` at `>=` the same 10.0.x. #366 raises EF Core to 10.0.10 while Extensions stay at 10.0.8, because those live in the other two groups:

```
error NU1605: Warning As Error: Detected package downgrade:
  Microsoft.Extensions.Caching.Memory from 10.0.10 to 10.0.8
  Core.Services -> Data.Scanner -> Microsoft.EntityFrameworkCore 10.0.10
                                -> Microsoft.Extensions.Caching.Memory (>= 10.0.10)
  Core.Services -> Microsoft.Extensions.Caching.Memory (>= 10.0.8)
```

That is a hard error under the .NET 10 SDK, not a warning — there is no `Directory.Build.props` or `-warnaserror` involved. #363 is green only because it happens to be self-consistent: it raises Extensions and AspNetCore together, and EF Core 10.0.8 demands nothing newer.

## Change

Collapse the three into one `dotnet` group. `MySql.EntityFrameworkCore` joins it — it version-locks to `Microsoft.EntityFrameworkCore.Relational` and drags the same Extensions floor along.

`Microsoft.NET.Test.Sdk` is excluded from `dotnet` so it stays in `test`. It versions independently (18.x, not 10.0.x), and keeping it separate leaves a runtime bump and a test-tooling bump reviewable apart from each other.

## Verification

Simulated pattern assignment (including the exclusion) over every `PackageReference` in the solution:

```
dotnet    Microsoft.AspNetCore.Authentication.JwtBearer
dotnet    Microsoft.AspNetCore.Mvc.Testing
dotnet    Microsoft.AspNetCore.OpenApi
dotnet    Microsoft.EntityFrameworkCore{,.Design,.InMemory,.Sqlite}
dotnet    Microsoft.Extensions.{Caching.Memory,Configuration.Abstractions,Http,Logging.Abstractions}
dotnet    MySql.EntityFrameworkCore
test      Microsoft.NET.Test.Sdk
test      coverlet.collector, Moq, xunit, xunit.runner.visualstudio
```

All platform packages in `dotnet`, all test tooling in `test`, nothing ungrouped. `dependabot.yml` parses as valid YAML.

## Notes

- No CHANGELOG entry: `ci:` is exempt, and this is build plumbing.
- This does not need the open PRs closed. Once #363 merges, `Microsoft.Extensions.*` lands at 10.0.10, and a rebased #366 reduces to the `MySql.EntityFrameworkCore 10.0.7 → 10.0.9` bump alone, which restores cleanly. Future bumps arrive pre-consolidated.
- #359 was a separate, unrelated problem: it pinned `@angular/platform-browser-dynamic` at `^21.2.16` (which peer-depends on `@angular/common` at exactly 21.2.16) while moving `common` to `^21.2.19`. That version does exist upstream; the PR was simply cut before it published. `@dependabot recreate` has been requested.