### PR TITLE
fix: approve accepted any geofence status, like reject used to (#409 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Approving a geofence accepted any status**, the same gap [#409](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/409) closed on reject. A geofence the owner had never submitted could be approved and made public, and an already-approved one could be approved again under a different name — pushing a second entry into Koji and stranding the first, which is exactly the leak #409 fixed. Approve now accepts only a submission awaiting review, or one previously rejected and being reconsidered.
+
+### Fixed
 - **Creating a geofence accepted malformed polygons, which then poisoned the shared geofence feed** ([#410](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/410)). The create endpoint checked only how many points a polygon had, so `[[1],[2],[3]]` and coordinates nowhere on Earth were stored as-is. Those rows were then served by `GET /api/geofence-feed` — the anonymous endpoint that is the single geofence source for PoracleJS — and crashed the owner's GeoJSON export with a 500 that persisted until they worked out which geofence to delete. GeoJSON import had always validated point shape and coordinate range properly; the two write paths into the same table simply disagreed. Both now share one rule, and the read paths skip anything malformed rather than trusting it, so a row written before this existed cannot break a feed everyone depends on.
 
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -459,6 +459,22 @@ public partial class UserGeofenceService(
         var geofence = await this._repository.GetByIdAsync(id)
             ?? throw new GeofenceNotFoundException(id);
 
+        // Approve accepted any status, the same gap #409 fixed on reject.
+        //
+        //   pending_review  the normal path
+        //   rejected        allowed: an admin reconsidering a call they already made. Nothing is in Koji
+        //                   yet, so this is a plain promotion.
+        //   active          refused: never submitted. Approving it skips the submission flow entirely, so
+        //                   there is no review thread and the owner never asked for it to be public.
+        //   approved        refused: already public in Koji. Re-approving under a different promoted name
+        //                   would push a second entry and strand the first — the exact leak #409 closed.
+        //                   Renaming a live public area is a different operation from approving one.
+        if (!ApprovableStatuses.Contains(geofence.Status))
+        {
+            throw new InvalidOperationException(
+                $"Geofence must be awaiting review to be approved. Current status: '{geofence.Status}'.");
+        }
+
         // Parse polygon from local DB
         if (string.IsNullOrEmpty(geofence.PolygonJson))
         {
@@ -666,6 +682,13 @@ public partial class UserGeofenceService(
 
         return toRestore;
     }
+
+    /// <summary>
+    /// Statuses an admin may approve from. See the comment in <see cref="ApproveSubmissionAsync"/> for why
+    /// <c>active</c> and <c>approved</c> are not among them.
+    /// </summary>
+    private static readonly HashSet<string> ApprovableStatuses =
+        new(StringComparer.Ordinal) { "pending_review", "rejected" };
 
     /// <summary>
     /// Whether this geofence was ever pushed into the shared Koji project. <c>PromotedName</c> is written

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
@@ -1377,4 +1377,63 @@ public class UserGeofenceServiceTests
                 Polygon = [[40, -75], [41, -75]]
             }));
     }
+
+    // ── Approve state machine ───────────────────────────────────────────────────
+    // Approve accepted any status, the same gap #409 closed on reject.
+
+    [Theory]
+    [InlineData("pending_review")]
+    [InlineData("rejected")]
+    public async Task ApproveSubmissionAsyncAllowsAwaitingReviewAndReconsideredRejections(string status)
+    {
+        this.SeedGeofence(status);
+
+        var result = await this._sut.ApproveSubmissionAsync("admin1", 7, null);
+
+        Assert.Equal("approved", result.Status);
+    }
+
+    [Fact]
+    public async Task ApproveSubmissionAsyncRefusesAGeofenceThatWasNeverSubmitted()
+    {
+        // No review thread, and the owner never asked for it to be public.
+        this.SeedGeofence("active");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._sut.ApproveSubmissionAsync("admin1", 7, null));
+
+        Assert.Contains("active", ex.Message, StringComparison.Ordinal);
+        this._kojiService.Verify(
+            k => k.SaveGeofenceAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double[][]>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveSubmissionAsyncRefusesAnAlreadyApprovedGeofence()
+    {
+        // Re-approving under a different promoted name would push a second Koji entry and strand the
+        // first — the exact leak #409 closed.
+        this.SeedGeofence("approved", promotedName: "Downtown Official");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._sut.ApproveSubmissionAsync("admin1", 7, "Downtown Renamed"));
+
+        this._kojiService.Verify(
+            k => k.SaveGeofenceAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double[][]>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveSubmissionAsyncChecksTheStatusBeforeTouchingKoji()
+    {
+        // The guard has to run before SaveGeofenceAsync, or a refused approval still publishes the fence.
+        this.SeedGeofence("active");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._sut.ApproveSubmissionAsync("admin1", 7, null));
+
+        this._repository.Verify(r => r.UpdateAsync(It.IsAny<UserGeofence>()), Times.Never);
+        this._areaWriter.Verify(
+            w => w.RenameAreaInAllProfilesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
 }


### PR DESCRIPTION
Follow-up to #409/#445. That PR closed the hole on **reject** and I deliberately left **approve** alone rather than invent a policy. Asked and answered — approve now enforces the same state machine.

| status | | why |
|---|---|---|
| `pending_review` | allowed | the normal path |
| `rejected` | allowed | an admin reconsidering a call they already made; nothing is in Koji yet |
| `active` | refused | never submitted. Approving skips the submission flow, so there is no review thread and the owner never asked for it to be public. |
| `approved` | refused | already public. Re-approving under a different promoted name pushes a second Koji entry and strands the first — the exact leak #409 closed. Renaming a live public area is a different operation from approving one. |

The guard runs **before** `SaveGeofenceAsync`, so a refused approval can't publish the fence on its way to failing. Pinned by a test.

## This also closes out the unverified paths in #444 and #445

Both shipped with unit tests only, because proving them needs a real approve against the production Koji project. Ran that end to end, with Discord disabled so nothing posted to the live review forum — Koji is what needed proving.

```
create + submit + approve as "ZZ E2E Promoted"
  -> 200, present in Koji as a public area
  -> humans.area and profiles.area #1 hold "zz e2e promoted"
  -> the original "zz e2e check" is gone, not duplicated        [#444]
  -> profiles.area #0 untouched, per-profile activation kept    [#444]
  -> all 11 real areas intact

re-approve                     -> 400 "Current status: 'approved'"
reject an approved geofence    -> 400 "Current status: 'approved'"   [#409]

admin delete
  -> 204, gone from Koji                                        [#445]
  -> area entry removed under the PROMOTED name, 20 -> 19       [#445]
```

That last line is the unreported bug #445 also fixed: the old code removed `KojiName`, but after approval the owner is subscribed under the promoted name, so the removal silently missed.

Test geofence and its Koji entry both cleaned up; nothing left behind.

## One thing the run turned up

My local `.env` still pointed `DB_HOST` at `10.0.3.231` — I'd fixed the prod host's `.env` but not my own — so the first read of the areas table looked empty and the rename appeared not to have happened. It had; I was reading the wrong database. Local config corrected. Worth knowing that any direct-DB verification is only as good as which host you're pointed at.

Backend 1705 passed.