### PR TITLE
docs: point self-hosters at a release tag, not main

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ Three Docker channels are published to GHCR — see [TESTING.md](TESTING.md) for
 | Beta | `:beta`, `:main-<sha>` | Every push to `main` |
 | PR preview | `:pr-<number>` | PRs with the `preview` label |
 
+The same split applies when you **build from source** — and it is easy to miss, because a fresh clone puts you on `main`:
+
+| You check out | You get |
+|---|---|
+| A release tag (`git checkout "$(git describe --tags --abbrev=0)"`) | Stable — the same code as `:latest` |
+| `main` | Beta — every merged PR, including work that has never been in a release |
+
+If you are self-hosting, use a release tag or the published `:latest` image. `main` is where changes soak before a release; running it means running code that has not shipped yet.
+
 ## CI/CD
 
 - **ci.yml** — Builds backend, runs tests, builds frontend, runs lint/prettier/jest

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -82,3 +82,6 @@ docker compose up -d
 docker compose up -d --force-recreate
 docker build --no-cache -t poracleweb.net:latest .
 ```
+
+!!! warning "Building from source builds whatever is checked out"
+    These commands build your working tree. On a fresh clone that is `main` — the beta channel, which carries merged-but-unreleased work. Check out a release tag first (`git checkout "$(git describe --tags --abbrev=0)"`), or skip the build entirely and use the published `ghcr.io/pgan-dev/poracleweb.net:latest` image, which only moves when a release is published.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -10,9 +10,16 @@ This is the recommended way to run PoracleWeb.NET in production.
 ```bash
 git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
 cd PoracleWeb.NET
+
+# Check out the newest release. Without this you are on `main`, which is the
+# beta channel — it carries merged-but-unreleased work.
+git checkout "$(git describe --tags --abbrev=0)"
 ```
 
 Or download and extract a release. Everything below runs from this root directory.
+
+!!! warning "`main` is the beta channel"
+    `main` receives every merged pull request and is published as the `:beta` Docker image. It is where changes soak before a release, so it can contain work that has never been in a released version. Build from a release tag unless you specifically want to test unreleased changes — and if you do, prefer the `:beta` image over building from source so you get the exact artifact that was tested.
 
 ## 2. Create your `.env` and `docker-compose.yml`
 
@@ -183,11 +190,15 @@ The app will now be available at `http://your-server:9090`. Remember to update y
 === "Built from source"
 
     ```bash
-    git pull
+    git fetch --tags
+    git checkout "$(git describe --tags --abbrev=0 origin/main)"
     ./scripts/docker.sh update
     ```
 
     Or without the script: `docker build -t poracleweb.net:latest . && docker compose up -d --force-recreate`
+
+    !!! note "A plain `git pull` tracks the beta channel"
+        `git pull` on `main` moves you to the newest merged commit, not the newest release. Fetch tags and check the newest one out to stay on released code.
 
 ## Common issues
 

--- a/docs/getting-started/standalone-setup.md
+++ b/docs/getting-started/standalone-setup.md
@@ -38,6 +38,10 @@ You'll configure everything in a single `.env` file at the project root and run 
     git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
     cd PoracleWeb.NET
 
+    # Check out the newest release. `main` is the beta channel and carries
+    # merged-but-unreleased work.
+    git checkout "$(git describe --tags --abbrev=0)"
+
     # Build everything with the convenience script
     ./scripts/dev.sh build
 


### PR DESCRIPTION
The Docker channels are already separated — `:latest` on release, `:beta` on every push to `main`. The **source** channel is not, and our own docs walk people straight into it.

## The gap

Quick Start says:

```bash
git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git   # no tag -> main
cd PoracleWeb.NET
...
docker build -t poracleweb.net:latest .
```

and the update instructions say `git pull` + rebuild. So a self-hoster following our documentation builds **main HEAD** and then tracks it continuously — running beta without knowing it. `main` is currently **10 commits ahead of v2.12.1**, including behaviour changes that have never been in a release.

Compose users were always fine: `docker-compose.yml.example` defaults to `ghcr.io/pgan-dev/poracleweb.net:latest`, which only moves on a published release. It's the clone-and-build path that leaks.

## What changed

- **Quick Start** and the **standalone build-from-source** path gain `git checkout "$(git describe --tags --abbrev=0)"`.
- **Update instructions** fetch tags and check out the newest, instead of `git pull` onto main — with a note explaining why a plain pull tracks beta.
- The raw `docker build` commands in `configuration/docker.md` carry a warning that they build whatever is checked out, and point at the published image as the simpler option.
- The README's release-channel table gains a **source** counterpart, so the tag-vs-main split is stated in the same place the image split already is.

**Deliberately unchanged:** the clone under README *Development* and in `development-setup.md`. Contributors want `main`.

## Verified

Not just written — run. On a real clone:

```
fresh clone HEAD        5073231  (main)
after the documented cmd  v2.12.1  -> d42e69f
```

`mkdocs build --strict` is clean.

## Scope

This is the cheap half of the wider question about whether PRs should target a `develop` branch. It removes most of the exposure today without touching a single workflow.

The branch change is still worth doing deliberately, and is not in this PR: `ci.yml`, `changelog.yml` and `docs.yml` are all pinned to `branches: [main]`, as are the merge queue and ruleset. Retargeting PRs before rewiring those means **PRs run with no CI at all** — that already happened once, to #394 while it was stacked.
