### PR TITLE
ci: add a develop branch so main tracks releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ name: Changelog Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [main]
+    branches: [main, develop]
   merge_group:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ name: CI
 # every queued PR stalls until it times out.
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   merge_group:
 
 jobs:

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -56,12 +56,12 @@ jobs:
               }
             }
 
-  prune-main-shas:
+  prune-develop-shas:
     runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:
-      - name: Keep only last 10 main-<sha> images
+      - name: Keep only last 10 develop-<sha> images
         uses: actions/delete-package-versions@v5
         with:
           package-name: poracleweb.net

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   push:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 env:
@@ -41,8 +41,8 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=beta,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            type=sha,prefix=main-,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=beta,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+            type=sha,prefix=develop-,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
             type=sha,prefix=,enable=${{ github.event_name == 'release' }}
 
       # Computed here rather than pulled out of the metadata-action JSON, so the value passed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,17 @@ PoracleNG can change `current_profile_no` outside of PoracleWeb — the active-h
 ### JWT Generation (IJwtService)
 JWT token generation is centralized in `IJwtService` / `JwtService` (singleton). Three methods: `GenerateToken(UserInfo)` for fresh tokens, `GenerateImpersonationToken(UserInfo, impersonatedBy)` for admin impersonation, and `GenerateTokenWithReplacedProfile(ClaimsPrincipal, profileNo)` for profile switches. The latter filters out registered JWT claims (`exp`, `nbf`, `iat`, `iss`, `aud`) before copying to prevent stale claim duplication. All controllers (`AuthController`, `ProfileController`, `ProfileOverviewController`, `AdminController`) use this service — no inline JWT generation.
 
+## Branching
+
+| Branch | Purpose |
+|---|---|
+| `main` | Released code. Only moves when a release is merged. Publishes `:latest`, which prod's watchtower auto-deploys. A plain `git clone` lands here, so self-hosters get released code. |
+| `develop` | Integration. **Open pull requests against this.** Publishes `:beta` on every merge, which the dev instance auto-deploys. |
+
+Cutting a release: merge `develop` into `main`, then publish a GitHub release. `release-changelog.yml` opens a PR promoting `[Unreleased]` to the new version section, and `docker-publish.yml` pushes `:latest`.
+
+`ci.yml` and `changelog.yml` run for pushes and PRs on **both** branches -- a workflow filtered to one branch means PRs into the other run with no checks at all and merge looking green (this happened to #394 while it was stacked on another branch).
+
 ## Build & Run
 
 ### Using convenience scripts (recommended)

--- a/README.md
+++ b/README.md
@@ -112,24 +112,33 @@ Three Docker channels are published to GHCR — see [TESTING.md](TESTING.md) for
 | Channel | Tag | Trigger |
 |---|---|---|
 | Stable | `:latest`, `:vX.Y.Z` | Release tag |
-| Beta | `:beta`, `:main-<sha>` | Every push to `main` |
+| Beta | `:beta`, `:develop-<sha>` | Every push to `develop` |
 | PR preview | `:pr-<number>` | PRs with the `preview` label |
 
-The same split applies when you **build from source** — and it is easy to miss, because a fresh clone puts you on `main`:
+The same split applies when you **build from source**:
 
 | You check out | You get |
 |---|---|
-| A release tag (`git checkout "$(git describe --tags --abbrev=0)"`) | Stable — the same code as `:latest` |
-| `main` | Beta — every merged PR, including work that has never been in a release |
+| `main`, or a release tag | Stable — the same code as `:latest` |
+| `develop` | Beta — every merged PR, including work that has never been in a release |
 
-If you are self-hosting, use a release tag or the published `:latest` image. `main` is where changes soak before a release; running it means running code that has not shipped yet.
+`main` only moves when a release is published, so a plain `git clone` gives you released code. `develop` is where changes soak first; running it means running code that has not shipped yet.
+
+## Branches
+
+| Branch | Purpose |
+|---|---|
+| `main` | Released code. Only moves on a release. Publishes `:latest`. |
+| `develop` | Integration. **Pull requests target this.** Publishes `:beta` on every merge. |
+
+Cutting a release means merging `develop` into `main` and publishing a GitHub release; the changelog is promoted from `[Unreleased]` automatically.
 
 ## CI/CD
 
 - **ci.yml** — Builds backend, runs tests, builds frontend, runs lint/prettier/jest
-- **docker-publish.yml** — Builds and publishes Docker image to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net) (`:latest` on release, `:beta` on main)
+- **docker-publish.yml** — Builds and publishes Docker image to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net) (`:latest` on release, `:beta` on `develop`)
 - **docker-preview.yml** — Builds `:pr-<number>` images on PRs labeled `preview`
