### PR TITLE
fix: editing a Max Battle wiped its move and evolution filters (#412)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.spec.ts
@@ -1,0 +1,119 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { MaxBattleEditDialogComponent } from './max-battle-edit-dialog.component';
+import { MaxBattle, MaxBattleUpdate } from '../../core/models';
+import { AuthService } from '../../core/services/auth.service';
+import { ConfigService } from '../../core/services/config.service';
+import { I18nService } from '../../core/services/i18n.service';
+import { IconService } from '../../core/services/icon.service';
+import { MasterDataService } from '../../core/services/masterdata.service';
+import { MaxBattleService } from '../../core/services/max-battle.service';
+
+/**
+ * The edit dialog hardcoded `move: 9000` and `evolution: 9000` (the "any" sentinel) while reading
+ * every adjacent field off the existing alarm. Neither dialog can set those filters -- they come from
+ * the bot -- so changing the distance silently destroyed them and widened what the user got alerted
+ * on, with no way to put them back from the UI. See #412.
+ */
+describe('MaxBattleEditDialogComponent — filter preservation (#412)', () => {
+  const ANY = 9000;
+
+  /** Charizard, filtered to a specific move and evolution. */
+  const item: MaxBattle = {
+    id: 'user1',
+    uid: 79,
+    clean: 0,
+    distance: 100,
+    evolution: 3,
+    form: 0,
+    gmax: 1,
+    level: 7,
+    move: 14,
+    ping: '',
+    pokemonId: 6,
+    profileNo: 1,
+    stationId: null,
+    template: 'default',
+  };
+
+  const setup = (overrides: Partial<MaxBattle> = {}) => {
+    const sent: MaxBattleUpdate[] = [];
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { apiHost: 'http://test-api' } },
+        { provide: MAT_DIALOG_DATA, useValue: { item: { ...item, ...overrides } } },
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: MatSnackBar, useValue: { open: jest.fn() } },
+        { provide: I18nService, useValue: { instant: (k: string) => k } },
+        { provide: IconService, useValue: { getPokemonUrl: () => '' } },
+        { provide: MasterDataService, useValue: { getPokemonName: () => 'Charizard' } },
+        { provide: AuthService, useValue: { isImpersonating: () => false } },
+        {
+          provide: MaxBattleService,
+          useValue: {
+            update: (_uid: number, payload: MaxBattleUpdate) => {
+              sent.push(payload);
+              return of({});
+            },
+          },
+        },
+      ],
+      imports: [MaxBattleEditDialogComponent],
+    });
+
+    const component = TestBed.createComponent(MaxBattleEditDialogComponent).componentInstance;
+    return { component, sent };
+  };
+
+  it('keeps the move filter when only the distance changes', () => {
+    const { component, sent } = setup();
+    component.form.controls.distanceMode.setValue('distance');
+    component.form.controls.distanceKm.setValue(8);
+
+    component.save();
+
+    expect(sent[0].move).toBe(14);
+    expect(sent[0].move).not.toBe(ANY);
+  });
+
+  it('keeps the evolution filter when only the distance changes', () => {
+    const { component, sent } = setup();
+    component.form.controls.distanceMode.setValue('distance');
+    component.form.controls.distanceKm.setValue(8);
+
+    component.save();
+
+    expect(sent[0].evolution).toBe(3);
+    expect(sent[0].evolution).not.toBe(ANY);
+  });
+
+  it('still sends the edited distance', () => {
+    const { component, sent } = setup();
+    component.form.controls.distanceMode.setValue('distance');
+    component.form.controls.distanceKm.setValue(8);
+
+    component.save();
+
+    expect(sent[0].distance).toBe(8000);
+  });
+
+  it('leaves an unfiltered alarm unfiltered', () => {
+    const { component, sent } = setup({ evolution: ANY, move: ANY });
+
+    component.save();
+
+    expect(sent[0].move).toBe(ANY);
+    expect(sent[0].evolution).toBe(ANY);
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.ts
@@ -153,11 +153,15 @@ export class MaxBattleEditDialogComponent {
     const update: MaxBattleUpdate = {
       clean: preserve(item.clean, AUTO_DELETE, values.clean ? 1 : 0),
       distance: distanceMeters,
-      evolution: 9000,
+      // Carried through from the existing alarm, not reset to the 9000 "any" sentinel. Neither
+      // dialog can set these -- they come from the bot -- so hardcoding 9000 here meant any
+      // unrelated edit, a distance change included, silently destroyed the user's filter and
+      // widened what they get alerted on. See #412.
+      evolution: item.evolution,
       form: item.form,
       gmax: gmaxVal,
       level: levelVal,
-      move: 9000,
+      move: item.move,
       ping: values.ping || '',
       pokemonId: item.pokemonId,
       stationId: null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Editing a Max Battle alarm destroyed its move and evolution filters** ([#412](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/412)). The edit dialog hardcoded `move: 9000` and `evolution: 9000` — the "any" sentinel — while reading every neighbouring field off the existing alarm. Changing the distance, or anything else, therefore reset both filters and widened what the user got alerted on. Neither dialog can set those filters (they come from the bot), so once wiped they could only be restored through the bot or a direct API call, and the card's move pill simply vanished. Both values are now carried through from the existing alarm. The backend was never at fault: `MaxBattleUpdate` treats null as "leave alone", and an update omitting the two fields always preserved them.
+
+### Fixed
 - **"Track all invasions" failed every single time, and so did the "All Invasions" quick pick** ([#416](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/416)). Both asked PoracleNG to track invasions with no grunt type — the toggle posted `gruntType: null` and the quick pick shipped with empty filters — and both were coalesced to an empty string on the way out. PoracleNG has no catch-all: it rejects an empty `grunt_type` with `400 Grunt type mandatory`, which PoracleWeb turned into a generic 500 and a "failed to create" toast. The save button was never disabled, so the feature looked available and was not. Both now fan out over the Team Rocket grunt types, which is what the toggle's own hint already promised ("Creates a single alarm for every grunt type, leader, and Giovanni"). Pokestop event types are excluded — they are not Rocket invasions and have their own section. A missing grunt type is now rejected at the API edge with a 400 that says so, instead of being forwarded upstream to fail.
 
 ### Fixed


### PR DESCRIPTION
Closes #412.

The edit dialog's `save()` hardcoded `move: 9000` and `evolution: 9000` — the "any" sentinel — while reading every neighbouring field off the existing alarm. Changing the distance, or anything else in the dialog, therefore destroyed both filters and broadened alerting past what the user had configured.

Neither dialog exposes a control for these; they're set from the bot. So once wiped they could only be restored through the bot or a direct API call, and the card's move pill simply vanished — the app displayed a filter it gave you no way to re-enter.

### The backend was never at fault

`MaxBattleUpdate.Move` and `.Evolution` are `int?`, and `ApplyUpdate` skips nulls, so an update omitting them always preserved them. Both are now carried through from the existing alarm, the same way `form` already was.

### Verification

Live, the same edit sent both ways:

```
start                      uid=41  distance=100   move=14    evolution=3
fixed payload, dist 8000   uid=42  distance=8000  move=14    evolution=3
old payload,   dist 8000   uid=43  distance=8000  move=9000  evolution=9000
```

The second line is the fix; the third is the old dialog payload, included to show the repro is real and not a mis-set fixture.

Frontend 885 passed, ESLint and Prettier clean. New spec covers move and evolution surviving a distance-only edit, the distance still being applied, and an already-unfiltered alarm staying unfiltered.

### Swept for the same shape

Checked the other nine edit dialogs. The only other `9000` literals are `values.maxCp ?? 9000` and `values.maxWeight ?? 9000000` in the Pokemon dialog — fallbacks behind real controls, not overwrites. This was the only instance.

### Worth knowing

The uid rotates on each update (41 → 42 → 43 above) because Max Battles is insert-only upstream — that's #403, not something this PR introduces.

Also unchanged: there is still no UI to *set* a move or evolution filter, and the list renders a pill for move but nothing for evolution, so an evolution filter stays invisible. Adding those controls is a feature, not part of stopping the data loss.