### PR TITLE
ci: add merge_group triggers so main can use a merge queue

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,10 +5,18 @@ name: Changelog Check
 # Replaces the old post-merge auto-writer, which always failed pushing to protected main
 # and risked duplicate entries. Release cuts are still handled by release-changelog.yml.
 
+# `merge_group` is listed so this required check reports against the merge queue's temporary
+# branch; without it, every queued PR stalls waiting for a check that never runs.
+#
+# The check itself is a pull-request-level policy and is deliberately a no-op in the queue.
+# A `merge_group` payload has no `pull_request` object at all, so TITLE, LABELS, BASE_SHA and
+# HEAD_SHA would all be empty: the exempt-prefix test would miss, `git show ""` would fail,
+# and the job would report a bogus failure on a PR that already passed this gate.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read
@@ -18,12 +26,24 @@ jobs:
     name: Changelog entry present
     runs-on: ubuntu-latest
     steps:
+      # Unconditional, so the job always has at least one successful step. A job whose every
+      # step is skipped by an `if:` is recorded as a failure, which would block the queue --
+      # the same trap documented in auto-merge-deps.yml.
+      - name: Context
+        run: echo "event=${{ github.event_name }}"
+
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
+      - name: Already validated on the pull request
+        if: github.event_name == 'merge_group'
+        run: echo "Merge queue run — the CHANGELOG gate was enforced when this PR was reviewed."
+
       - name: Require a CHANGELOG entry under [Unreleased]
+        if: github.event_name == 'pull_request'
         env:
           # Passed via env (not inlined) to avoid shell injection from PR titles/labels.
           TITLE: ${{ github.event.pull_request.title }}
@@ -73,6 +93,6 @@ jobs:
 
           echo "::error::This PR has no new entry under '## [Unreleased]' in CHANGELOG.md."
           echo "Add a Keep a Changelog entry (e.g. under '### Fixed'), or:"
-          echo "  - use a 'docs|style|chore|ci|test|build:' PR title for non-user-facing changes, or"
+          echo "  - use a 'deps|docs|style|chore|ci|test|build:' PR title for non-user-facing changes, or"
           echo "  - apply the 'skip-changelog' label for a legitimate exception."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 
+# `merge_group` is required for the merge queue on `main`. Both jobs below are required
+# status checks, and a queued PR waits on them being reported against the queue's temporary
+# merge branch -- not against the PR head. Without this trigger they never run there and
+# every queued PR stalls until it times out.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   backend:


### PR DESCRIPTION
Step 1 of 2 for putting a merge queue on `main`. **This is the prerequisite and must merge before the queue is switched on** — enabling the queue first would stall every PR that enters it.

## Why this is needed

A PR in a merge queue waits on its required checks being reported against the **queue's temporary merge branch**, not against the PR head. A required check whose workflow has no `merge_group` trigger never runs there at all, so the PR sits in the queue until it times out and gets ejected — strictly worse than today's behaviour.

`main` requires three contexts, from two workflows:

| Required check | Workflow |
|---|---|
| `Backend (.NET)` | `ci.yml` |
| `Frontend (Angular)` | `ci.yml` |
| `Changelog entry present` | `changelog.yml` |

## `ci.yml`

Trigger added, nothing else. Both jobs just build and test, so they work unchanged on a merge branch.

## `changelog.yml`

This one needed real thought rather than a copy-paste of the trigger.

A `merge_group` payload carries **no `pull_request` object**. So `TITLE`, `LABELS`, `BASE_SHA` and `HEAD_SHA` would all resolve to empty strings:

- the exempt-prefix test would miss (an empty title matches no prefix)
- `git show ":CHANGELOG.md"` would fail on the empty SHA
- the job would report a **bogus failure** on a PR that had already passed the gate

The changelog check is a pull-request-level policy — there is nothing meaningful to re-verify once the PR is approved and queued. It is now explicitly a no-op on `merge_group` and runs only on `pull_request`.

The job also keeps one **unconditional** step. A job whose every step is skipped by an `if:` is recorded as a *failure*, which would block the queue — the same trap already documented in `auto-merge-deps.yml`.

Job names are unchanged, so the three required status check contexts still match.

## Also

Corrects the failure message, which still listed the pre-#368 exempt set and omitted `deps:`.

## Step 2 — enabling the queue (not in this PR)

Two settings changes, after this merges:

1. **Turn off `strict` on the required status checks.** "Require branches to be up to date before merging" is redundant with a merge queue — the queue builds each entry against the current tip itself — and it is the direct cause of the convoy problem this is meant to solve.
2. **Add a `merge_queue` rule targeting `main`.** Classic branch protection does not expose merge queue via its API (its keys are `required_status_checks`, `required_pull_request_reviews`, … and no `merge_queue`), so this goes in a repository ruleset. The repo already uses one for Copilot review.

Suggested queue settings, matching existing convention:

- `merge_method: SQUASH` — matches how everything is merged here today
- `grouping_strategy: ALLGREEN`
- `min_entries_to_merge: 1` with `min_entries_to_merge_wait_minutes: 5` so single PRs are not delayed
- `check_response_timeout_minutes: 60` — the frontend job alone runs ~2.5 min, so this is generous

## Why it is worth doing

Today `strict=true` means every merge to `main` re-strands every other open PR at `BEHIND`, and approved, auto-merge-armed PRs then sit indefinitely. During this session three armed PRs stayed `BEHIND` through ten consecutive one-minute polls and only moved after a manual `@dependabot rebase`. Enabling `allow_update_branch` helped but did not fix it. With a dozen Dependabot PRs open at once, that is a lot of manual nudging.
