### PR TITLE
build: drop deprecated @angular/platform-browser-dynamic from the test setup

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/package-lock.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/package-lock.json
@@ -36,7 +36,6 @@
         "@angular/build": "^21.2.14",
         "@angular/cli": "^21.2.14",
         "@angular/compiler-cli": "^21.2.16",
-        "@angular/platform-browser-dynamic": "^21.2.16",
         "@jest/globals": "^30.4.1",
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
@@ -1191,25 +1190,6 @@
         "@angular/animations": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.16",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.16.tgz",
-      "integrity": "sha512-WtTnkJOmKiGccHRQfBdkwODAkpTB4zbPN3IKhcqCjlezKaPqZB5tjrIu72Z5pmi5VIgJz1LmfO1LSVCMC5h7dA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "21.2.16",
-        "@angular/compiler": "21.2.16",
-        "@angular/core": "21.2.16",
-        "@angular/platform-browser": "21.2.16"
       }
     },
     "node_modules/@angular/router": {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/package.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/package.json
@@ -43,7 +43,6 @@
     "@angular/build": "^21.2.14",
     "@angular/cli": "^21.2.14",
     "@angular/compiler-cli": "^21.2.16",
-    "@angular/platform-browser-dynamic": "^21.2.16",
     "@jest/globals": "^30.4.1",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/setup-jest.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/setup-jest.ts
@@ -1,11 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
-TestBed.initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-  { teardown: { destroyAfterEach: true } },
-);
+TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
+  teardown: { destroyAfterEach: true },
+});


### PR DESCRIPTION
Unblocks #359 (angular group bump), which has been failing `npm ci` with `ERESOLVE`.

## Cause

`@angular/platform-browser-dynamic` pins its peer `@angular/common` to an **exact** version. #359 moves `@angular/common` to 21.2.19 while `platform-browser-dynamic` stays at 21.2.16 and demands `@angular/common@21.2.16` precisely:

```
npm error While resolving: @angular/platform-browser-dynamic@21.2.16
npm error Found: @angular/common@21.2.19
npm error Could not resolve dependency:
npm error peer @angular/common@"21.2.16" from @angular/platform-browser-dynamic@21.2.16
```

This is not specific to #359 — any future Angular patch bump hits the same wall, because the exact peer pin cannot tolerate the group moving ahead of it.

The package is also deprecated upstream:

> `@angular/platform-browser-dynamic` is deprecated. Use `@angular/platform-browser` instead.

## Why this is possible now

#344 (merged) took jest-preset-angular from 16 to 17, which **dropped `@angular/platform-browser-dynamic` from its peer dependencies**. Nothing requires the package any more. Its only remaining use in this repo was a single import in `setup-jest.ts`.

## Change

Remove the `devDependency` and repoint the test bootstrap at `@angular/platform-browser/testing`, which exports the equivalent pair:

```ts
import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';

TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
  teardown: { destroyAfterEach: true },
});
```

I confirmed both symbols are exported by the installed package (`@angular/platform-browser/types/testing.d.ts`) rather than assuming the rename.

## Verification

- **872 tests across 78 suites pass** — the full frontend suite, unchanged count from `main`
- **Production build succeeds** with no errors (the pre-existing bundle-budget warning is unrelated and present on `main`)
- **`npm install` resolves with no `ERESOLVE`**
- `platform-browser-dynamic` is gone from both `node_modules` and `package-lock.json` (0 references)
- Prettier clean

## Notes

- No CHANGELOG entry: `build:` is exempt, and this touches only dev tooling and the test bootstrap — nothing user-facing ships differently.
- After this merges, #359 needs a `@dependabot recreate` to pick up a consistent Angular set.
