### PR TITLE
fix: alarms written during a JWT profile desync landed on the wrong profile (#411)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
@@ -35,7 +35,9 @@ public class EggController(IEggService eggService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] EggCreate model)
     {
         var egg = model.ToEgg();
-        egg.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._eggService.CreateAsync(this.UserId, egg);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
@@ -35,7 +35,9 @@ public class FortChangeController(IFortChangeService fortChangeService) : BaseAp
     public async Task<IActionResult> Create([FromBody] FortChangeCreate model)
     {
         var fortChange = model.ToFortChange();
-        fortChange.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._fortChangeService.CreateAsync(this.UserId, fortChange);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
@@ -35,7 +35,9 @@ public class GymController(IGymService gymService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] GymCreate model)
     {
         var gym = model.ToGym();
-        gym.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._gymService.CreateAsync(this.UserId, gym);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
@@ -35,7 +35,9 @@ public class InvasionController(IInvasionService invasionService) : BaseApiContr
     public async Task<IActionResult> Create([FromBody] InvasionCreate model)
     {
         var invasion = model.ToInvasion();
-        invasion.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._invasionService.CreateAsync(this.UserId, invasion);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
@@ -35,7 +35,9 @@ public class LureController(ILureService lureService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] LureCreate model)
     {
         var lure = model.ToLure();
-        lure.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._lureService.CreateAsync(this.UserId, lure);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
@@ -35,7 +35,9 @@ public class MaxBattleController(IMaxBattleService maxBattleService) : BaseApiCo
     public async Task<IActionResult> Create([FromBody] MaxBattleCreate model)
     {
         var maxBattle = model.ToMaxBattle();
-        maxBattle.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._maxBattleService.CreateAsync(this.UserId, maxBattle);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
@@ -35,7 +35,9 @@ public class MonsterController(IMonsterService monsterService) : BaseApiControll
     public async Task<IActionResult> Create([FromBody] MonsterCreate model)
     {
         var monster = model.ToMonster();
-        monster.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._monsterService.CreateAsync(this.UserId, monster);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
@@ -35,7 +35,9 @@ public class NestController(INestService nestService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] NestCreate model)
     {
         var nest = model.ToNest();
-        nest.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._nestService.CreateAsync(this.UserId, nest);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
@@ -35,7 +35,9 @@ public class QuestController(IQuestService questService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] QuestCreate model)
     {
         var quest = model.ToQuest();
-        quest.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._questService.CreateAsync(this.UserId, quest);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
@@ -35,7 +35,9 @@ public class RaidController(IRaidService raidService) : BaseApiController
     public async Task<IActionResult> Create([FromBody] RaidCreate model)
     {
         var raid = model.ToRaid();
-        raid.ProfileNo = this.ProfileNo;
+        // Deliberately not stamped from the JWT claim: writes no longer carry profile_no, so
+        // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
+        // claim back would assert a profile the row was never written to. See #411.
         var result = await this._raidService.CreateAsync(this.UserId, raid);
         return this.CreatedAtAction(nameof(GetByUid), new
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Alarms created while your session's profile claim was stale landed on the wrong profile, invisible and undeletable** ([#411](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/411)). Alarm writes carried a profile number stamped from the login token, and that token lives four hours — long enough for the active profile to move underneath it via the active-hours scheduler, the bot's `!profile` command, or a second tab. PoracleNG took the submitted number at face value for Pokemon alarms while scoping every read to the live profile, so the alarm saved successfully and then could not be seen, edited or deleted. Writes no longer send a profile number at all: PoracleNG files each alarm under the profile you are actually on, which is what it already did for the other nine alarm types.
+
+### Fixed
 - **Approving a geofence accepted any status**, the same gap [#409](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/409) closed on reject. A geofence the owner had never submitted could be approved and made public, and an already-approved one could be approved again under a different name — pushing a second entry into Koji and stranding the first, which is exactly the leak #409 fixed. Approve now accepts only a submission awaiting review, or one previously rejected and being reconsidered.
 
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
@@ -10,9 +10,11 @@ public class MonsterService(IPoracleTrackingProxy proxy, IFeatureGate featureGat
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
 
-    // Note: profileNo is kept for interface compatibility but PoracleNG scopes to the user's
-    // active profile (humans.current_profile_no) automatically. The JWT profileNo and the
-    // active profile should always match because SwitchProfile updates both.
+    // profileNo is kept for interface compatibility only. PoracleNG scopes reads to the user's active
+    // profile (humans.current_profile_no), and writes no longer carry profile_no at all — see
+    // PoracleJsonHelper.SerializeToElement. The previous claim here, that the JWT profileNo and the
+    // active profile can never diverge, was wrong: the active-hours scheduler and the bot's !profile
+    // command both move it out of band, and JWTs live four hours. See #411.
     public async Task<IEnumerable<Monster>> GetByUserAsync(string userId, int profileNo)
     {
         var json = await this._proxy.GetByUserAsync(TrackingType, userId);

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleJsonHelper.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleJsonHelper.cs
@@ -20,27 +20,60 @@ internal static class PoracleJsonHelper
     public static readonly JsonElement EmptyArray = JsonDocument.Parse("[]").RootElement.Clone();
 
     /// <summary>
-    /// Serializes a value to a JsonElement using snake_case naming.
-    /// Strips "uid":0 from the output — PoracleNG treats uid=0 as an update target
-    /// instead of a new insert. Omitting uid tells PoracleNG to create a new row.
+    /// Serializes an alarm payload for PoracleNG, using snake_case naming and removing two properties
+    /// that do more harm than good on the wire.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>uid: 0</c> is stripped because PoracleNG reads a present uid as "update this row", so a new
+    /// alarm with the default uid became an update against a row that does not exist instead of an insert.
+    /// </para>
+    /// <para>
+    /// <c>profile_no</c> is stripped because it was stamped from the caller's JWT claim, and that claim
+    /// goes stale whenever <c>current_profile_no</c> changes out of band — the active-hours scheduler, the
+    /// bot's <c>!profile</c> command, or a second tab. PoracleNG honours a submitted <c>profile_no</c>
+    /// verbatim for the pokemon type while scoping every other type, and every read path, to the live
+    /// <c>current_profile_no</c>. A stale claim therefore wrote a monster onto a profile the user was no
+    /// longer on: the POST returned 201 with a real uid, and the row was then invisible to reads and
+    /// undeletable. Confirmed against PoracleNG that a submitted <c>profile_no</c> is taken at face value
+    /// even when no such profile exists — <c>profile_no: 9</c> creates an orphan — and that omitting it
+    /// makes PoracleNG use <c>current_profile_no</c>. Omitting it is therefore both the safe option and
+    /// the one that matches how the other nine types already behave. See #411.
+    /// </para>
+    /// </remarks>
     public static JsonElement SerializeToElement<T>(T value)
     {
         var bytes = JsonSerializer.SerializeToUtf8Bytes(value, SnakeCaseOptions);
         using var doc = JsonDocument.Parse(bytes);
         var root = doc.RootElement;
 
-        if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("uid", out var uid) && uid.GetInt32() == 0)
-        {
-            return StripProperty(root, "uid");
-        }
-
         if (root.ValueKind == JsonValueKind.Array)
         {
-            return StripZeroUidsFromArray(root);
+            return StripAlarmMetadataFromArray(root);
+        }
+
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            return StripAlarmMetadata(root);
         }
 
         return root.Clone();
+    }
+
+    /// <summary>Names that must never reach PoracleNG on an alarm write. See <see cref="SerializeToElement"/>.</summary>
+    private static bool ShouldStrip(JsonProperty prop) =>
+        prop.NameEquals("profile_no") ||
+        (prop.NameEquals("uid") && prop.Value.ValueKind == JsonValueKind.Number && prop.Value.GetInt32() == 0);
+
+    private static JsonElement StripAlarmMetadata(JsonElement obj)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            WriteStripped(writer, obj);
+        }
+
+        return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
     }
 
     /// <summary>
@@ -68,7 +101,7 @@ internal static class PoracleJsonHelper
         return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
     }
 
-    private static JsonElement StripZeroUidsFromArray(JsonElement array)
+    private static JsonElement StripAlarmMetadataFromArray(JsonElement array)
     {
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
@@ -76,9 +109,9 @@ internal static class PoracleJsonHelper
             writer.WriteStartArray();
             foreach (var item in array.EnumerateArray())
             {
-                if (item.ValueKind == JsonValueKind.Object && item.TryGetProperty("uid", out var uid) && uid.GetInt32() == 0)
+                if (item.ValueKind == JsonValueKind.Object)
                 {
-                    StripPropertyTo(writer, item, "uid");
+                    WriteStripped(writer, item);
                 }
                 else
                 {
@@ -92,12 +125,12 @@ internal static class PoracleJsonHelper
         return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
     }
 
-    private static void StripPropertyTo(Utf8JsonWriter writer, JsonElement obj, string propertyName)
+    private static void WriteStripped(Utf8JsonWriter writer, JsonElement obj)
     {
         writer.WriteStartObject();
         foreach (var prop in obj.EnumerateObject())
         {
-            if (prop.NameEquals(propertyName))
+            if (ShouldStrip(prop))
             {
                 continue;
             }
@@ -107,6 +140,7 @@ internal static class PoracleJsonHelper
 
         writer.WriteEndObject();
     }
+
 
     /// <summary>
     /// Deserializes a JsonElement array to a typed list using snake_case naming.

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/AlarmWritePayloadTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/AlarmWritePayloadTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// What actually goes on the wire for an alarm write.
+/// <para>
+/// Alarm writes carried <c>profile_no</c> stamped from the caller's JWT claim. That claim goes stale
+/// whenever <c>current_profile_no</c> moves out of band — the active-hours scheduler, the bot's
+/// <c>!profile</c> command, a second tab — and JWTs live four hours. PoracleNG takes a submitted
+/// <c>profile_no</c> at face value for the pokemon type (verified: <c>profile_no: 9</c> creates a row on
+/// a profile that does not exist) while scoping every read to the live one. So a stale claim wrote an
+/// alarm that returned 201 and was then invisible to reads and undeletable. Omitting it makes PoracleNG
+/// use <c>current_profile_no</c>, which is what the other nine types already did. See #411.
+/// </para>
+/// </summary>
+public class AlarmWritePayloadTests
+{
+    private readonly Mock<IPoracleTrackingProxy> _proxy = new();
+    private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly List<JsonElement> _sent = [];
+
+    public AlarmWritePayloadTests()
+    {
+        this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+        this._proxy
+            .Setup(p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()))
+            .Callback<string, string, JsonElement>((_, _, body) => this._sent.Add(body.Clone()))
+            .ReturnsAsync(new TrackingCreateResult([1], 0, 0, 1));
+    }
+
+    private MonsterService Monsters() => new(this._proxy.Object, this._featureGate.Object);
+
+    private static IEnumerable<JsonElement> Objects(JsonElement sent) =>
+        sent.ValueKind == JsonValueKind.Array ? sent.EnumerateArray() : [sent];
+
+    [Fact]
+    public async Task CreateDoesNotSendProfileNo()
+    {
+        await Monsters().CreateAsync("u1", new Monster { PokemonId = 201, ProfileNo = 3 });
+
+        Assert.All(Objects(this._sent[0]), o => Assert.False(o.TryGetProperty("profile_no", out _)));
+    }
+
+    [Fact]
+    public async Task CreateDoesNotSendProfileNoWhenItIsZero()
+    {
+        // Zero is a real profile number, so "strip only non-zero" would still target the wrong profile.
+        await Monsters().CreateAsync("u1", new Monster { PokemonId = 201, ProfileNo = 0 });
+
+        Assert.All(Objects(this._sent[0]), o => Assert.False(o.TryGetProperty("profile_no", out _)));
+    }
+
+    [Fact]
+    public async Task UpdateDoesNotSendProfileNo()
+    {
+        await Monsters().UpdateAsync("u1", new Monster { Uid = 9, PokemonId = 201, ProfileNo = 3 });
+
+        Assert.All(Objects(this._sent[0]), o => Assert.False(o.TryGetProperty("profile_no", out _)));
+    }
+
+    [Fact]
+    public async Task BulkCreateStripsProfileNoFromEveryElement()
+    {
+        await Monsters().BulkCreateAsync("u1",
+        [
+            new Monster { PokemonId = 1, ProfileNo = 2 },
+            new Monster { PokemonId = 2, ProfileNo = 3 }
+        ]);
+
+        var items = this._sent[0].EnumerateArray().ToList();
+        Assert.Equal(2, items.Count);
+        Assert.All(items, o => Assert.False(o.TryGetProperty("profile_no", out _)));
+    }
+
+    [Fact]
+    public async Task CreateStillOmitsTheDefaultUidSoItIsAnInsert()
+    {
+        await Monsters().CreateAsync("u1", new Monster { PokemonId = 201 });
+
+        Assert.All(Objects(this._sent[0]), o => Assert.False(o.TryGetProperty("uid", out _)));
+    }
+
+    [Fact]
+    public async Task UpdateStillSendsItsUidSoItTargetsTheRightRow()
+    {
+        await Monsters().UpdateAsync("u1", new Monster { Uid = 42, PokemonId = 201 });
+
+        Assert.All(Objects(this._sent[0]), o => Assert.Equal(42, o.GetProperty("uid").GetInt32()));
+    }
+
+    [Fact]
+    public async Task TheRestOfThePayloadIsUntouched()
+    {
+        await Monsters().CreateAsync("u1", new Monster { PokemonId = 149, Distance = 500, ProfileNo = 7 });
+
+        var o = Objects(this._sent[0]).First();
+        Assert.Equal(149, o.GetProperty("pokemon_id").GetInt32());
+        Assert.Equal(500, o.GetProperty("distance").GetInt32());
+        Assert.Equal("u1", o.GetProperty("id").GetString());
+    }
+}


### PR DESCRIPTION
Closes #411.

Alarm writes carried `profile_no` stamped from the caller's JWT claim. That claim goes stale whenever `current_profile_no` moves out of band — the active-hours scheduler, the bot's `!profile` command, a second tab — and JWTs live four hours.

### Established the upstream behaviour before choosing a fix

```
POST pokemon with no profile_no   -> row lands on current_profile_no (0)
POST pokemon with profile_no: 9   -> row lands on profile 9, which does not exist
```

Submitted values are taken at face value, with no validation. So a stale claim wrote a monster onto a profile the user wasn't on: 201 with a real uid, then invisible to `GET` and undeletable, because every read path scopes to `current_profile_no`.

### Fix

Writes no longer send `profile_no` at all. PoracleNG then files the row under the live active profile — which is what the other nine tracking types already did, since PoracleNG ignores the submitted value for those. One strip in `PoracleJsonHelper.SerializeToElement` covers all ten services, and nothing else uses that helper.

The ten controllers no longer stamp the claim onto the model either. Echoing it back asserted a profile the row was never written to — the create response said `profileNo: 5` while the row was on profile 0.

Also corrected the comment in `MonsterService` claiming the JWT `profileNo` and the active profile "should always match". `CLAUDE.md` documents the mechanisms that make them diverge, and `/api/auth/me` exists specifically to resync them.

### Verification

Live, with a token claiming profile 5 while the live profile was 0:

```
POST   /api/monsters        -> 201 uid 40387, row on profile 0
GET    /api/monsters        -> finds it
GET    /api/monsters/40387  -> 200   (was 404)
DELETE /api/monsters/40387  -> 204   (was 404)
leftovers                   -> 0
```

Backend 1712 passed. Seven new tests assert what actually reaches the wire, through the real service path rather than the internal helper: no `profile_no` on create, update or bulk, including when it is zero (zero is a real profile number, so "strip only non-zero" would still target the wrong one), while `uid` handling is unchanged.

### Why not resync the claim instead

Making `BaseApiController.ProfileNo` read the live value would add a lookup to every alarm request to produce a number we then only use to tell PoracleNG something it already knows better. Not sending it is both cheaper and unambiguous.