### PR TITLE
fix: silent duplicate-profile-name failure, and remove the dead fort clean toggle (#427, #437)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-add-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-add-dialog.component.html
@@ -82,8 +82,6 @@
           [alarmType]="'fort-update'"
           [value]="form.controls.template.value ?? ''"
           (valueChange)="form.controls.template.setValue($event)"></app-template-selector>
-        <mat-slide-toggle [formControl]="form.controls.clean"> {{ 'ALARM.CLEAN_MODE' | translate }} </mat-slide-toggle>
-        <p class="clean-hint">{{ 'ALARM.CLEAN_HINT_FORT' | translate }}</p>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-add-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-add-dialog.component.ts
@@ -19,7 +19,6 @@ import { FortChangeService } from '../../core/services/fort-change.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { compose } from '../../shared/utils/clean-flags';
 
 @Component({
   imports: [
@@ -57,7 +56,6 @@ export class FortChangeAddDialogComponent {
     changeTypeName: [true],
     changeTypeNew: [true],
     changeTypeRemoval: [true],
-    clean: [false],
     distanceKm: [this.alertDefaults.defaultDistanceKm()],
     distanceMode: [this.alertDefaults.defaultMode()],
     fortType: ['everything'],
@@ -89,7 +87,6 @@ export class FortChangeAddDialogComponent {
     this.fortChangeService
       .create({
         changeTypes,
-        clean: compose(!!v.clean, false, false),
         distance: dist,
         fortType: v.fortType,
         includeEmpty: v.includeEmpty ? 1 : 0,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.html
@@ -87,9 +87,6 @@
           [value]="form.controls.template.value ?? ''"
           (valueChange)="form.controls.template.setValue($event)">
         </app-template-selector>
-
-        <mat-slide-toggle [formControl]="form.controls.clean"> {{ 'ALARM.CLEAN_MODE' | translate }} </mat-slide-toggle>
-        <p class="clean-hint">{{ 'ALARM.CLEAN_HINT_FORT' | translate }}</p>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
@@ -19,7 +19,6 @@ import { FortChangeService } from '../../core/services/fort-change.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
   imports: [
@@ -57,7 +56,6 @@ export class FortChangeEditDialogComponent {
     changeTypeName: [this.data.changeTypes?.includes('name') ?? false],
     changeTypeNew: [this.data.changeTypes?.includes('new') ?? false],
     changeTypeRemoval: [this.data.changeTypes?.includes('removal') ?? false],
-    clean: [isAutoDelete(this.data.clean)],
     distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
     distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     fortType: [this.data.fortType ?? 'everything'],
@@ -89,7 +87,6 @@ export class FortChangeEditDialogComponent {
     this.fortChangeService
       .update(this.data.uid, {
         changeTypes,
-        clean: preserve(this.data.clean, AUTO_DELETE, v.clean ? 1 : 0),
         distance: dist,
         fortType: v.fortType,
         includeEmpty: v.includeEmpty ? 1 : 0,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.html
@@ -67,9 +67,6 @@
             <span class="fort-subtitle">Fort Change Tracking</span>
           </div>
           <div class="card-top-actions">
-            @if (isAutoDelete(item.clean)) {
-              <span class="clean-tag" [matTooltip]="'ALARM.CLEAN_HINT_FORT' | translate">clean</span>
-            }
             @if (item.includeEmpty === 1) {
               <span class="include-empty-tag" [matTooltip]="'FORT_CHANGES.INCLUDE_EMPTY' | translate">incl. empty</span>
             }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.ts
@@ -185,11 +185,6 @@ export class FortChangeListComponent implements OnInit {
     }
   }
 
-  /** True when the auto-delete bit (clean bit 1) is set, ignoring the edit-in-place / summary bits. */
-  isAutoDelete(clean: number): boolean {
-    return (clean & 1) !== 0;
-  }
-
   loadItems(): void {
     this.loading.set(true);
     this.fortChangeService

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.html
@@ -11,8 +11,8 @@
       [placeholder]="'PROFILES.PROFILE_NAME_PLACEHOLDER' | translate"
       maxlength="32"
       (keyup.enter)="save()" />
-    @if (nameError()) {
-      <mat-error>{{ nameError() }}</mat-error>
+    @if (hasNameConflict()) {
+      <mat-hint class="name-conflict">{{ 'DIALOG.PROMPT_CONFLICT' | translate }}</mat-hint>
     } @else {
       <mat-hint>{{ profileName.length }}/32</mat-hint>
     }
@@ -20,7 +20,7 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-button (click)="dialogRef.close()">{{ 'COMMON.CANCEL' | translate }}</button>
-  <button mat-raised-button color="primary" (click)="save()" [disabled]="saving() || !profileName.trim()">
+  <button mat-raised-button color="primary" (click)="save()" [disabled]="saving() || !profileName.trim() || hasNameConflict()">
     <mat-icon>add</mat-icon> {{ 'PROFILES.CREATE' | translate }}
   </button>
 </mat-dialog-actions>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.scss
@@ -1,3 +1,9 @@
 .full-width {
   width: 100%;
 }
+
+// The conflict message rides in the hint slot because <mat-error> only renders when the form
+// field control reports errorState, which a bare ngModel never does. See #427.
+.name-conflict {
+  color: var(--mat-sys-error, #b3261e);
+}

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles/profile-add-dialog.component.ts
@@ -51,11 +51,20 @@ export class ProfileAddDialogComponent {
       });
   }
 
+  /**
+   * Checked as the user types so the Create button disables before the click, rather than the click
+   * silently doing nothing.
+   */
+  hasNameConflict(): boolean {
+    const name = this.profileName.trim().toLowerCase();
+    return name.length > 0 && this.existingNames().has(name);
+  }
+
   save(): void {
     const name = this.profileName.trim();
     if (!name) return;
 
-    if (this.existingNames().has(name.toLowerCase())) {
+    if (this.hasNameConflict()) {
       this.nameError.set(this.i18n.instant('DIALOG.PROMPT_CONFLICT'));
       return;
     }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Sletter automatisk notifikationen fra Discord, når lokkemodulet udløber",
     "CLEAN_HINT_NEST": "Sletter automatisk notifikationen fra Discord, når reder migrerer",
     "CLEAN_HINT_GYM": "Sletter automatisk notifikationen fra Discord, når gym-aktiviteten ændres",
-    "CLEAN_HINT_FORT": "Sletter automatisk notifikationen fra Discord, når den udløber",
     "CLEAN_HINT_MAX_BATTLE": "Sletter automatisk notifikationen fra Discord, når max-kampen slutter",
     "SAVING": "Gemmer...",
     "SAVE": "Gem",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Löscht die Benachrichtigung automatisch aus Discord, wenn das Lockmodul abläuft",
     "CLEAN_HINT_NEST": "Löscht die Benachrichtigung automatisch aus Discord, wenn Nester wechseln",
     "CLEAN_HINT_GYM": "Löscht die Benachrichtigung automatisch aus Discord, wenn sich die Arena-Aktivität ändert",
-    "CLEAN_HINT_FORT": "Löscht die Benachrichtigung automatisch aus Discord, wenn sie abläuft",
     "CLEAN_HINT_MAX_BATTLE": "Löscht die Benachrichtigung automatisch aus Discord, wenn der Max-Kampf endet",
     "SAVING": "Wird gespeichert...",
     "SAVE": "Speichern",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -324,7 +324,6 @@
     "CLEAN_HINT_LURE": "Automatically deletes the notification from Discord after the lure expires",
     "CLEAN_HINT_NEST": "Automatically deletes the notification from Discord when nests migrate",
     "CLEAN_HINT_GYM": "Automatically deletes the notification from Discord after gym activity changes",
-    "CLEAN_HINT_FORT": "Automatically deletes the notification from Discord after it expires",
     "CLEAN_HINT_MAX_BATTLE": "Automatically deletes the notification from Discord after the max battle ends",
     "SAVING": "Saving...",
     "SAVE": "Save",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Elimina automáticamente la notificación de Discord cuando el señuelo expira",
     "CLEAN_HINT_NEST": "Elimina automáticamente la notificación de Discord cuando los nidos migran",
     "CLEAN_HINT_GYM": "Elimina automáticamente la notificación de Discord cuando la actividad del gimnasio cambia",
-    "CLEAN_HINT_FORT": "Elimina automáticamente la notificación de Discord tras expirar",
     "CLEAN_HINT_MAX_BATTLE": "Elimina automáticamente la notificación de Discord cuando el combate max termina",
     "SAVING": "Guardando...",
     "SAVE": "Guardar",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Supprime automatiquement la notification de Discord quand le leurre expire",
     "CLEAN_HINT_NEST": "Supprime automatiquement la notification de Discord quand les nids migrent",
     "CLEAN_HINT_GYM": "Supprime automatiquement la notification de Discord quand l'activité d'arène change",
-    "CLEAN_HINT_FORT": "Supprime automatiquement la notification de Discord après expiration",
     "CLEAN_HINT_MAX_BATTLE": "Supprime automatiquement la notification de Discord quand le combat max se termine",
     "SAVING": "Enregistrement...",
     "SAVE": "Enregistrer",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Elimina automaticamente la notifica da Discord dopo che l'esca scade",
     "CLEAN_HINT_NEST": "Elimina automaticamente la notifica da Discord quando i nidi migrano",
     "CLEAN_HINT_GYM": "Elimina automaticamente la notifica da Discord dopo che l'attività della palestra cambia",
-    "CLEAN_HINT_FORT": "Elimina automaticamente la notifica da Discord dopo la scadenza",
     "CLEAN_HINT_MAX_BATTLE": "Elimina automaticamente la notifica da Discord dopo che la battaglia max finisce",
     "SAVING": "Salvataggio...",
     "SAVE": "Salva",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Verwijdert de melding automatisch uit Discord nadat het lokmiddel verloopt",
     "CLEAN_HINT_NEST": "Verwijdert de melding automatisch uit Discord wanneer nesten roteren",
     "CLEAN_HINT_GYM": "Verwijdert de melding automatisch uit Discord wanneer gymactiviteit verandert",
-    "CLEAN_HINT_FORT": "Verwijdert de melding automatisch uit Discord nadat het verloopt",
     "CLEAN_HINT_MAX_BATTLE": "Verwijdert de melding automatisch uit Discord nadat het max gevecht eindigt",
     "SAVING": "Opslaan...",
     "SAVE": "Opslaan",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Automatycznie usuwa powiadomienie z Discord po wygaśnięciu przynęty",
     "CLEAN_HINT_NEST": "Automatycznie usuwa powiadomienie z Discord przy migracji gniazd",
     "CLEAN_HINT_GYM": "Automatycznie usuwa powiadomienie z Discord po zmianie aktywności areny",
-    "CLEAN_HINT_FORT": "Automatycznie usuwa powiadomienie z Discord po wygaśnięciu",
     "CLEAN_HINT_MAX_BATTLE": "Automatycznie usuwa powiadomienie z Discord po zakończeniu bitwy max",
     "SAVING": "Zapisywanie...",
     "SAVE": "Zapisz",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Exclui automaticamente a notificação do Discord após a isca expirar",
     "CLEAN_HINT_NEST": "Exclui automaticamente a notificação do Discord quando os ninhos migram",
     "CLEAN_HINT_GYM": "Exclui automaticamente a notificação do Discord após mudança de atividade do ginásio",
-    "CLEAN_HINT_FORT": "Exclui automaticamente a notificação do Discord após expirar",
     "CLEAN_HINT_MAX_BATTLE": "Exclui automaticamente a notificação do Discord após a batalha max acabar",
     "SAVING": "Salvando...",
     "SAVE": "Salvar",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Elimina automaticamente a notificação do Discord após o isco expirar",
     "CLEAN_HINT_NEST": "Elimina automaticamente a notificação do Discord quando os ninhos migram",
     "CLEAN_HINT_GYM": "Elimina automaticamente a notificação do Discord quando a atividade do ginásio muda",
-    "CLEAN_HINT_FORT": "Elimina automaticamente a notificação do Discord após expirar",
     "CLEAN_HINT_MAX_BATTLE": "Elimina automaticamente a notificação do Discord após a batalha max terminar",
     "SAVING": "A guardar...",
     "SAVE": "Guardar",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -320,7 +320,6 @@
     "CLEAN_HINT_LURE": "Raderar automatiskt notisen från Discord när lockmodulen går ut",
     "CLEAN_HINT_NEST": "Raderar automatiskt notisen från Discord när nästen migrerar",
     "CLEAN_HINT_GYM": "Raderar automatiskt notisen från Discord när gym-aktiviteten ändras",
-    "CLEAN_HINT_FORT": "Raderar automatiskt notisen från Discord när den går ut",
     "CLEAN_HINT_MAX_BATTLE": "Raderar automatiskt notisen från Discord när max-striden är slut",
     "SAVING": "Sparar...",
     "SAVE": "Spara",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Creating a profile with a name you already use did nothing at all** ([#427](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/427)). The dialog detected the clash and set an error message, but Angular Material only renders that slot when the field is in a validation error state, which this one never was — so pressing Create produced no message, no toast and no request, and the only visible change was the character counter disappearing. The clash is now flagged as you type and the Create button disables, so the dead click cannot happen.
+
+### Removed
+- **The auto-delete setting on Fort Change alarms** ([#437](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/437)). PoracleNG has no such field for fort changes, so the toggle was discarded on every save and the badge on the card could never be true. Split out of [#402](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/402), which removed the same dead setting from the Cleaning page.
+
+### Fixed
 - **"Disable Geocoding" did not disable geocoding** ([#420](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/420)). The toggle was stored and shown in admin settings but nothing read it, so an operator who switched it off for privacy or OpenStreetMap terms-of-use reasons was still making outbound Nominatim requests on every address search. It now genuinely stops them: the search and reverse-lookup endpoints refuse, and the location dialog hides its search box rather than showing one that fails. Setting a location by coordinates or on the map still works.
 
 ### Removed

--- a/Core/Pgan.PoracleWebNet.Core.Mappings/AlarmMappingExtensions.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Mappings/AlarmMappingExtensions.cs
@@ -258,7 +258,6 @@ public static class AlarmMappingExtensions
         FortType = src.FortType,
         IncludeEmpty = src.IncludeEmpty,
         ChangeTypes = src.ChangeTypes,
-        Clean = src.Clean,
         Template = src.Template,
     };
 
@@ -269,7 +268,6 @@ public static class AlarmMappingExtensions
         if (src.FortType != null) dest.FortType = src.FortType;
         if (src.IncludeEmpty != null) dest.IncludeEmpty = src.IncludeEmpty.Value;
         if (src.ChangeTypes != null) dest.ChangeTypes = src.ChangeTypes;
-        if (src.Clean != null) dest.Clean = src.Clean.Value;
         if (src.Template != null) dest.Template = src.Template;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Models/FortChange.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/FortChange.cs
@@ -38,10 +38,6 @@ public class FortChange
     /// </summary>
     [JsonConverter(typeof(StringOrArrayConverter))]
     public List<string> ChangeTypes { get; set; } = [];
-    public int Clean
-    {
-        get; set;
-    }
     public string? Template
     {
         get; set;

--- a/Core/Pgan.PoracleWebNet.Core.Models/FortChangeCreate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/FortChangeCreate.cs
@@ -38,11 +38,6 @@ public class FortChangeCreate
     public List<string> ChangeTypes { get; set; } = [];
 
     // clean is a PoracleNG bitmask: bit 1 = auto-delete, bit 2 = edit-in-place, bit 4 = summary.
-    [Range(0, 7)]
-    public int Clean
-    {
-        get; set;
-    }
 
     [StringLength(256)]
     public string? Template

--- a/Core/Pgan.PoracleWebNet.Core.Models/FortChangeUpdate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/FortChangeUpdate.cs
@@ -41,11 +41,6 @@ public class FortChangeUpdate
     }
 
     // clean is a PoracleNG bitmask: bit 1 = auto-delete, bit 2 = edit-in-place, bit 4 = summary.
-    [Range(0, 7)]
-    public int? Clean
-    {
-        get; set;
-    }
 
     [StringLength(256)]
     public string? Template

--- a/Tests/Pgan.PoracleWebNet.Tests/Mappings/MappingExtensionTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Mappings/MappingExtensionTests.cs
@@ -512,7 +512,6 @@ public class MappingExtensionTests
             FortType = "pokestop",
             IncludeEmpty = 1,
             ChangeTypes = ["name", "location"],
-            Clean = 1,
             Template = "fortTemplate",
         };
 
@@ -523,7 +522,6 @@ public class MappingExtensionTests
         Assert.Equal("pokestop", model.FortType);
         Assert.Equal(1, model.IncludeEmpty);
         Assert.Equal(["name", "location"], model.ChangeTypes);
-        Assert.Equal(1, model.Clean);
         Assert.Equal("fortTemplate", model.Template);
     }
 
@@ -1205,7 +1203,6 @@ public class MappingExtensionTests
             FortType = "pokestop",
             IncludeEmpty = 1,
             ChangeTypes = ["name", "location"],
-            Clean = 1,
             Template = "origTemplate",
         };
 
@@ -1219,7 +1216,6 @@ public class MappingExtensionTests
         Assert.Equal("pokestop", existing.FortType);
         Assert.Equal(1, existing.IncludeEmpty);
         Assert.Equal(["name", "location"], existing.ChangeTypes);
-        Assert.Equal(1, existing.Clean);
         Assert.Equal("origTemplate", existing.Template);
     }
 
@@ -1234,7 +1230,6 @@ public class MappingExtensionTests
             FortType = "pokestop",
             IncludeEmpty = 1,
             ChangeTypes = ["name", "location"],
-            Clean = 1,
             Template = "origTemplate",
         };
 
@@ -1254,7 +1249,6 @@ public class MappingExtensionTests
         Assert.Equal(60, existing.Uid);
         Assert.Equal("<@orig>", existing.Ping);
         Assert.Equal(150, existing.Distance);
-        Assert.Equal(1, existing.Clean);
         Assert.Equal("origTemplate", existing.Template);
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Validation/CleanRangeValidationTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Validation/CleanRangeValidationTests.cs
@@ -83,14 +83,6 @@ public class CleanRangeValidationTests
     [MemberData(nameof(RejectedValues))]
     public void MaxBattleCreateCleanRejectsOutOfRange(int value) => Assert.False(ValidateClean(new MaxBattleCreate(), value));
 
-    [Theory]
-    [MemberData(nameof(AcceptedValues))]
-    public void FortChangeCreateCleanAcceptsBitmaskRange(int value) => Assert.True(ValidateClean(new FortChangeCreate(), value));
-
-    [Theory]
-    [MemberData(nameof(RejectedValues))]
-    public void FortChangeCreateCleanRejectsOutOfRange(int value) => Assert.False(ValidateClean(new FortChangeCreate(), value));
-
     // ── Update types ────────────────────────────────────────
 
     [Theory]
@@ -149,14 +141,6 @@ public class CleanRangeValidationTests
     [MemberData(nameof(RejectedValues))]
     public void MaxBattleUpdateCleanRejectsOutOfRange(int value) => Assert.False(ValidateClean(new MaxBattleUpdate(), value));
 
-    [Theory]
-    [MemberData(nameof(AcceptedValues))]
-    public void FortChangeUpdateCleanAcceptsBitmaskRange(int value) => Assert.True(ValidateClean(new FortChangeUpdate(), value));
-
-    [Theory]
-    [MemberData(nameof(RejectedValues))]
-    public void FortChangeUpdateCleanRejectsOutOfRange(int value) => Assert.False(ValidateClean(new FortChangeUpdate(), value));
-
     // Update types allow null (null-skip merge semantics) — null must always validate.
 
     [Fact]
@@ -180,6 +164,6 @@ public class CleanRangeValidationTests
     [Fact]
     public void MaxBattleUpdateCleanAcceptsNull() => Assert.True(ValidateClean(new MaxBattleUpdate(), null));
 
-    [Fact]
-    public void FortChangeUpdateCleanAcceptsNull() => Assert.True(ValidateClean(new FortChangeUpdate(), null));
+    // FortChange has no Clean property: PoracleNG has no clean column for forts and its
+    // FortTracking struct has no Clean field, so the setting was discarded on save. Removed in #437.
 }


### PR DESCRIPTION
Closes #427 and #437. Both are "the UI offers something that cannot work", so they travel together.

## #427 — the dead Create click

The dialog set `nameError` on a clash and rendered it in a `<mat-error>`. Material only renders that slot when the field's control reports `errorState`, and a bare `ngModel` with no validators never does — so the message was invisible. `save()` then returned early with no snackbar and no request: clicking **Create** did nothing observable except the character-count hint vanishing.

The clash is now detected as you type, the Create button disables, and the message rides in the hint slot — which always renders — styled as an error.

Adding an `ErrorStateMatcher` would also have made `<mat-error>` work, but the disabled button is the better outcome: the click never becomes dead in the first place.

## #437 — a setting PoracleNG cannot store

Established in #402 from two independent sources: the dev table is `(uid, id, profile_no, ping, distance, template, fort_type, include_empty, change_types)` with no `clean` column, and PoracleNG's own `FortTracking` struct has no `Clean` field. The value was discarded on every save and the card badge could never be true.

Removed from both dialogs, the list badge, the three models, the mapping extensions, the clean-range validation cases, and `ALARM.CLEAN_HINT_FORT` in all 11 locales.

## Verification

Backend 1704 passed, frontend 898 passed, ESLint and Prettier clean.

## Note on the #437 edit

I made this harder than it needed to be. Two regexes were too broad — one stripped `Clean = src.Clean,` from *every* alarm type's mapping rather than just fort changes, and another removed 30 lines across unrelated tests. Both were caught by the suite going red, reverted with `git checkout`, and redone as exact line matches bounded to the fort-change blocks. Worth flagging because the first version compiled fine; only the tests caught it. The final diff is 0 additions and 2 deletions in `AlarmMappingExtensions.cs`, which is what it should always have been.