### PR TITLE
fix: "track all invasions" failed 100% of the time, in two places (#416)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-add-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-add-dialog.component.spec.ts
@@ -1,0 +1,123 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { InvasionAddDialogComponent } from './invasion-add-dialog.component';
+import { AlertDefaultsService } from '../../core/services/alert-defaults.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ConfigService } from '../../core/services/config.service';
+import { I18nService } from '../../core/services/i18n.service';
+import { InvasionService } from '../../core/services/invasion.service';
+import { MasterDataService } from '../../core/services/masterdata.service';
+
+/**
+ * "Track all" posted a single alarm with gruntType: null. PoracleNG rejects an empty grunt_type
+ * ("Grunt type mandatory") and has no catch-all, so the toggle failed 100% of the time while the
+ * save button stayed enabled. It now fans out over the Team Rocket grunts. See #416.
+ */
+describe('InvasionAddDialogComponent — track all (#416)', () => {
+  let created: { gruntType: string | null }[];
+
+  const setup = (): InvasionAddDialogComponent => {
+    created = [];
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { apiHost: 'http://test-api' } },
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: MatSnackBar, useValue: { open: jest.fn() } },
+        { provide: I18nService, useValue: { instant: (k: string) => k } },
+        { provide: AuthService, useValue: { isImpersonating: () => false } },
+        { provide: MasterDataService, useValue: { getPokemon: () => of([]) } },
+        { provide: AlertDefaultsService, useValue: { defaultDistanceKm: () => 1, defaultMode: () => 'areas' } },
+        {
+          provide: InvasionService,
+          useValue: {
+            create: (payload: { gruntType: string | null }) => {
+              created.push(payload);
+              return of({ uid: created.length });
+            },
+          },
+        },
+      ],
+      imports: [InvasionAddDialogComponent],
+    });
+
+    const fixture = TestBed.createComponent(InvasionAddDialogComponent);
+    const component = fixture.componentInstance;
+    component.ngOnInit();
+    return component;
+  };
+
+  it('never sends a null or empty gruntType', () => {
+    const component = setup();
+    component.trackAll.set(true);
+
+    component.save();
+
+    expect(created.length).toBeGreaterThan(0);
+    for (const payload of created) {
+      expect(payload.gruntType).toBeTruthy();
+    }
+  });
+
+  it('creates one alarm per Team Rocket grunt', () => {
+    const component = setup();
+    const expected = component.rocketGrunts().length;
+    component.trackAll.set(true);
+
+    component.save();
+
+    expect(created).toHaveLength(expected);
+  });
+
+  it('covers the leaders and Giovanni, as the hint promises', () => {
+    const component = setup();
+    component.trackAll.set(true);
+
+    component.save();
+
+    const types = created.map(c => c.gruntType);
+    for (const boss of ['cliff', 'arlo', 'sierra', 'giovanni']) {
+      expect(types).toContain(boss);
+    }
+  });
+
+  it('excludes Pokestop event types, which are not Rocket invasions', () => {
+    const component = setup();
+    component.trackAll.set(true);
+
+    component.save();
+
+    const types = created.map(c => c.gruntType);
+    for (const event of ['kecleon', 'gold-stop', 'showcase']) {
+      expect(types).not.toContain(event);
+    }
+  });
+
+  it('still creates only what was ticked when track all is off', () => {
+    const component = setup();
+    component.toggleGrunt('fire');
+    component.toggleGrunt('water');
+
+    component.save();
+
+    expect(created.map(c => c.gruntType).sort()).toEqual(['fire', 'water']);
+  });
+
+  it('does nothing when nothing is selected', () => {
+    const component = setup();
+
+    component.save();
+
+    expect(created).toHaveLength(0);
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-add-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-add-dialog.component.ts
@@ -182,38 +182,17 @@ export class InvasionAddDialogComponent implements OnInit {
   save(): void {
     if (!this.canSave()) return;
 
-    if (this.trackAll()) {
-      this.saving.set(true);
-      const v = this.form.getRawValue();
-      const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
-      this.invasionService
-        .create({
-          clean: v.clean ? 1 : 0,
-          distance: dist,
-          gender: v.gender ?? 0,
-          gruntType: null,
-          ping: v.ping || null,
-          template: v.template || null,
-        })
-        .subscribe({
-          error: () => {
-            this.snackBar.open(this.i18n.instant('INVASIONS.SNACK_FAILED_CREATE'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
-            this.saving.set(false);
-          },
-          next: () => {
-            this.snackBar.open(this.i18n.instant('INVASIONS.SNACK_ALL_CREATED'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
-            this.dialogRef.close(true);
-          },
-        });
-      return;
-    }
+    // "Track all" used to post a single alarm with gruntType: null. PoracleNG has no catch-all --
+    // it rejects an empty grunt_type with "Grunt type mandatory" -- so that call failed every time.
+    // The toggle now means what its hint always claimed: one alarm per Team Rocket grunt type.
+    // Pokestop events are excluded; they are not Rocket invasions and have their own section.
+    const targets = this.trackAll() ? this.rocketGrunts() : this.gruntOptions().filter(o => o.selected);
+    if (targets.length === 0) return;
 
-    const selected = this.gruntOptions().filter(o => o.selected);
-    if (selected.length === 0) return;
     this.saving.set(true);
     const v = this.form.getRawValue();
     const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
-    const creates = selected.map(g =>
+    const creates = targets.map(g =>
       this.invasionService.create({
         clean: v.clean ? 1 : 0,
         distance: dist,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **"Track all invasions" failed every single time, and so did the "All Invasions" quick pick** ([#416](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/416)). Both asked PoracleNG to track invasions with no grunt type — the toggle posted `gruntType: null` and the quick pick shipped with empty filters — and both were coalesced to an empty string on the way out. PoracleNG has no catch-all: it rejects an empty `grunt_type` with `400 Grunt type mandatory`, which PoracleWeb turned into a generic 500 and a "failed to create" toast. The save button was never disabled, so the feature looked available and was not. Both now fan out over the Team Rocket grunt types, which is what the toggle's own hint already promised ("Creates a single alarm for every grunt type, leader, and Giovanni"). Pokestop event types are excluded — they are not Rocket invasions and have their own section. A missing grunt type is now rejected at the API edge with a 400 that says so, instead of being forwarded upstream to fail.
+
+### Fixed
 - **`GET /api/masterdata/grunts` returned 500 to every caller** ([#419](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/419)). The proxy requested `/api/config/grunts`, a path neither supported backend serves, so the call always 404'd upstream and `EnsureSuccessStatusCode()` turned that into an unhandled exception — which also left the controller's own "Grunt data not available" branch permanently unreachable. Corrected to `/api/masterdata/grunts`, which PoracleNG does serve; the route now returns the full grunt table. Upstream failures return `null` rather than throwing, matching the sibling calls in the same file, so a real outage produces the intended 404 instead of a 500.
 
 ### Security

--- a/Core/Pgan.PoracleWebNet.Core.Models/InvasionCreate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/InvasionCreate.cs
@@ -22,6 +22,12 @@ public class InvasionCreate
         get; set;
     }
 
+    /// <summary>
+    /// Required. PoracleNG has no catch-all — an empty value is rejected upstream, so accepting one
+    /// here only converted a clear 400 into an opaque 500. Track everything by posting one alarm per
+    /// grunt type. See #416.
+    /// </summary>
+    [Required(AllowEmptyStrings = false)]
     [StringLength(256)]
     public string? GruntType
     {

--- a/Core/Pgan.PoracleWebNet.Core.Models/InvasionGruntTypes.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/InvasionGruntTypes.cs
@@ -1,0 +1,45 @@
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// The Team Rocket <c>grunt_type</c> values PoracleNG accepts for invasion tracking.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PoracleNG has no catch-all: <c>grunt_type</c> must be a non-empty string, and an empty one is
+/// rejected with <c>400 {"message":"Grunt type mandatory"}</c>. "Track everything" therefore has to be
+/// a fan-out over this list — one row per type — which is also how the invasion table's natural key
+/// (<c>id, profile_no, gender, grunt_type</c>) expects rows to be shaped. See #416.
+/// </para>
+/// <para>
+/// This is the twin of <c>GRUNT_TYPES</c> in
+/// <c>ClientApp/src/app/modules/invasions/invasion-add-dialog.component.ts</c>. The two must stay in
+/// sync; <c>InvasionGruntTypesTests</c> pins the contents so a one-sided edit fails the build.
+/// The frontend list additionally splits <c>mixed</c> into male and female rows for display — the
+/// same <c>grunt_type</c>, differing only by gender — so it has one more entry than this one.
+/// </para>
+/// <para>
+/// Pokestop event types (<c>kecleon</c>, <c>gold-stop</c>, <c>showcase</c>) are deliberately absent.
+/// They are not Team Rocket invasions and are offered separately in the UI.
+/// </para>
+/// </remarks>
+public static class InvasionGruntTypes
+{
+    /// <summary>The eighteen elemental grunt types.</summary>
+    public static IReadOnlyList<string> Elemental { get; } =
+    [
+        "bug", "dark", "dragon", "electric", "fairy", "fighting", "fire", "flying", "ghost",
+        "grass", "ground", "ice", "metal", "normal", "poison", "psychic", "rock", "water"
+    ];
+
+    /// <summary>Grunts that are not tied to a single element.</summary>
+    public static IReadOnlyList<string> Special { get; } = ["mixed", "darkness", "decoy"];
+
+    /// <summary>The three Rocket leaders. Giovanni is separate — he needs a Super Rocket Radar.</summary>
+    public static IReadOnlyList<string> Leaders { get; } = ["cliff", "arlo", "sierra"];
+
+    public const string Giovanni = "giovanni";
+
+    /// <summary>Every Team Rocket grunt type: elemental, special, leaders and Giovanni.</summary>
+    public static IReadOnlyList<string> All { get; } =
+        [.. Elemental, .. Special, .. Leaders, Giovanni];
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -29,7 +29,7 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Invasions);
         model.Id = userId;
-        model.GruntType ??= "";
+        RequireGruntType(model);
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
@@ -44,7 +44,7 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
     public async Task<Invasion> UpdateAsync(string userId, Invasion model)
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Invasions);
-        model.GruntType ??= "";
+        RequireGruntType(model);
         var oldUid = model.Uid;
 
         // PoracleNG guards this type with a natural unique key and its create has no upsert path, so
@@ -141,7 +141,7 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
         foreach (var model in modelList)
         {
             model.Id = userId;
-            model.GruntType ??= "";
+            RequireGruntType(model);
         }
 
         var body = SerializeToElement(modelList);
@@ -153,6 +153,23 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
         }
 
         return modelList;
+    }
+
+    /// <summary>
+    /// PoracleNG rejects an empty <c>grunt_type</c> with <c>400 "Grunt type mandatory"</c> and has no
+    /// catch-all keyword, so coalescing a missing value to <c>""</c> guaranteed a failure that surfaced
+    /// as a generic 500. Fail here instead, where the message says what is actually wrong. Callers that
+    /// want "everything" must fan out over <see cref="InvasionGruntTypes.All"/>. See #416.
+    /// </summary>
+    private static void RequireGruntType(Invasion model)
+    {
+        if (string.IsNullOrWhiteSpace(model.GruntType))
+        {
+            throw new ArgumentException(
+                "grunt_type is required — PoracleNG has no catch-all value. To track everything, "
+                + "create one alarm per InvasionGruntTypes.All entry.",
+                nameof(model));
+        }
     }
 
     private static List<Invasion> DeserializeItems(JsonElement json) =>

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -588,14 +588,23 @@ public partial class QuickPickService(
     // one alarm per leader rather than complicating the QuickPick schema. Giovanni is
     // deliberately excluded (separate `invasion-giovanni` pick, since he spawns from the
     // Super Rocket Radar only).
-    private static readonly string[] LeaderFanOutGruntTypes = ["cliff", "arlo", "sierra"];
+    private static readonly IReadOnlyList<string> LeaderFanOutGruntTypes = InvasionGruntTypes.Leaders;
 
     private async Task<List<int>> ApplyInvasionAsync(
         string userId, int profileNo, QuickPickDefinition definition, QuickPickApplyRequest request)
     {
-        if (definition.Id == "invasion-leader")
+        // "All Invasions" shipped with empty filters, so BuildInvasion produced grunt_type "" and every
+        // apply failed with a 500. PoracleNG has no catch-all, so "all" has to be a fan-out too. See #416.
+        var fanOut = definition.Id switch
         {
-            var invasions = LeaderFanOutGruntTypes.Select(gt => BuildInvasion(definition.Filters, profileNo, request, gt)).ToList();
+            "all-invasions" => InvasionGruntTypes.All,
+            "invasion-leader" => LeaderFanOutGruntTypes,
+            _ => null
+        };
+
+        if (fanOut != null)
+        {
+            var invasions = fanOut.Select(gt => BuildInvasion(definition.Filters, profileNo, request, gt)).ToList();
             var created = await this._invasionService.BulkCreateAsync(userId, invasions);
             return [.. created.Select(i => i.Uid)];
         }
@@ -617,8 +626,6 @@ public partial class QuickPickService(
         {
             invasion.GruntType = gruntTypeOverride;
         }
-
-        invasion.GruntType ??= "";
 
         if (request.Distance.HasValue)
         {

--- a/Tests/Pgan.PoracleWebNet.Tests/Models/InvasionGruntTypesTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Models/InvasionGruntTypesTests.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Tests.Models;
+
+/// <summary>
+/// <see cref="InvasionGruntTypes"/> is the backend twin of the <c>GRUNT_TYPES</c> table in the Angular
+/// invasion dialog. Both drive a "track everything" fan-out, and PoracleNG has no catch-all to fall
+/// back on, so a one-sided edit silently leaves one path tracking fewer grunts than the other. These
+/// tests read the TypeScript and compare. See #416.
+/// </summary>
+public class InvasionGruntTypesTests
+{
+    private const string DialogPath =
+        "Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-add-dialog.component.ts";
+
+    [Fact]
+    public void AllIsTheUnionOfItsParts()
+    {
+        Assert.Equal(
+            [.. InvasionGruntTypes.Elemental, .. InvasionGruntTypes.Special, .. InvasionGruntTypes.Leaders, InvasionGruntTypes.Giovanni],
+            InvasionGruntTypes.All);
+    }
+
+    [Fact]
+    public void AllHasNoDuplicates()
+    {
+        Assert.Equal(InvasionGruntTypes.All.Count, InvasionGruntTypes.All.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void AllIsLowercase()
+    {
+        // grunt_type is matched verbatim upstream; a capitalised entry would just never fire.
+        Assert.All(InvasionGruntTypes.All, t => Assert.Equal(t.ToLowerInvariant(), t));
+    }
+
+    [Fact]
+    public void PokestopEventTypesAreExcluded()
+    {
+        // Kecleon, gold stops and showcases are not Team Rocket invasions. "Track all invasions"
+        // must not silently subscribe a user to them.
+        Assert.DoesNotContain("kecleon", InvasionGruntTypes.All);
+        Assert.DoesNotContain("gold-stop", InvasionGruntTypes.All);
+        Assert.DoesNotContain("showcase", InvasionGruntTypes.All);
+    }
+
+    [Fact]
+    public void MatchesTheAngularDialogList()
+    {
+        var dialog = ReadDialogSource();
+
+        // Each GRUNT_TYPES row looks like: { gruntType: 'fire', invasionId: 7, ... }
+        var frontend = Regex.Matches(dialog, @"gruntType:\s*'([a-z-]+)'")
+            .Select(m => m.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(frontend);
+
+        var backend = InvasionGruntTypes.All.ToHashSet(StringComparer.Ordinal);
+
+        var missingFromBackend = frontend.Except(backend).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var missingFromFrontend = backend.Except(frontend).OrderBy(x => x, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            missingFromBackend.Count == 0,
+            $"The dialog offers grunt types the backend list lacks: {string.Join(", ", missingFromBackend)}. "
+            + "Add them to InvasionGruntTypes or the 'All Invasions' quick pick will skip them.");
+
+        Assert.True(
+            missingFromFrontend.Count == 0,
+            $"InvasionGruntTypes has entries the dialog does not offer: {string.Join(", ", missingFromFrontend)}. "
+            + "Add them to GRUNT_TYPES or the dialog's 'Track all' will skip them.");
+    }
+
+    private static string ReadDialogSource()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Pgan.PoracleWebNet.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir.FullName, DialogPath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Could not find {path}");
+        return File.ReadAllText(path);
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -68,14 +68,14 @@ public class InvasionServiceTests
         this._proxy.Setup(p => p.CreateAsync("invasion", "user1", It.IsAny<JsonElement>()))
             .ReturnsAsync(new TrackingCreateResult([1], 0, 0, 1));
 
-        var result = await this._sut.CreateAsync("user1", new Invasion());
+        var result = await this._sut.CreateAsync("user1", new Invasion { GruntType = "fire" });
         Assert.Equal("user1", result.Id);
     }
 
     [Fact]
     public async Task UpdateAsyncDelegates()
     {
-        var i = new Invasion { Uid = 1 };
+        var i = new Invasion { Uid = 1, GruntType = "fire" };
         this._proxy.Setup(p => p.CreateAsync("invasion", "user1", It.IsAny<JsonElement>()))
             .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
 
@@ -175,26 +175,45 @@ public class InvasionServiceTests
         Assert.Equal(12, await this._sut.CountByUserAsync("u", 1));
     }
 
-    [Fact]
-    public async Task CreateAsyncNormalizesNullGruntType()
+    // These two used to assert that a missing grunt type is coalesced to "". That was the bug:
+    // PoracleNG rejects an empty grunt_type with 400 "Grunt type mandatory" and has no catch-all,
+    // so the coalesce guaranteed a failure that reached the user as a generic 500. See #416.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsyncRejectsMissingGruntTypeInsteadOfSendingItUpstream(string? gruntType)
     {
         this._proxy.Setup(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()))
             .ReturnsAsync(new TrackingCreateResult([1], 0, 0, 1));
 
-        var model = new Invasion { GruntType = null };
-        var result = await this._sut.CreateAsync("u1", model);
-        Assert.Equal("", result.GruntType);
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => this._sut.CreateAsync("u1", new Invasion { GruntType = gruntType }));
+
+        this._proxy.Verify(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task UpdateAsyncRejectsMissingGruntType(string? gruntType)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => this._sut.UpdateAsync("u1", new Invasion { Uid = 1, GruntType = gruntType }));
     }
 
     [Fact]
-    public async Task UpdateAsyncNormalizesNullGruntType()
+    public async Task BulkCreateAsyncRejectsMissingGruntTypeWithoutPartiallyCreating()
     {
-        this._proxy.Setup(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()))
-            .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
+        var models = new List<Invasion>
+        {
+            new() { GruntType = "fire" },
+            new() { GruntType = null },
+        };
 
-        var model = new Invasion { Uid = 1, GruntType = null };
-        var result = await this._sut.UpdateAsync("u1", model);
-        Assert.Equal("", result.GruntType);
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.BulkCreateAsync("u1", models));
+
+        this._proxy.Verify(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()), Times.Never);
     }
 
     [Fact]
@@ -204,7 +223,7 @@ public class InvasionServiceTests
         {
             new() { GruntType = "mixed" },
             new() { GruntType = "dark" },
-            new() { GruntType = null },
+            new() { GruntType = "giovanni" },
         };
         this._proxy.Setup(p => p.CreateAsync("invasion", "u1", It.IsAny<JsonElement>()))
             .ReturnsAsync(new TrackingCreateResult([10, 11, 12], 0, 0, 3));


### PR DESCRIPTION
Closes #416.

The add dialog's Track All toggle posted a single alarm with `gruntType: null`. `InvasionService` coalesced it to `""` and PoracleNG rejected it. Confirmed against dev PoracleNG directly:

```
grunt_type ""      -> 400 {"message":"Grunt type mandatory"}
grunt_type "fire"  -> 200
```

There is no catch-all keyword, and the invasion table has no row with `grunt_type=''` — empty is not a supported wildcard, it is just invalid. PoracleWeb turned that 400 into a generic 500 and a "failed to create" toast, while `canSave()` returned true on the toggle alone, so the control was always enabled and never worked.

### The same bug exists a second time

Not in the original report, found while tracing this one: the **"All Invasions" quick pick** ships with `Filters = []`, so `BuildInvasion` produced the identical empty grunt type and every apply 500'd. Same root cause, same fix, so it is in this PR.

### Fix

Both now fan out — which is what the toggle's own hint always claimed: *"Creates a single alarm for every grunt type, leader, and Giovanni."*

The dialog reuses the multi-select path that already worked. The quick pick fans out over a new `InvasionGruntTypes.All`. All 28 candidate types were probed against dev PoracleNG before writing the list, and every one is accepted. Pokestop events (`kecleon`, `gold-stop`, `showcase`) are excluded — not Rocket invasions, and they have their own section in the UI.

A missing grunt type is now rejected where it can be explained: `[Required]` on `InvasionCreate` gives a 400 for direct API calls, and a service-level guard covers service-to-service callers like quick picks. Nothing silently forwards a value PoracleNG will refuse.

### Keeping the two lists honest

`InvasionGruntTypes` is the backend twin of the dialog's `GRUNT_TYPES` table. Two lists in two languages both driving a "track everything" fan-out is exactly how one path quietly ends up covering fewer grunts than the other, so `InvasionGruntTypesTests` parses the TypeScript and compares — a one-sided edit fails the build.

### Verification

Live against dev:

```
POST /api/invasions  gruntType null   -> 400   (was 500)
POST /api/invasions  gruntType ""     -> 400   (was 500)
POST /api/invasions  gruntType fire   -> 201

POST /api/quick-picks/all-invasions/apply
    -> 200, 25 rows, no empty grunt_type       (was 500, 0 rows created)
POST /api/quick-picks/invasion-leader/apply
    -> 200, 3 rows: arlo cliff sierra          (unchanged)
```

Backend 1628 passed, frontend 881 passed, ESLint and Prettier clean. New: a dialog spec covering the fan-out, the leader/Giovanni coverage the hint promises, and the event-type exclusion.

Two existing tests asserted the coalesce to `""`. That was the bug, so they are replaced rather than adapted.

### Note

`INVASIONS.SNACK_ALL_CREATED` is now unused — the fan-out reports a count like the multi-select path does. Left in the locale files rather than touching all ten while #425 is open on i18n.