-- **docker-prune.yml** — Nightly cleanup of stale `pr-*` and `main-<sha>` tags
+- **docker-prune.yml** — Nightly cleanup of stale `pr-*` and `develop-<sha>` tags
 - **pr-labeler.yml** — Auto-labels PRs from branch prefix / PR title for release-note grouping
 - **release.yml** (config) — Groups PRs by label when generating GitHub release notes
 

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -84,4 +84,4 @@ docker build --no-cache -t poracleweb.net:latest .
 ```
 
 !!! warning "Building from source builds whatever is checked out"
-    These commands build your working tree. On a fresh clone that is `main` — the beta channel, which carries merged-but-unreleased work. Check out a release tag first (`git checkout "$(git describe --tags --abbrev=0)"`), or skip the build entirely and use the published `ghcr.io/pgan-dev/poracleweb.net:latest` image, which only moves when a release is published.
+    These commands build your working tree. On a fresh clone that is `main`, which tracks releases; on `develop` it is unreleased work. Check out a release tag first (`git checkout "$(git describe --tags --abbrev=0)"`), or skip the build entirely and use the published `ghcr.io/pgan-dev/poracleweb.net:latest` image, which only moves when a release is published.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,15 +11,15 @@ This is the recommended way to run PoracleWeb.NET in production.
 git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
 cd PoracleWeb.NET
 
-# Check out the newest release. Without this you are on `main`, which is the
-# beta channel — it carries merged-but-unreleased work.
+# Check out the newest release. Without this you are on whatever the default
+# branch resolves to; a tag pins you to a released version.
 git checkout "$(git describe --tags --abbrev=0)"
 ```
 
 Or download and extract a release. Everything below runs from this root directory.
 
-!!! warning "`main` is the beta channel"
-    `main` receives every merged pull request and is published as the `:beta` Docker image. It is where changes soak before a release, so it can contain work that has never been in a released version. Build from a release tag unless you specifically want to test unreleased changes — and if you do, prefer the `:beta` image over building from source so you get the exact artifact that was tested.
+!!! warning "`develop` is the beta channel"
+    `develop` receives every merged pull request and is published as the `:beta` Docker image. `main` only moves when a release is published. It is where changes soak before a release, so it can contain work that has never been in a released version. Build from a release tag unless you specifically want to test unreleased changes — and if you do, prefer the `:beta` image over building from source so you get the exact artifact that was tested.
 
 ## 2. Create your `.env` and `docker-compose.yml`
 
@@ -198,7 +198,7 @@ The app will now be available at `http://your-server:9090`. Remember to update y
     Or without the script: `docker build -t poracleweb.net:latest . && docker compose up -d --force-recreate`
 
     !!! note "A plain `git pull` tracks the beta channel"
-        `git pull` on `main` moves you to the newest merged commit, not the newest release. Fetch tags and check the newest one out to stay on released code.
+        `git pull` moves you to the newest commit on your current branch. On `develop` that is the beta channel. Fetch tags and check the newest one out to stay on released code.
 
 ## Common issues
 

--- a/docs/getting-started/standalone-setup.md
+++ b/docs/getting-started/standalone-setup.md
@@ -38,7 +38,7 @@ You'll configure everything in a single `.env` file at the project root and run 
     git clone https://github.com/PGAN-Dev/PoracleWeb.NET.git
     cd PoracleWeb.NET
 
-    # Check out the newest release. `main` is the beta channel and carries
+    # Check out the newest release. `develop` is the beta channel and carries
     # merged-but-unreleased work.
     git checkout "$(git describe --tags --abbrev=0)"
 


### PR DESCRIPTION
Implements the branch split we discussed. The trigger was consumers, not the deploy pipeline: a plain `git clone` lands on the default branch, and the documented self-host path builds from source — so with `main` as the integration branch, self-hosters were building merged-but-unreleased code. `main` was 12 commits ahead of `v2.12.1` when this came up.

## The model

```
PR ──▶ develop ──▶ :beta   ──▶ dev instance
       develop ──▶ main + GitHub release ──▶ :latest ──▶ prod
```

| Branch | Purpose |
|---|---|
| `main` | Released code. Only moves when a release is merged. Publishes `:latest`. A plain clone lands here. |
| `develop` | Integration. **PRs target this.** Publishes `:beta` on every merge. |

## Rewiring — the part that had to be right

A workflow filtered to one branch means PRs into the other run with **no checks** and merge looking green. That is not hypothetical: it happened to #394 while it was stacked on another branch, and it went green with zero checks executed. So every trigger was audited, not just the obvious ones:

| Workflow | Change |
|---|---|
| `ci.yml` | `push` and `pull_request` on `[main, develop]` |
| `changelog.yml` | `pull_request` on `[main, develop]` |
| `docker-publish.yml` | `:beta` and `:develop-<sha>` now come from `develop`; `:latest` still only on a published release |
| `docker-prune.yml` | prunes `develop-<sha>` instead of `main-<sha>` |
| `docs.yml` | **left on `main`**, so the published docs describe the released version |

No infrastructure change is needed: the dev instance watches the `:beta` tag, which simply has a new source. Prod watches `:latest`, unchanged.

## Docs

README gains a **Branches** section, and both channel tables (image and source) now name `develop` as beta. The getting-started and docker pages no longer describe `main` as the beta channel — that was true when #432 landed and is now inverted. CLAUDE.md records the flow and the CI-filter trap.

## After merging — two manual steps I cannot do

1. **Create `develop` from `main`** and set it as the default PR base. I can create the branch, but changing the repo's default PR target is a settings change I would rather you make deliberately.
2. **Mirror branch protection onto `develop`.** `main` currently has classic protection — required checks `Frontend (Angular)`, `Backend (.NET)`, `Changelog entry present`, 1 approving review, conversation resolution required — plus ruleset `20426419` (merge queue). Without the same on `develop`, PRs there merge unprotected, which would leave us worse off than before.

Until step 2 is done, `develop` is unprotected — so it is worth doing in the same sitting.
