### PR TITLE
fix: GET /api/masterdata/grunts returned 500 to every caller (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`GET /api/masterdata/grunts` returned 500 to every caller** ([#419](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/419)). The proxy requested `/api/config/grunts`, a path neither supported backend serves, so the call always 404'd upstream and `EnsureSuccessStatusCode()` turned that into an unhandled exception — which also left the controller's own "Grunt data not available" branch permanently unreachable. Corrected to `/api/masterdata/grunts`, which PoracleNG does serve; the route now returns the full grunt table. Upstream failures return `null` rather than throwing, matching the sibling calls in the same file, so a real outage produces the intended 404 instead of a 500.
+
 ### Security
 - **`GET /api/config` published the Poracle admin id list to anonymous callers** ([#415](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/415)). The route was `[AllowAnonymous]` and returned the upstream config object whole, so an unauthenticated request to an internet-facing host returned the Discord and Telegram admin ids, the webhook delegation map, the internal provider URL and the static map key. The same admin list is `[Authorize]`-and-admin-gated on `GET /api/admin/poracle-admins`, and PoracleNG gates its own copy behind `X-Poracle-Secret` — PoracleWeb was the one place it was public. The route now requires authentication and returns a `PublicPoracleConfig` projection instead of the raw object. The projection is an allowlist, so a field added upstream is not exposed until someone adds it deliberately. Nothing needed the old payload: the only browser consumers are the Pokemon add and edit dialogs, both behind the auth guard, and both read only the PvP cap fields. `GET /api/config/templates` and `GET /api/config/dts` stay anonymous. If your instance has been reachable from the internet, treat the admin ids and the static key as disclosed.
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleApiProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleApiProxy.cs
@@ -252,11 +252,21 @@ public class PoracleApiProxy(HttpClient httpClient, IConfiguration configuration
         return await response.Content.ReadAsStringAsync();
     }
 
+    /// <summary>
+    /// Invasion grunt master data. The path is <c>/api/masterdata/grunts</c> — <c>/api/config/grunts</c>
+    /// exists in neither supported backend, so this call could only ever 404 and throw.
+    /// </summary>
+    /// <returns>The raw JSON, or <c>null</c> when upstream is unreachable or does not serve it.</returns>
     public async Task<string?> GetGruntsAsync()
     {
-        var request = this.CreateRequest(HttpMethod.Get, $"{this._apiAddress}/api/config/grunts");
+        var request = this.CreateRequest(HttpMethod.Get, $"{this._apiAddress}/api/masterdata/grunts");
         var response = await this._httpClient.SendAsync(request);
-        response.EnsureSuccessStatusCode();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
         return await response.Content.ReadAsStringAsync();
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleApiProxyGruntsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleApiProxyGruntsTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// <c>GetGruntsAsync</c> requested <c>/api/config/grunts</c>, a path neither supported backend serves.
+/// Every call 404'd, <c>EnsureSuccessStatusCode()</c> threw, and <c>GET /api/masterdata/grunts</c>
+/// returned 500 to anonymous callers — while the controller's own "Grunt data not available" branch
+/// sat unreachable. See #419.
+/// </summary>
+public class PoracleApiProxyGruntsTests
+{
+    private const string ApiAddress = "http://localhost:3030";
+
+    private static PoracleApiProxy CreateSut(MockHttpMessageHandler handler) => new(
+        new HttpClient(handler),
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Poracle:ApiAddress"] = ApiAddress,
+                ["Poracle:ApiSecret"] = "test-secret"
+            })
+            .Build());
+
+    [Fact]
+    public async Task GetGruntsAsyncRequestsTheMasterdataPath()
+    {
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ """{"10":{"type":"Dark"}}""");
+        var sut = CreateSut(handler);
+
+        await sut.GetGruntsAsync();
+
+        Assert.Equal($"{ApiAddress}/api/masterdata/grunts", handler.LastRequest?.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task GetGruntsAsyncReturnsTheBodyOn200()
+    {
+        const string body = /*lang=json,strict*/ """{"10":{"type":"Dark","gender":2}}""";
+        var sut = CreateSut(new MockHttpMessageHandler(HttpStatusCode.OK, body));
+
+        Assert.Equal(body, await sut.GetGruntsAsync());
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task GetGruntsAsyncReturnsNullInsteadOfThrowing(HttpStatusCode status)
+    {
+        // The old EnsureSuccessStatusCode() turned every upstream failure into a 500 from our own API
+        // and made the controller's 404 branch dead code.
+        var sut = CreateSut(new MockHttpMessageHandler(status, "{}"));
+
+        Assert.Null(await sut.GetGruntsAsync());
+    }
+
+    private sealed class MockHttpMessageHandler(HttpStatusCode statusCode, string responseBody) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest
+        {
+            get; private set;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes #419.

`GetGruntsAsync` requested `/api/config/grunts`, a path neither supported backend serves. Probing dev directly:

```
/api/config/grunts      -> 404
/api/masterdata/grunts  -> 200
```

So the call always 404'd upstream, `EnsureSuccessStatusCode()` threw, and the route returned 500 — every time, for anonymous and authenticated callers alike.

It also left the controller's own "Grunt data not available" 404 branch permanently unreachable, and the existing unit test was asserting that dead branch against a mock the real proxy could not produce.

### Fix

The path is corrected to `/api/masterdata/grunts`, which returns the real grunt table.

And the method returns `null` on a non-success response instead of throwing, matching `GetAdminRolesAsync` immediately above it in the same file. A genuine upstream outage now produces the intended 404 rather than a 500, and the controller's branch is reachable — so the controller test means something.

### Verification

Live, anonymous:

```
before   GET /api/masterdata/grunts -> 500  {"error":"An unexpected error occurred."}
after    GET /api/masterdata/grunts -> 200  18240 bytes, 85 grunt entries
```

Backend 1619 passed. New proxy tests pin the URL, the 200 body, and null-not-throw across 404 / 401 / 500.

### Not changed

The endpoint stays `[AllowAnonymous]`, consistent with the other masterdata routes, and the Invasions screen still uses its local constants. Wiring the SPA to this data is a feature, not part of fixing the 500 — worth doing separately if the local constants ever drift from upstream.