### PR TITLE
ci: stop auto-merging majors inside dependabot groups

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -35,8 +35,20 @@ jobs:
         #  - any grouped bundle (groups are curated; CI gates)
         #  - GitHub Actions minor bumps
         # Majors and runtime-dep minors wait for human review.
+        #
+        # The major exclusion is hoisted out in front of the group clause deliberately. Without
+        # it, `dependency-group != ''` waved through a major inside any curated group, which
+        # contradicts the line above. That is not hypothetical: #344 opened as
+        # jest-preset-angular 16.1.5 -> 16.2.0 and Dependabot recreated it in place as
+        # 16.1.5 -> 17.0.0, still auto-merge eligible because it belongs to the `jest` group.
+        #
+        # For a grouped PR, fetch-metadata reports `update-type` as the highest semver change in
+        # the bundle, so one major anywhere in a group holds the whole bundle for review. If the
+        # output is ever absent the comparison is simply true and grouped bundles behave exactly
+        # as they did before, so this cannot fail closed on us.
         if: |
-          github.actor == 'dependabot[bot]' && (
+          github.actor == 'dependabot[bot]' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major' && (
             steps.meta.outputs.update-type == 'version-update:semver-patch' ||
             steps.meta.outputs.dependency-group != '' ||
             (steps.meta.outputs.package-ecosystem == 'github_actions' &&
@@ -47,9 +59,12 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Same major exclusion as the auto-merge gate above — a bundle held for review must not
+      # arrive pre-approved, or the review requirement is satisfied without anyone looking.
       - name: Approve on behalf of repo
         if: |
-          github.actor == 'dependabot[bot]' && (
+          github.actor == 'dependabot[bot]' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major' && (
             steps.meta.outputs.update-type == 'version-update:semver-patch' ||
             steps.meta.outputs.dependency-group != ''
           )


### PR DESCRIPTION
The workflow comment states: *"Majors and runtime-dep minors wait for human review."* The condition did not enforce that. `dependency-group != ''` waved through a major inside any curated group, so the group clause silently overrode the stated policy.

Not hypothetical. #344 opened as `jest-preset-angular 16.1.5 → 16.2.0`, a patch. Dependabot recreated it in place as **16.1.5 → 17.0.0**, a major. It stayed auto-merge eligible *and* pre-approved, purely by virtue of belonging to the `jest` group.

## Change

Hoist the major exclusion in front of the group clause, on both gates:

```yaml
github.actor == 'dependabot[bot]' &&
steps.meta.outputs.update-type != 'version-update:semver-major' && (
  ... existing criteria ...
)
```

The **approve** step needs the same guard as the merge step. Branch protection requires one approving review; pre-approving a bundle that is being held for review satisfies that requirement without anyone having looked at it, which defeats the hold.

For a grouped PR, `fetch-metadata` reports `update-type` as the highest semver change in the bundle, so a single major anywhere holds the whole bundle. If that output is ever absent, the comparison is trivially true and grouped bundles behave exactly as they do today — this cannot fail closed and start blocking routine bumps.

## Verification

Simulated both gates across eight scenarios:

| Scenario | Auto-merge | Approve |
|---|---|---|
| grouped patch (jest 16.1.5→16.2.0) | yes | yes |
| **grouped major (jest 16→17) — #344** | **no** | **no** |
| grouped minor (dotnet 10.0.8→10.0.10) | yes | yes |
| ungrouped patch | yes | yes |
| ungrouped major (ngx-translate 17→18) | no | no |
| Actions minor (cache 5→5.1) | yes | no |
| Actions major (checkout 6→7) | no | no |
| grouped, `update-type` absent | yes | yes |

All match intent. Workflow parses as valid YAML.

## Effect on #344

#344 is currently armed and will merge before this lands. That is fine on the merits — I checked the peer requirement: jest-preset-angular 17 needs `jest: ^30.0.0`, the project is on `^30.4.2`, and the frontend suite passes. This change governs future bundles.

## Notes

- No CHANGELOG entry: `ci:` is exempt, and this is build plumbing.
- Independent of #371 (dependabot group consolidation); the two do not touch the same file.
