### PR TITLE
fix: editing a quick-pick alarm made the quick pick unremovable (#403)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
@@ -63,6 +63,9 @@ public static class ServiceCollectionExtensions
 
         // Register Services
         services.AddScoped<IMonsterService, MonsterService>();
+        // Keeps quick-pick tracked uids pointing at live rows when an edit rotates them (#403).
+        // Registered before the alarm services, which all depend on it.
+        services.AddScoped<ITrackedUidRemapper, TrackedUidRemapper>();
         services.AddScoped<IRaidService, RaidService>();
         services.AddScoped<IEggService, EggService>();
         services.AddScoped<IQuestService, QuestService>();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Editing a quick-pick alarm made that quick pick impossible to remove** ([#403](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/403)). PoracleNG rewrites a tracking row on edit for every alarm type except monsters, so the row comes back with a new uid. Quick-pick applied state stores the uids captured at apply time, so after any edit the stored uid pointed at a row that no longer existed: **Remove** deleted nothing and still reported success, and the next page load — seeing none of the tracked uids alive — decided the user had deleted the alarms by hand and cleared the applied state, so the UI stopped offering to remove it at all. The alarm kept firing with no way to get rid of it short of deleting it manually. Alarm edits now move the stored uid with the row. A regression test fails the build if a new alarm service rotates uids without wiring this up.
+
+### Fixed
 - **Editing a Max Battle alarm destroyed its move and evolution filters** ([#412](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/412)). The edit dialog hardcoded `move: 9000` and `evolution: 9000` — the "any" sentinel — while reading every neighbouring field off the existing alarm. Changing the distance, or anything else, therefore reset both filters and widened what the user got alerted on. Neither dialog can set those filters (they come from the bot), so once wiped they could only be restored through the bot or a direct API call, and the card's move pill simply vanished. Both values are now carried through from the existing alarm. The backend was never at fault: `MaxBattleUpdate` treats null as "leave alone", and an update omitting the two fields always preserved them.
 
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IQuickPickAppliedStateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IQuickPickAppliedStateRepository.cs
@@ -6,6 +6,12 @@ public interface IQuickPickAppliedStateRepository
 {
     public Task<QuickPickAppliedState?> GetAsync(string userId, int profileNo, string quickPickId);
     public Task<List<QuickPickAppliedState>> GetByUserAndProfileAsync(string userId, int profileNo);
+
+    /// <summary>
+    /// Every applied state for the user across all profiles. Used by the uid remapper, which cannot know
+    /// which profile an edited alarm belongs to.
+    /// </summary>
+    public Task<List<QuickPickAppliedState>> GetByUserAsync(string userId);
     public Task CreateOrUpdateAsync(QuickPickAppliedState state);
     public Task DeleteAsync(string userId, int profileNo, string quickPickId);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ITrackedUidRemapper.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ITrackedUidRemapper.cs
@@ -1,0 +1,27 @@
+namespace Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+/// <summary>
+/// Keeps quick-pick applied state pointing at live alarm rows when a uid rotates.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PoracleNG implements a tracking edit as delete-and-insert for every type except monsters, so the row
+/// comes back with a new uid. Quick-pick applied state persists the uids captured at apply time, and
+/// removal deletes by those uids — so after any edit, removal deleted nothing, reported 204, and the
+/// alarm kept firing. Worse, the summary read then saw zero surviving uids, concluded the user had
+/// deleted the alarms by hand, and cleared the applied state, leaving no way to remove it from the UI
+/// at all. See #403.
+/// </para>
+/// <para>
+/// Alarm services call this whenever they observe a rotation, so the stored uid follows the row.
+/// It is deliberately best-effort: a failure here must not fail an edit that already succeeded.
+/// </para>
+/// </remarks>
+public interface ITrackedUidRemapper
+{
+    /// <summary>
+    /// Rewrites <paramref name="oldUid"/> to <paramref name="newUid"/> in every applied state belonging to
+    /// <paramref name="userId"/> for <paramref name="alarmType"/>. A no-op when no quick pick tracks the uid.
+    /// </summary>
+    public Task RemapAsync(string userId, string alarmType, int oldUid, int newUid);
+}

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/QuickPickAppliedStateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/QuickPickAppliedStateRepository.cs
@@ -35,6 +35,16 @@ public class QuickPickAppliedStateRepository(PoracleWebContext context) : IQuick
         return [.. entities.Select(MapToModel)];
     }
 
+    public async Task<List<QuickPickAppliedState>> GetByUserAsync(string userId)
+    {
+        var entities = await this._context.QuickPickAppliedStates
+            .AsNoTracking()
+            .Where(s => s.UserId == userId)
+            .ToListAsync();
+
+        return [.. entities.Select(MapToModel)];
+    }
+
     public async Task CreateOrUpdateAsync(QuickPickAppliedState state)
     {
         var entity = await this._context.QuickPickAppliedStates

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<EggService> logger) : IEggService
+public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<EggService> logger, ITrackedUidRemapper uidRemapper) : IEggService
 {
     private const string TrackingType = "egg";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<EggService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Egg>> GetByUserAsync(string userId, int profileNo)
     {
@@ -52,7 +53,7 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<FortChangeService> logger) : IFortChangeService
+public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<FortChangeService> logger, ITrackedUidRemapper uidRemapper) : IFortChangeService
 {
     private const string TrackingType = "fort";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<FortChangeService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<FortChange>> GetByUserAsync(string userId, int profileNo)
     {
@@ -50,7 +51,7 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<GymService> logger) : IGymService
+public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<GymService> logger, ITrackedUidRemapper uidRemapper) : IGymService
 {
     private const string TrackingType = "gym";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<GymService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Gym>> GetByUserAsync(string userId, int profileNo)
     {
@@ -50,7 +51,7 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<InvasionService> logger) : IInvasionService
+public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<InvasionService> logger, ITrackedUidRemapper uidRemapper) : IInvasionService
 {
     private const string TrackingType = "invasion";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<InvasionService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Invasion>> GetByUserAsync(string userId, int profileNo)
     {
@@ -58,7 +59,8 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
             oldUid,
             original is null ? null : SerializeToElement(original),
             SerializeToElement(model),
-            this._logger);
+            this._logger,
+            this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<LureService> logger) : ILureService
+public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<LureService> logger, ITrackedUidRemapper uidRemapper) : ILureService
 {
     private const string TrackingType = "lure";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<LureService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Lure>> GetByUserAsync(string userId, int profileNo)
     {
@@ -56,7 +57,8 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
             oldUid,
             original is null ? null : SerializeToElement(original),
             SerializeToElement(model),
-            this._logger);
+            this._logger,
+            this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
@@ -5,10 +5,11 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<MaxBattleService> logger) : IMaxBattleService
+public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<MaxBattleService> logger, ITrackedUidRemapper uidRemapper) : IMaxBattleService
 {
     private const string TrackingType = "maxbattle";
     private readonly ILogger<MaxBattleService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
 
@@ -45,7 +46,8 @@ public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate 
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.MaxBattles);
         // MaxBattle is insert-only in PoracleNG (no dedup/upsert).
         // Delete the old alarm first, then create a replacement.
-        await this._proxy.DeleteByUidAsync(TrackingType, userId, model.Uid);
+        var oldUid = model.Uid;
+        await this._proxy.DeleteByUidAsync(TrackingType, userId, oldUid);
 
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
@@ -54,6 +56,9 @@ public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate 
         {
             model.Uid = (int)result.NewUids[0];
         }
+
+        // Quick-pick applied state stores uids captured at apply time; follow the row. See #403.
+        await this._uidRemapper.RemapAsync(userId, TrackingType, oldUid, model.Uid);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/NaturalKeyTrackingUpdate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NaturalKeyTrackingUpdate.cs
@@ -38,7 +38,8 @@ internal static partial class NaturalKeyTrackingUpdate
         int oldUid,
         JsonElement? original,
         JsonElement updated,
-        ILogger logger)
+        ILogger logger,
+        ITrackedUidRemapper? uidRemapper = null)
     {
         // Not an edit: nothing to free up, so this is an ordinary create.
         if (oldUid <= 0)
@@ -52,7 +53,15 @@ internal static partial class NaturalKeyTrackingUpdate
         try
         {
             var result = await proxy.CreateAsync(trackingType, userId, updated);
-            return result.NewUids.Count > 0 ? (int)result.NewUids[0] : oldUid;
+            var newUid = result.NewUids.Count > 0 ? (int)result.NewUids[0] : oldUid;
+
+            // Quick-pick applied state stores uids captured at apply time; follow the row. See #403.
+            if (uidRemapper != null)
+            {
+                await uidRemapper.RemapAsync(userId, trackingType, oldUid, newUid);
+            }
+
+            return newUid;
         }
         catch (Exception ex)
         {

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<NestService> logger) : INestService
+public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<NestService> logger, ITrackedUidRemapper uidRemapper) : INestService
 {
     private const string TrackingType = "nest";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<NestService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Nest>> GetByUserAsync(string userId, int profileNo)
     {
@@ -50,7 +51,7 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<QuestService> logger) : IQuestService
+public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<QuestService> logger, ITrackedUidRemapper uidRemapper) : IQuestService
 {
     private const string TrackingType = "quest";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<QuestService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Quest>> GetByUserAsync(string userId, int profileNo)
     {
@@ -50,7 +51,7 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -5,12 +5,13 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<RaidService> logger) : IRaidService
+public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, ILogger<RaidService> logger, ITrackedUidRemapper uidRemapper) : IRaidService
 {
     private const string TrackingType = "raid";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
     private readonly ILogger<RaidService> _logger = logger;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     public async Task<IEnumerable<Raid>> GetByUserAsync(string userId, int profileNo)
     {
@@ -50,7 +51,7 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackedUidRemapper.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackedUidRemapper.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Core.Services;
+
+/// <inheritdoc cref="ITrackedUidRemapper"/>
+public partial class TrackedUidRemapper(
+    IQuickPickAppliedStateRepository appliedStateRepository,
+    ILogger<TrackedUidRemapper> logger) : ITrackedUidRemapper
+{
+    private readonly IQuickPickAppliedStateRepository _appliedStateRepository = appliedStateRepository;
+    private readonly ILogger<TrackedUidRemapper> _logger = logger;
+
+    public async Task RemapAsync(string userId, string alarmType, int oldUid, int newUid)
+    {
+        if (oldUid == newUid || oldUid <= 0 || newUid <= 0 || string.IsNullOrEmpty(userId))
+        {
+            return;
+        }
+
+        try
+        {
+            // Scanned across every profile: an alarm edit does not tell us which profile the row belongs
+            // to, and a uid is unique per user anyway, so a match in any profile is the right one.
+            var states = await this._appliedStateRepository.GetByUserAsync(userId);
+
+            foreach (var state in states)
+            {
+                if (!string.Equals(state.AlarmType, alarmType, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var index = state.TrackedUids.IndexOf(oldUid);
+                if (index < 0)
+                {
+                    continue;
+                }
+
+                state.TrackedUids[index] = newUid;
+                await this._appliedStateRepository.CreateOrUpdateAsync(state);
+                LogRemapped(this._logger, state.QuickPickId, alarmType, oldUid, newUid);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The edit itself already succeeded. Losing the remap costs the user a working "remove"
+            // button on one quick pick; failing the request would cost them the edit. Log and move on.
+            LogRemapFailed(this._logger, ex, alarmType, oldUid, newUid);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Quick pick {QuickPickId} now tracks {AlarmType} uid {NewUid} in place of rotated uid {OldUid}.")]
+    private static partial void LogRemapped(ILogger logger, string quickPickId, string alarmType, int oldUid, int newUid);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Could not remap quick-pick tracked {AlarmType} uid {OldUid} to {NewUid}; removing that quick pick may leave the alarm behind.")]
+    private static partial void LogRemapFailed(ILogger logger, Exception exception, string alarmType, int oldUid, int newUid);
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -29,7 +29,8 @@ internal static partial class TrackingUpdateReconciler
         string userId,
         int oldUid,
         TrackingCreateResult result,
-        ILogger logger)
+        ILogger logger,
+        ITrackedUidRemapper? uidRemapper = null)
     {
         // oldUid <= 0 means this was not an edit. No insert, or the same uid back, means the upsert worked.
         if (oldUid <= 0 || result.Inserts <= 0 || result.NewUids.Count == 0)
@@ -52,6 +53,12 @@ internal static partial class TrackingUpdateReconciler
             // The new row already carries the user's intended settings, so the edit succeeded. Surface the
             // leftover duplicate for triage rather than failing an update that actually applied.
             LogStaleDeleteFailed(logger, ex, trackingType, oldUid, newUid);
+        }
+
+        // Quick-pick applied state stores uids captured at apply time; follow the row. See #403.
+        if (uidRemapper != null)
+        {
+            await uidRemapper.RemapAsync(userId, trackingType, oldUid, newUid);
         }
 
         return newUid;

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/EggServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/EggServiceTests.cs
@@ -18,11 +18,12 @@ public class EggServiceTests
     private readonly EggService _sut;
 
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
 
     public EggServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new EggService(this._proxy.Object, this._featureGate.Object, NullLogger<EggService>.Instance);
+        this._sut = new EggService(this._proxy.Object, this._featureGate.Object, NullLogger<EggService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
@@ -17,13 +17,14 @@ public class FortChangeServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly FortChangeService _sut;
     private static readonly string[] stringArray = ["name", "location"];
 
     public FortChangeServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new FortChangeService(this._proxy.Object, this._featureGate.Object, NullLogger<FortChangeService>.Instance);
+        this._sut = new FortChangeService(this._proxy.Object, this._featureGate.Object, NullLogger<FortChangeService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/GymServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/GymServiceTests.cs
@@ -16,12 +16,13 @@ public class GymServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly GymService _sut;
 
     public GymServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new GymService(this._proxy.Object, this._featureGate.Object, NullLogger<GymService>.Instance);
+        this._sut = new GymService(this._proxy.Object, this._featureGate.Object, NullLogger<GymService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -17,12 +17,13 @@ public class InvasionServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly InvasionService _sut;
 
     public InvasionServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new InvasionService(this._proxy.Object, this._featureGate.Object, NullLogger<InvasionService>.Instance);
+        this._sut = new InvasionService(this._proxy.Object, this._featureGate.Object, NullLogger<InvasionService>.Instance, this._uidRemapper.Object);
         // The natural-key replace strategy reads the original row and frees the key first.
         this._proxy.Setup(p => p.GetByUserAsync("invasion", It.IsAny<string>()))
             .ReturnsAsync(JsonSerializer.SerializeToElement(Array.Empty<object>()));

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/LureServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/LureServiceTests.cs
@@ -16,12 +16,13 @@ public class LureServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly LureService _sut;
 
     public LureServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new LureService(this._proxy.Object, this._featureGate.Object, NullLogger<LureService>.Instance);
+        this._sut = new LureService(this._proxy.Object, this._featureGate.Object, NullLogger<LureService>.Instance, this._uidRemapper.Object);
         // The natural-key replace strategy reads the original row and frees the key first.
         this._proxy.Setup(p => p.GetByUserAsync("lure", It.IsAny<string>()))
             .ReturnsAsync(JsonSerializer.SerializeToElement(Array.Empty<object>()));
@@ -245,4 +246,20 @@ public class LureServiceTests
     private static JsonElement ItemsJson(int uid) =>
         JsonSerializer.SerializeToElement(new[] { new { uid, id = "user1" } });
 
+
+    // A rotated uid orphans any quick pick that created the alarm. See #403.
+    [Fact]
+    public async Task UpdateAsyncRepointsQuickPickTrackedUidAtTheReplacementRow()
+    {
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "user1"))
+            .ReturnsAsync(CreateJsonArray(new { uid = 239, id = "user1", lure_id = 501, distance = 500 }));
+        this._proxy.Setup(p => p.DeleteByUidAsync("lure", "user1", 239)).Returns(Task.CompletedTask);
+        this._proxy.Setup(p => p.CreateAsync("lure", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([240], 0, 0, 1));
+
+        var result = await this._sut.UpdateAsync("user1", new Lure { Uid = 239, LureId = 501, Distance = 600 });
+
+        Assert.Equal(240, result.Uid);
+        this._uidRemapper.Verify(r => r.RemapAsync("user1", "lure", 239, 240), Times.Once);
+    }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
@@ -16,12 +16,13 @@ public class MaxBattleServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly MaxBattleService _sut;
 
     public MaxBattleServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new MaxBattleService(this._proxy.Object, this._featureGate.Object, Mock.Of<ILogger<MaxBattleService>>());
+        this._sut = new MaxBattleService(this._proxy.Object, this._featureGate.Object, Mock.Of<ILogger<MaxBattleService>>(), this._uidRemapper.Object);
     }
 
     [Fact]
@@ -321,5 +322,20 @@ public class MaxBattleServiceTests
         var jsonStr = JsonSerializer.Serialize(items, SnakeCaseOptions);
         using var doc = JsonDocument.Parse(jsonStr);
         return doc.RootElement.Clone();
+    }
+
+    // MaxBattle is insert-only upstream, so every edit rotates the uid and orphans any quick pick
+    // that created the alarm. See #403.
+    [Fact]
+    public async Task UpdateAsyncRepointsQuickPickTrackedUidAtTheReplacementRow()
+    {
+        this._proxy.Setup(p => p.DeleteByUidAsync("maxbattle", "user1", 82)).Returns(Task.CompletedTask);
+        this._proxy.Setup(p => p.CreateAsync("maxbattle", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([83], 0, 0, 1));
+
+        var result = await this._sut.UpdateAsync("user1", new MaxBattle { Uid = 82 });
+
+        Assert.Equal(83, result.Uid);
+        this._uidRemapper.Verify(r => r.RemapAsync("user1", "maxbattle", 82, 83), Times.Once);
     }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/NestServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/NestServiceTests.cs
@@ -16,12 +16,13 @@ public class NestServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly NestService _sut;
 
     public NestServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new NestService(this._proxy.Object, this._featureGate.Object, NullLogger<NestService>.Instance);
+        this._sut = new NestService(this._proxy.Object, this._featureGate.Object, NullLogger<NestService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuestServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuestServiceTests.cs
@@ -16,12 +16,13 @@ public class QuestServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly QuestService _sut;
 
     public QuestServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new QuestService(this._proxy.Object, this._featureGate.Object, NullLogger<QuestService>.Instance);
+        this._sut = new QuestService(this._proxy.Object, this._featureGate.Object, NullLogger<QuestService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
@@ -16,12 +16,13 @@ public class RaidServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _uidRemapper = new();
     private readonly RaidService _sut;
 
     public RaidServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new RaidService(this._proxy.Object, this._featureGate.Object, NullLogger<RaidService>.Instance);
+        this._sut = new RaidService(this._proxy.Object, this._featureGate.Object, NullLogger<RaidService>.Instance, this._uidRemapper.Object);
     }
 
     [Fact]
@@ -242,6 +243,32 @@ public class RaidServiceTests
 
         this._proxy.Verify(p => p.DeleteByUidAsync("raid", "user1", 41), Times.Once);
         Assert.Equal(42, result.Uid);
+    }
+
+    // A rotated uid orphans any quick pick that created the alarm: removal deletes by the stored uid,
+    // finds nothing, reports success, and the alarm keeps firing. See #403.
+
+    [Fact]
+    public async Task UpdateAsyncRepointsQuickPickTrackedUidAtTheNewRow()
+    {
+        this._proxy.Setup(p => p.CreateAsync("raid", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([42], 0, 0, 1));
+
+        await this._sut.UpdateAsync("user1", new Raid { Uid = 41 });
+
+        this._uidRemapper.Verify(r => r.RemapAsync("user1", "raid", 41, 42), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncDoesNotRemapWhenTheUidSurvivesTheUpsert()
+    {
+        this._proxy.Setup(p => p.CreateAsync("raid", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
+
+        await this._sut.UpdateAsync("user1", new Raid { Uid = 41 });
+
+        this._uidRemapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperCoverageTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperCoverageTests.cs
@@ -1,0 +1,49 @@
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// A new alarm service that rotates uids but never remaps them reintroduces #403 silently: quick-pick
+/// removal reports success, deletes nothing, and the summary read then wipes the applied state so the
+/// user cannot retry. Nothing about that failure is visible without knowing to look, so it is pinned here.
+/// </summary>
+public class TrackedUidRemapperCoverageTests
+{
+    /// <summary>
+    /// Every service whose update rotates the uid — all of them except monsters, which PoracleNG
+    /// genuinely upserts in place.
+    /// </summary>
+    public static TheoryData<Type> RotatingServices =>
+    [
+        typeof(RaidService), typeof(EggService), typeof(QuestService), typeof(NestService),
+        typeof(GymService), typeof(FortChangeService), typeof(InvasionService), typeof(LureService),
+        typeof(MaxBattleService)
+    ];
+
+    [Theory]
+    [MemberData(nameof(RotatingServices))]
+    public void RotatingServicesTakeTheUidRemapper(Type serviceType)
+    {
+        var takesRemapper = serviceType
+            .GetConstructors()
+            .Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(ITrackedUidRemapper)));
+
+        Assert.True(
+            takesRemapper,
+            $"{serviceType.Name} rewrites the row on update, so its uid changes. Without ITrackedUidRemapper "
+            + "any quick pick that created the alarm keeps pointing at the dead uid and can never remove it.");
+    }
+
+    [Fact]
+    public void MonsterServiceDoesNotNeedIt()
+    {
+        // Documented deliberately: monsters are the one type PoracleNG updates in place, so there is no
+        // rotation to follow. If that ever changes, this test failing is the reminder.
+        var takesRemapper = typeof(MonsterService)
+            .GetConstructors()
+            .Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(ITrackedUidRemapper)));
+
+        Assert.False(takesRemapper);
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
+using Pgan.PoracleWebNet.Core.Models;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// PoracleNG rewrites a tracking row on edit, so the uid changes. Quick-pick applied state stores the
+/// uids captured at apply time, so without this the stored uids went stale: removal deleted nothing,
+/// reported 204, and the summary read then wiped the applied state — leaving an alarm that fired forever
+/// with no UI to remove it. See #403.
+/// </summary>
+public class TrackedUidRemapperTests
+{
+    private readonly Mock<IQuickPickAppliedStateRepository> _repo = new();
+    private readonly TrackedUidRemapper _sut;
+
+    public TrackedUidRemapperTests() =>
+        this._sut = new TrackedUidRemapper(this._repo.Object, NullLogger<TrackedUidRemapper>.Instance);
+
+    private static QuickPickAppliedState State(string quickPickId, string alarmType, params int[] uids) => new()
+    {
+        UserId = "u1",
+        ProfileNo = 1,
+        QuickPickId = quickPickId,
+        AlarmType = alarmType,
+        TrackedUids = [.. uids]
+    };
+
+    [Fact]
+    public async Task RewritesTheRotatedUidInPlace()
+    {
+        var state = State("lure-glacial", "lure", 239);
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ReturnsAsync([state]);
+
+        await this._sut.RemapAsync("u1", "lure", 239, 240);
+
+        Assert.Equal([240], state.TrackedUids);
+        this._repo.Verify(r => r.CreateOrUpdateAsync(state), Times.Once);
+    }
+
+    [Fact]
+    public async Task LeavesTheOtherTrackedUidsAlone()
+    {
+        var state = State("raid-legendary", "raid", 10, 11, 12);
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ReturnsAsync([state]);
+
+        await this._sut.RemapAsync("u1", "raid", 11, 99);
+
+        Assert.Equal([10, 99, 12], state.TrackedUids);
+    }
+
+    [Fact]
+    public async Task IgnoresAppliedStateForAnotherAlarmType()
+    {
+        // uids are only unique within a type, so a raid uid 5 must not rewrite a lure's uid 5.
+        var lure = State("lure-glacial", "lure", 5);
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ReturnsAsync([lure]);
+
+        await this._sut.RemapAsync("u1", "raid", 5, 6);
+
+        Assert.Equal([5], lure.TrackedUids);
+        this._repo.Verify(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickAppliedState>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RemapsAcrossEveryProfileTheUserHas()
+    {
+        // An alarm edit does not say which profile the row belongs to, and a uid is unique per user,
+        // so whichever profile's state references it is the right one.
+        var p2 = State("gym-team", "gym", 77);
+        p2.ProfileNo = 2;
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ReturnsAsync([p2]);
+
+        await this._sut.RemapAsync("u1", "gym", 77, 78);
+
+        Assert.Equal([78], p2.TrackedUids);
+    }
+
+    [Fact]
+    public async Task DoesNothingWhenNoQuickPickTracksTheUid()
+    {
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ReturnsAsync([State("quest-stardust", "quest", 1)]);
+
+        await this._sut.RemapAsync("u1", "quest", 500, 501);
+
+        this._repo.Verify(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickAppliedState>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(5, 0)]
+    [InlineData(7, 7)]
+    public async Task SkipsNonRotations(int oldUid, int newUid)
+    {
+        await this._sut.RemapAsync("u1", "lure", oldUid, newUid);
+
+        this._repo.Verify(r => r.GetByUserAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SwallowsRepositoryFailures()
+    {
+        // The edit already succeeded upstream. Failing here would fail a request that worked, and cost
+        // the user their edit to save a "remove" button.
+        this._repo.Setup(r => r.GetByUserAsync("u1")).ThrowsAsync(new InvalidOperationException("db down"));
+
+        await this._sut.RemapAsync("u1", "lure", 1, 2);
+    }
+}


### PR DESCRIPTION
Addresses the edit-path half of #403. The bulk-distance half is split out — see the bottom.

PoracleNG implements a tracking edit as delete-and-insert for every type except monsters, so the row comes back with a new uid. Measured on dev, **both** edit routes rotate for all nine types:

| type | `PUT /{uid}` | bulk distance |
|---|---|---|
| raids | 386 → 387 | 387 → 388 |
| eggs | 152 → 153 | 153 → 154 |
| quests | 437 → 438 | 438 → 439 |
| invasions | 689 → 690 | 690 → 691 |
| lures | 155 → 156 | 156 → 157 |
| gyms | 123 → 124 | 124 → 125 |
| maxbattles | 44 → 45 | 45 → 46 |

Quick-pick applied state stores the uids captured at apply time, so after any edit the stored uid pointed at a row that no longer existed. **Remove** deleted nothing and still returned 204 — and the next summary read, seeing none of the tracked uids alive, concluded the user had deleted the alarms by hand and cleared the applied state. So the alarm kept firing and the UI no longer offered any way to remove it.

### Fix

`ITrackedUidRemapper` moves the stored uid with the row. It's wired into the three places a uid rotates on an edit: `TrackingUpdateReconciler` (raid, egg, quest, nest, gym, fort), `NaturalKeyTrackingUpdate` (lure, invasion), and `MaxBattleService`.

Best-effort by design. The edit already succeeded upstream, so a remap failure logs a warning rather than failing a request that worked — losing the remap costs a working Remove button on one quick pick; throwing would cost the user their edit.

### Verification

End to end on dev, the issue's own repro:

```
apply lure-glacial     -> trackedUids [168]
PUT /api/lures/168     -> 200, live row is now uid 169
GET /api/quick-picks   -> trackedUids [169]        (was still [168])
DELETE .../remove      -> 204, 0 lure rows remain  (the alarm used to survive)
```

Backend 1651 passed.

`TrackedUidRemapperCoverageTests` fails the build if a new alarm service takes no remapper, and pins monsters as the deliberate exception. It earned its place immediately — it caught `LureService` and `InvasionService` silently *not* passing the remapper through, because their call sites were indented differently from the other seven and my edit missed them.

### Not fixed here

The same failure is still reproducible through `PUT /distance` and `PUT /distance/bulk`. Confirmed live after this fix: applied state wiped, remove 404s, alarm survives.

I did not bundle it because the obvious implementation is wrong. The batch create response comes back **reordered** — submitting lures 161, 162, 163 returned 164, 165, 166 mapping to 163, 162, 161:

```
before : [(161, 501), (162, 502), (163, 503)]
after  : [(164, 503), (165, 502), (166, 501)]
```

A positional remap would repoint quick picks at the *wrong* alarms, so removal would delete an alarm the user still wanted. That is worse than the bug being fixed. Pairing has to be content-based, which is a different piece of work and deserves its own review — filed separately with this evidence.