### PR TITLE
fix: the Cleaning page was broken three separate ways (#402)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/CleaningController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/CleaningController.cs
@@ -1,12 +1,14 @@
 using Microsoft.AspNetCore.Mvc;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Api.Controllers;
 
 [Route("api/cleaning")]
-public class CleaningController(ICleaningService cleaningService) : BaseApiController
+public class CleaningController(ICleaningService cleaningService, IFeatureGate featureGate) : BaseApiController
 {
     private readonly ICleaningService _cleaningService = cleaningService;
+    private readonly IFeatureGate _featureGate = featureGate;
 
     [HttpGet("status")]
     public async Task<IActionResult> GetStatus()
@@ -18,21 +20,42 @@ public class CleaningController(ICleaningService cleaningService) : BaseApiContr
     [HttpPut("all/{enabled:int}")]
     public async Task<IActionResult> ToggleAll(int enabled)
     {
+        // Each toggle re-checks its own feature gate, so awaiting all of them unconditionally meant one
+        // disabled alarm type threw partway through -- 403 to the caller, with the types processed before
+        // it already written. Skip disabled types instead, and tell the caller which were skipped.
         var total = 0;
-        total += await this._cleaningService.ToggleCleanMonstersAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanRaidsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanEggsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanQuestsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanInvasionsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanLuresAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanNestsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanGymsAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanFortChangesAsync(this.UserId, this.ProfileNo, enabled);
-        total += await this._cleaningService.ToggleCleanMaxBattlesAsync(this.UserId, this.ProfileNo, enabled);
+        var skipped = new List<string>();
+
+        foreach (var (disableKey, toggle) in this.BulkToggles())
+        {
+            if (!await this._featureGate.IsEnabledAsync(disableKey))
+            {
+                skipped.Add(disableKey);
+                continue;
+            }
+
+            total += await toggle(enabled);
+        }
+
         return this.Ok(new
         {
-            updated = total
+            updated = total,
+            skipped,
         });
+    }
+
+    /// <summary>Every alarm type the bulk toggle covers, paired with the gate that can switch it off.</summary>
+    private IEnumerable<(string DisableKey, Func<int, Task<int>> Toggle)> BulkToggles()
+    {
+        yield return (DisableFeatureKeys.Pokemon, e => this._cleaningService.ToggleCleanMonstersAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Raids, e => this._cleaningService.ToggleCleanRaidsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Raids, e => this._cleaningService.ToggleCleanEggsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Quests, e => this._cleaningService.ToggleCleanQuestsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Invasions, e => this._cleaningService.ToggleCleanInvasionsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Lures, e => this._cleaningService.ToggleCleanLuresAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Nests, e => this._cleaningService.ToggleCleanNestsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.Gyms, e => this._cleaningService.ToggleCleanGymsAsync(this.UserId, this.ProfileNo, e));
+        yield return (DisableFeatureKeys.MaxBattles, e => this._cleaningService.ToggleCleanMaxBattlesAsync(this.UserId, this.ProfileNo, e));
     }
 
     [HttpPut("{alarmType}/{enabled:int}")]
@@ -48,7 +71,7 @@ public class CleaningController(ICleaningService cleaningService) : BaseApiContr
             "lures" => await this._cleaningService.ToggleCleanLuresAsync(this.UserId, this.ProfileNo, enabled),
             "nests" => await this._cleaningService.ToggleCleanNestsAsync(this.UserId, this.ProfileNo, enabled),
             "gyms" => await this._cleaningService.ToggleCleanGymsAsync(this.UserId, this.ProfileNo, enabled),
-            "fortchanges" => await this._cleaningService.ToggleCleanFortChangesAsync(this.UserId, this.ProfileNo, enabled),
+
             "maxbattles" => await this._cleaningService.ToggleCleanMaxBattlesAsync(this.UserId, this.ProfileNo, enabled),
             // Unknown types are client input, not a fault. "pokemon" is a natural guess for "monsters".
             _ => (int?)null
@@ -71,6 +94,6 @@ public class CleaningController(ICleaningService cleaningService) : BaseApiContr
     private static readonly string[] ValidAlarmTypes =
     [
         "monsters", "raids", "eggs", "quests", "invasions",
-        "lures", "nests", "gyms", "fortchanges", "maxbattles",
+        "lures", "nests", "gyms", "maxbattles",
     ];
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/cleaning/cleaning.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/cleaning/cleaning.component.ts
@@ -121,15 +121,6 @@ export class CleaningComponent implements OnInit {
       type: 'gyms',
     },
     {
-      color: '#795548',
-      descriptionKey: 'CLEANING.FORT_CHANGES_DESC',
-      enabled: signal(false),
-      hasAlarms: signal(false),
-      icon: 'domain',
-      labelKey: 'NAV.FORT_CHANGES',
-      type: 'fortchanges',
-    },
-    {
       color: '#d500f9',
       descriptionKey: 'CLEANING.MAX_BATTLES_DESC',
       enabled: signal(false),
@@ -205,7 +196,7 @@ export class CleaningComponent implements OnInit {
         error: () => this.loading.set(false),
         next: counts => {
           for (const item of this.cleaningItems) {
-            const key = item.type === 'monsters' ? 'pokemon' : item.type === 'fortchanges' ? 'fortChanges' : item.type;
+            const key = item.type === 'monsters' ? 'pokemon' : item.type;
             const count = (counts as unknown as Record<string, number>)[key] ?? 0;
             item.hasAlarms.set(count > 0);
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The Cleaning page was broken three separate ways** ([#402](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/402)). **Max Battles duplicated every alarm on each click**: cleaning is a fetch-modify-POST that assumes PoracleNG upserts on `uid`, but its maxbattle create is insert-only, so each toggle inserted a full duplicate set while the originals kept `clean=0` — unbounded growth, one set per click. That type now frees its rows before re-creating them, and restores the originals if the re-create fails; the other types still upsert untouched. **Fort changes silently did nothing**: PoracleNG's `FortTracking` has no clean column at all (confirmed in its schema and its struct), yet the toggle returned `{"updated":N}` with a success message and wrote nothing. Fort changes are removed from the cleaning page, the status response and the API, which now returns 400 rather than faking success. **The bulk toggle applied partially and then failed**: every per-type toggle re-checks its own feature gate, so one admin-disabled alarm type threw partway through — a 403 to the caller with the types processed before it already written. It now skips disabled types and reports which were skipped, so the operation is all-or-nothing per type instead of silently half-applied.
+
 ## [2.13.0] - 2026-08-08
 
 ### Changed

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ICleaningService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ICleaningService.cs
@@ -11,6 +11,5 @@ public interface ICleaningService
     public Task<int> ToggleCleanLuresAsync(string userId, int profileNo, int clean);
     public Task<int> ToggleCleanNestsAsync(string userId, int profileNo, int clean);
     public Task<int> ToggleCleanGymsAsync(string userId, int profileNo, int clean);
-    public Task<int> ToggleCleanFortChangesAsync(string userId, int profileNo, int clean);
     public Task<int> ToggleCleanMaxBattlesAsync(string userId, int profileNo, int clean);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Services/CleaningService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/CleaningService.cs
@@ -13,6 +13,12 @@ public class CleaningService(IPoracleTrackingProxy trackingProxy, IFeatureGate f
     private readonly IPoracleTrackingProxy _trackingProxy = trackingProxy;
     private readonly IFeatureGate _featureGate = featureGate;
 
+    /// <summary>
+    /// Tracking types whose PoracleNG create only ever inserts, so a re-POST duplicates rather than
+    /// updates. Everything else upserts on <c>uid</c>.
+    /// </summary>
+    private static readonly HashSet<string> InsertOnlyTypes = new(StringComparer.Ordinal) { "maxbattle" };
+
     public async Task<Dictionary<string, bool>> GetCleanStatusAsync(string userId, int profileNo)
     {
         var allTracking = await this._trackingProxy.GetAllTrackingAsync(userId);
@@ -27,7 +33,6 @@ public class CleaningService(IPoracleTrackingProxy trackingProxy, IFeatureGate f
             ["lures"] = AllClean(allTracking, "lure"),
             ["nests"] = AllClean(allTracking, "nest"),
             ["gyms"] = AllClean(allTracking, "gym"),
-            ["fortChanges"] = AllClean(allTracking, "fort"),
             ["maxbattles"] = AllClean(allTracking, "maxbattle"),
         };
     }
@@ -59,8 +64,6 @@ public class CleaningService(IPoracleTrackingProxy trackingProxy, IFeatureGate f
     public async Task<int> ToggleCleanMaxBattlesAsync(string userId, int profileNo, int clean) =>
         await this.ToggleCleanAsync("maxbattle", userId, clean);
 
-    public async Task<int> ToggleCleanFortChangesAsync(string userId, int profileNo, int clean) =>
-        await this.ToggleCleanAsync("fort", userId, clean);
 
     /// <summary>
     /// Workaround: PoracleNG has no bulk clean toggle endpoint. We fetch all alarms of the type,
@@ -104,6 +107,34 @@ public class CleaningService(IPoracleTrackingProxy trackingProxy, IFeatureGate f
         }
 
         var body = JsonSerializer.SerializeToElement(updatedAlarms);
+
+        // PoracleNG's maxbattle create is insert-only -- it has no upsert path -- so re-POSTing the
+        // modified set inserted a full duplicate of every alarm and left the originals untouched.
+        // One click per duplicate set, unbounded. Free the rows first for that type only; the others
+        // upsert on uid and must not be deleted.
+        if (InsertOnlyTypes.Contains(type))
+        {
+            var uids = trackingJson.EnumerateArray()
+                .Where(a => a.TryGetProperty("uid", out var u) && u.ValueKind == JsonValueKind.Number)
+                .Select(a => a.GetProperty("uid").GetInt32())
+                .ToList();
+
+            await this._trackingProxy.BulkDeleteByUidsAsync(type, userId, uids);
+
+            try
+            {
+                await this._trackingProxy.CreateAsync(type, userId, body);
+            }
+            catch
+            {
+                // Put the originals back rather than leaving the user with no alarms at all.
+                await this._trackingProxy.CreateAsync(type, userId, trackingJson);
+                throw;
+            }
+
+            return count;
+        }
+
         await this._trackingProxy.CreateAsync(type, userId, body);
 
         return count;

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/CleaningControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/CleaningControllerTests.cs
@@ -2,17 +2,21 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Pgan.PoracleWebNet.Api.Controllers;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Tests.Controllers;
 
 public class CleaningControllerTests : ControllerTestBase
 {
     private readonly Mock<ICleaningService> _service = new();
+    private readonly Mock<IFeatureGate> _featureGate = new();
     private readonly CleaningController _sut;
 
     public CleaningControllerTests()
     {
-        this._sut = new CleaningController(this._service.Object);
+        // Everything enabled unless a test says otherwise.
+        this._featureGate.Setup(g => g.IsEnabledAsync(It.IsAny<string>())).ReturnsAsync(true);
+        this._sut = new CleaningController(this._service.Object, this._featureGate.Object);
         SetupUser(this._sut);
     }
 
@@ -65,6 +69,36 @@ public class CleaningControllerTests : ControllerTestBase
 
         var bad = Assert.IsType<BadRequestObjectResult>(result);
         Assert.Contains("Unknown alarm type", System.Text.Json.JsonSerializer.Serialize(bad.Value), StringComparison.Ordinal);
+    }
+
+
+    // --- Bulk toggle applied partially then 403'd (#402) ---
+
+    [Fact]
+    public async Task ToggleAllSkipsDisabledTypesInsteadOfFailingMidway()
+    {
+        SetupUser(this._sut);
+        this._featureGate.Setup(g => g.IsEnabledAsync(It.IsAny<string>())).ReturnsAsync(true);
+        this._featureGate.Setup(g => g.IsEnabledAsync(DisableFeatureKeys.Lures)).ReturnsAsync(false);
+        this._service.Setup(s => s.ToggleCleanMonstersAsync(It.IsAny<string>(), It.IsAny<int>(), 1)).ReturnsAsync(3);
+
+        var result = await this._sut.ToggleAll(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        // The disabled type is skipped, not thrown on, so the rest still apply.
+        this._service.Verify(s => s.ToggleCleanLuresAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        this._service.Verify(s => s.ToggleCleanMonstersAsync(It.IsAny<string>(), It.IsAny<int>(), 1), Times.Once);
+        this._service.Verify(s => s.ToggleCleanGymsAsync(It.IsAny<string>(), It.IsAny<int>(), 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToggleCleanRejectsFortChangesWhichCannotStoreTheFlag()
+    {
+        SetupUser(this._sut);
+
+        var result = await this._sut.ToggleClean("fortchanges", 1);
+
+        Assert.IsType<BadRequestObjectResult>(result);
     }
 
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CleaningServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CleaningServiceTests.cs
@@ -443,7 +443,6 @@ public class CleaningServiceTests
     [InlineData("nest", DisableFeatureKeys.Nests)]
     [InlineData("gym", DisableFeatureKeys.Gyms)]
     [InlineData("maxbattle", DisableFeatureKeys.MaxBattles)]
-    [InlineData("fort", DisableFeatureKeys.FortChanges)]
     public async Task ToggleCleanThrowsFeatureDisabledExceptionPerType(string trackingType, string disableKey)
     {
         // Iteration 2 review surfaced that CleaningService bypassed the alarm-service gates by writing
@@ -463,7 +462,6 @@ public class CleaningServiceTests
             "nest" => this._sut.ToggleCleanNestsAsync("u1", 1, 1),
             "gym" => this._sut.ToggleCleanGymsAsync("u1", 1, 1),
             "maxbattle" => this._sut.ToggleCleanMaxBattlesAsync("u1", 1, 1),
-            "fort" => this._sut.ToggleCleanFortChangesAsync("u1", 1, 1),
             _ => throw new InvalidOperationException(trackingType),
         };
 
@@ -474,4 +472,72 @@ public class CleaningServiceTests
         this._proxy.Verify(p => p.GetByUserAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         this._proxy.Verify(p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()), Times.Never);
     }
+
+    // --- Max Battles duplicated on every toggle (#402) ---
+    // PoracleNG's maxbattle create is insert-only, so the fetch-modify-POST inserted a full duplicate
+    // set per click and left the originals at clean=0. Unbounded growth.
+
+    [Fact]
+    public async Task ToggleCleanMaxBattlesFreesTheRowsBeforeRecreatingThem()
+    {
+        var json = JsonSerializer.SerializeToElement(new[]
+        {
+            new { uid = 82, id = "u1", clean = 0 },
+            new { uid = 83, id = "u1", clean = 0 },
+        });
+        this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "u1")).ReturnsAsync(json);
+        this._proxy.Setup(p => p.BulkDeleteByUidsAsync("maxbattle", "u1", It.IsAny<IEnumerable<int>>())).Returns(Task.CompletedTask);
+        this._proxy.Setup(p => p.CreateAsync("maxbattle", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([84, 85], 0, 0, 2));
+
+        var count = await this._sut.ToggleCleanMaxBattlesAsync("u1", 1, 1);
+
+        Assert.Equal(2, count);
+        this._proxy.Verify(p => p.BulkDeleteByUidsAsync("maxbattle", "u1",
+            It.Is<IEnumerable<int>>(u => u.OrderBy(x => x).SequenceEqual(new[] { 82, 83 }))), Times.Once);
+        this._proxy.Verify(p => p.CreateAsync("maxbattle", "u1", It.IsAny<JsonElement>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToggleCleanMaxBattlesRestoresTheOriginalsWhenRecreatingFails()
+    {
+        var json = JsonSerializer.SerializeToElement(new[] { new { uid = 82, id = "u1", clean = 0 } });
+        this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "u1")).ReturnsAsync(json);
+        this._proxy.Setup(p => p.BulkDeleteByUidsAsync("maxbattle", "u1", It.IsAny<IEnumerable<int>>())).Returns(Task.CompletedTask);
+        this._proxy.SetupSequence(p => p.CreateAsync("maxbattle", "u1", It.IsAny<JsonElement>()))
+            .ThrowsAsync(new HttpRequestException("upstream"))
+            .ReturnsAsync(new TrackingCreateResult([86], 0, 0, 1));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => this._sut.ToggleCleanMaxBattlesAsync("u1", 1, 1));
+
+        // Second create is the restore: a failed toggle must not leave the user with nothing.
+        this._proxy.Verify(p => p.CreateAsync("maxbattle", "u1", It.IsAny<JsonElement>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ToggleCleanMonstersStillUpsertsWithoutDeleting()
+    {
+        var json = JsonSerializer.SerializeToElement(new[] { new { uid = 5, id = "u1", clean = 0 } });
+        this._proxy.Setup(p => p.GetByUserAsync("pokemon", "u1")).ReturnsAsync(json);
+        this._proxy.Setup(p => p.CreateAsync("pokemon", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
+
+        await this._sut.ToggleCleanMonstersAsync("u1", 1, 1);
+
+        this._proxy.Verify(p => p.BulkDeleteByUidsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<int>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StatusNoLongerReportsFortChanges()
+    {
+        this._proxy.Setup(p => p.GetAllTrackingAsync("u1"))
+            .ReturnsAsync(JsonSerializer.SerializeToElement(new { }));
+
+        var status = await this._sut.GetCleanStatusAsync("u1", 1);
+
+        // forts carry no clean column in PoracleNG, so the entry was always a meaningless false.
+        Assert.DoesNotContain("fortChanges", status.Keys);
+        Assert.DoesNotContain("fortchanges", status.Keys);
+    }
+
 }


### PR DESCRIPTION
Closes #402.

Three independent bugs on one page. Each has a different root cause, so each has a different fix.

### (a) Max Battles duplicated every alarm on each click

Cleaning is a fetch-modify-POST that assumes PoracleNG upserts on `uid`. Its maxbattle create is insert-only, so every toggle inserted a full duplicate set while the originals kept `clean=0` — unbounded growth, one set per click, and the flag never actually took effect on the rows the user had.

That type now frees its rows before re-creating them, and restores the originals if the re-create fails. Every other type still upserts and is untouched.

Verified live against dev. Row count holds at 1 and the flag flips, where each click previously added a set:

```
before          rows: 1 [(86, 0)]
toggle on       rows: 1 [(87, 1)]
toggle on       rows: 1 [(88, 1)]
toggle off      rows: 1 [(89, 0)]
```

The uid rotates because delete-then-create is the only route for an insert-only type — the same known consequence as the lure/invasion path, and the reason [#403](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/403) exists.

### (b) Fort changes silently did nothing

PoracleNG has no clean column for forts. Confirmed twice before changing anything: the dev table is `uid, id, profile_no, ping, distance, template, fort_type, include_empty, change_types`, and PoracleNG's own `FortTracking` struct has no Clean field either — so this is upstream design, not a stale database.

The toggle nonetheless returned `{"updated":N}` and showed a success message. Removed from the cleaning page, the status response, the service and the API; the route now returns 400 instead of faking success.

### (c) The bulk toggle applied partially and then failed

`ToggleAll` awaited all ten per-type toggles unconditionally, and each one re-checks its own feature gate. One admin-disabled alarm type threw partway through — the caller got a 403 while everything sequenced before it was already written. It now skips disabled types and returns which were skipped, so the result is honest about what it did.

### One sub-claim was not real

The issue also reported a `fortChanges`/`fortchanges` casing mismatch. `cleaning.component.ts:208` already maps between the two. No change made.

### Not in scope

The fort-change add/edit dialogs and list badge still offer a clean toggle that cannot work, for the same upstream reason as (b). That spans three backend models and six frontend files, so it is filed separately rather than bundled into a fix PR.

### Verification

Backend 1611 passed, frontend 875 passed, ESLint and Prettier clean. New tests cover all three fixes. Four existing tests were replaced rather than adapted, because they asserted the buggy behaviour.