### PR TITLE
fix: follow quick-pick uids through a bulk distance update (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A bulk distance change still made a quick pick impossible to remove** ([#443](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/443)). The single-edit case was fixed in [#403](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/403), but the Update All and bulk-distance actions rewrite every row too, so the same stale-uid failure came back through them: Remove reported success, deleted nothing, and the next page load cleared the applied state so there was no way to try again. The replacement rows are now matched by their contents rather than their position, because the batch response comes back in a different order than it was sent — matching by position would have repointed a quick pick at somebody else's alarm and deleted the wrong one. Where two alarms are genuinely indistinguishable, nothing is moved rather than guessed.
+
+### Fixed
 - **Creating a profile with a name you already use did nothing at all** ([#427](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/427)). The dialog detected the clash and set an error message, but Angular Material only renders that slot when the field is in a validation error state, which this one never was — so pressing Create produced no message, no toast and no request, and the only visible change was the character counter disappearing. The clash is now flagged as you type and the Create button disables, so the dead click cannot happen.
 
 ### Removed

--- a/Core/Pgan.PoracleWebNet.Core.Services/BulkUidRemap.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/BulkUidRemap.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Core.Services;
+
+/// <summary>
+/// Follows quick-pick tracked uids through a bulk distance update.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bulk distance endpoints are a fetch-mutate-repost, and PoracleNG rewrites each row, so every uid
+/// changes. #403 fixed this for single edits, where the create response gives an unambiguous 1:1 mapping.
+/// It cannot be done that way here: the batch response comes back <em>reordered</em>. Submitting lures
+/// 161, 162, 163 returned 164, 165, 166 mapping to 163, 162, 161 — so pairing by position would repoint a
+/// quick pick at somebody else's alarm and its Remove would then delete an alarm the user still wanted.
+/// That is worse, and quieter, than the bug being fixed. See #443.
+/// </para>
+/// <para>
+/// Pairing is therefore done on content. A bulk distance update changes exactly one field, so two rows are
+/// the same alarm when every other field matches. Where a signature is ambiguous — two rows identical
+/// apart from distance — nothing is remapped and it is logged, because guessing is the failure mode this
+/// exists to avoid. Such rows are interchangeable anyway once both carry the same distance.
+/// </para>
+/// </remarks>
+public static partial class BulkUidRemap
+{
+    /// <summary>
+    /// Fields that differ between the two snapshots by definition, so they cannot identify a row.
+    /// <c>profile_no</c> is here because outgoing payloads no longer carry it (#411) while rows read back
+    /// from PoracleNG do - without this the two signatures never match and nothing is ever remapped.
+    /// </summary>
+    private static readonly HashSet<string> IgnoredForIdentity =
+        new(StringComparer.Ordinal) { "uid", "distance", "profile_no" };
+
+    /// <summary>
+    /// Re-reads the tracking rows and moves any quick-pick tracked uid onto its replacement.
+    /// Best-effort: the distance update itself has already succeeded, so nothing here may throw.
+    /// </summary>
+    /// <param name="submitted">The rows as they were posted, still carrying their pre-write uids.</param>
+    public static async Task ApplyAsync(
+        IPoracleTrackingProxy proxy,
+        string trackingType,
+        string userId,
+        JsonElement submitted,
+        ITrackedUidRemapper uidRemapper,
+        ILogger logger)
+    {
+        try
+        {
+            var identityKeys = IdentityKeys(submitted);
+            if (identityKeys.Count == 0)
+            {
+                return;
+            }
+
+            var before = BuildIndex(submitted, identityKeys);
+            if (before.Count == 0)
+            {
+                return;
+            }
+
+            var after = BuildIndex(await proxy.GetByUserAsync(trackingType, userId), identityKeys);
+
+            foreach (var (signature, oldUid) in before)
+            {
+                if (oldUid is null)
+                {
+                    // Ambiguous before the write, so there is nothing safe to move.
+                    LogAmbiguous(logger, trackingType, signature);
+                    continue;
+                }
+
+                if (!after.TryGetValue(signature, out var newUid) || newUid is null)
+                {
+                    LogNoMatch(logger, trackingType, oldUid.Value);
+                    continue;
+                }
+
+                if (newUid.Value != oldUid.Value)
+                {
+                    await uidRemapper.RemapAsync(userId, trackingType, oldUid.Value, newUid.Value);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // The distance change is already applied upstream. Failing here would fail a request that
+            // worked, to protect a quick pick's Remove button.
+            LogRemapFailed(logger, ex, trackingType);
+        }
+    }
+
+    /// <summary>
+    /// Maps each row's identity signature to its uid. A signature seen more than once maps to
+    /// <c>null</c>, which means "ambiguous — do not touch".
+    /// </summary>
+    private static Dictionary<string, int?> BuildIndex(JsonElement rows, IReadOnlyCollection<string> identityKeys)
+    {
+        var index = new Dictionary<string, int?>(StringComparer.Ordinal);
+
+        if (rows.ValueKind != JsonValueKind.Array)
+        {
+            return index;
+        }
+
+        foreach (var row in rows.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!row.TryGetProperty("uid", out var uidProp) || uidProp.ValueKind != JsonValueKind.Number)
+            {
+                continue;
+            }
+
+            var signature = Signature(row, identityKeys);
+            index[signature] = index.ContainsKey(signature) ? null : uidProp.GetInt32();
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// The property names that identify a row, taken from what we submitted.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the outgoing payload rather than fixed, because PoracleNG returns fields we never
+    /// send - a rendered <c>description</c>, and <c>profile_no</c> which outgoing writes deliberately omit
+    /// (#411). Comparing full property sets therefore never matched anything, which is how the first
+    /// version of this shipped green unit tests and did nothing at all in practice.
+    /// </remarks>
+    private static IReadOnlyCollection<string> IdentityKeys(JsonElement rows)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+
+        if (rows.ValueKind != JsonValueKind.Array)
+        {
+            return keys;
+        }
+
+        foreach (var row in rows.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            foreach (var prop in row.EnumerateObject())
+            {
+                if (!IgnoredForIdentity.Contains(prop.Name))
+                {
+                    keys.Add(prop.Name);
+                }
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>The identity fields, name-sorted so property order cannot affect the result.</summary>
+    private static string Signature(JsonElement row, IReadOnlyCollection<string> identityKeys) =>
+        string.Join(
+            "|",
+            identityKeys
+                .OrderBy(k => k, StringComparer.Ordinal)
+                .Select(k => row.TryGetProperty(k, out var v) ? $"{k}={v.GetRawText()}" : $"{k}=<absent>"));
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Two {TrackingType} rows share an identity after a bulk distance update; leaving quick-pick uids alone rather than guessing.")]
+    private static partial void LogAmbiguous(ILogger logger, string trackingType, string signature);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "No replacement row found for {TrackingType} uid {OldUid} after a bulk distance update.")]
+    private static partial void LogNoMatch(ILogger logger, string trackingType, int oldUid);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Could not follow quick-pick tracked uids through a bulk {TrackingType} distance update; removing an affected quick pick may leave its alarms behind.")]
+    private static partial void LogRemapFailed(ILogger logger, Exception exception, string trackingType);
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -97,6 +97,11 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -118,6 +123,11 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -95,6 +95,11 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -116,6 +121,11 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -95,6 +95,11 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -116,6 +121,11 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -104,6 +104,11 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -125,6 +130,11 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
@@ -102,6 +102,11 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -123,6 +128,11 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
@@ -109,6 +109,11 @@ public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate 
         {
             var body = SerializeToElement(itemList);
             await this._proxy.CreateAsync(TrackingType, userId, body);
+
+            // The rows were deleted and re-made, so every uid changed. Follow any quick pick that
+            // tracks them, pairing on content because the batch response is reordered. See #443.
+            await BulkUidRemap.ApplyAsync(
+                this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
         }
         catch (Exception ex)
         {
@@ -144,6 +149,11 @@ public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate 
         {
             var body = SerializeToElement(matching);
             await this._proxy.CreateAsync(TrackingType, userId, body);
+
+            // The rows were deleted and re-made, so every uid changed. Follow any quick pick that
+            // tracks them, pairing on content because the batch response is reordered. See #443.
+            await BulkUidRemap.ApplyAsync(
+                this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
         }
         catch (Exception ex)
         {

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -95,6 +95,11 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -116,6 +121,11 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -95,6 +95,11 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -116,6 +121,11 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -95,6 +95,11 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(itemList);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return itemList.Count;
     }
 
@@ -116,6 +121,11 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         var body = SerializeToElement(matching);
         await this._proxy.CreateAsync(TrackingType, userId, body);
+        // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
+        // tracks them, pairing on content because the batch response is reordered. See #443.
+        await BulkUidRemap.ApplyAsync(
+            this._proxy, TrackingType, userId, body, this._uidRemapper, this._logger);
+
         return matching.Count;
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/BulkUidRemapTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/BulkUidRemapTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// Bulk distance updates rewrite every row, so all their uids change. #403 fixed the single-edit case
+/// using the create response's 1:1 mapping; that cannot work here because the batch response comes back
+/// reordered — submitting lures 161, 162, 163 returned 164, 165, 166 mapping to 163, 162, 161. Pairing by
+/// position would repoint a quick pick at somebody else's alarm, so pairing is done on content. See #443.
+/// </summary>
+public class BulkUidRemapTests
+{
+    private readonly Mock<IPoracleTrackingProxy> _proxy = new();
+    private readonly Mock<ITrackedUidRemapper> _remapper = new();
+
+    private static JsonElement Rows(params (int Uid, int LureId, int Distance)[] rows) =>
+        JsonSerializer.SerializeToElement(
+            rows.Select(r => new { uid = r.Uid, lure_id = r.LureId, distance = r.Distance, id = "u1" }));
+
+    private Task RunAsync(JsonElement submitted) => BulkUidRemap.ApplyAsync(
+        this._proxy.Object, "lure", "u1", submitted, this._remapper.Object, NullLogger.Instance);
+
+    [Fact]
+    public async Task PairsByContentEvenWhenTheResponseComesBackReversed()
+    {
+        // The exact ordering observed against PoracleNG.
+        var submitted = Rows((161, 501, 700), (162, 502, 700), (163, 503, 700));
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1"))
+            .ReturnsAsync(Rows((164, 503, 700), (165, 502, 700), (166, 501, 700)));
+
+        await this.RunAsync(submitted);
+
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 161, 166), Times.Once);
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 162, 165), Times.Once);
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 163, 164), Times.Once);
+    }
+
+    [Fact]
+    public async Task DoesNotPairByPosition()
+    {
+        // The wrong answer, spelled out: 161 must not become 164.
+        var submitted = Rows((161, 501, 700), (162, 502, 700), (163, 503, 700));
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1"))
+            .ReturnsAsync(Rows((164, 503, 700), (165, 502, 700), (166, 501, 700)));
+
+        await this.RunAsync(submitted);
+
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 161, 164), Times.Never);
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 163, 166), Times.Never);
+    }
+
+    [Fact]
+    public async Task MatchesEvenThoughOutgoingRowsCarryNoProfileNo()
+    {
+        // Alarm writes stopped sending profile_no (#411) but rows read back from PoracleNG still have it.
+        // Without excluding it the signatures never match and nothing is ever remapped -- which is exactly
+        // what happened on the first live run of this fix.
+        var submitted = JsonSerializer.SerializeToElement(
+            new[] { new { uid = 172, lure_id = 501, distance = 900, id = "u1" } });
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(
+            JsonSerializer.SerializeToElement(
+                new[] { new { uid = 173, lure_id = 501, distance = 900, id = "u1", profile_no = 0 } }));
+
+        await this.RunAsync(submitted);
+
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 172, 173), Times.Once);
+    }
+
+    [Fact]
+    public async Task IgnoresTheDistanceChangeWhenMatching()
+    {
+        // Distance is the field that changed, so it cannot take part in identity.
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows((200, 501, 900)));
+
+        await this.RunAsync(Rows((199, 501, 500)));
+
+        this._remapper.Verify(r => r.RemapAsync("u1", "lure", 199, 200), Times.Once);
+    }
+
+    [Fact]
+    public async Task DoesNothingWhenTheUidSurvived()
+    {
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows((10, 501, 900)));
+
+        await this.RunAsync(Rows((10, 501, 500)));
+
+        this._remapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefusesToGuessWhenTwoRowsAreIndistinguishable()
+    {
+        // Identical apart from distance. Guessing here is exactly the failure this design avoids, and the
+        // two are interchangeable anyway once both carry the same distance.
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows((30, 501, 900), (31, 501, 900)));
+
+        await this.RunAsync(Rows((10, 501, 500), (11, 501, 500)));
+
+        this._remapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LeavesRowsAloneWhenNoReplacementIsFound()
+    {
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows((99, 999, 900)));
+
+        await this.RunAsync(Rows((10, 501, 500)));
+
+        this._remapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SwallowsAReadFailure()
+    {
+        // The distance change already applied upstream; failing here would fail a request that worked.
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ThrowsAsync(new HttpRequestException("down"));
+
+        await this.RunAsync(Rows((10, 501, 500)));
+    }
+
+    [Fact]
+    public async Task IgnoresAnEmptySubmission()
+    {
+        await this.RunAsync(JsonSerializer.SerializeToElement(Array.Empty<object>()));
+
+        this._proxy.Verify(p => p.GetByUserAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}


### PR DESCRIPTION
Closes #443, which is the half of #403 that was split out.

The bulk distance endpoints are a fetch-mutate-repost and PoracleNG rewrites every row, so all their uids change and quick-pick applied state went stale exactly as it did for single edits: **Remove** reported success, deleted nothing, and the next page load cleared the state so there was no way to retry.

### Pairing is by content, not position

The batch response comes back **reordered** — submitting lures 161, 162, 163 returns 164, 165, 166 mapping to 163, 162, 161. A positional remap would repoint a quick pick at another alarm, and its Remove would then delete something the user still wanted. Worse, and quieter, than the bug being fixed.

A bulk distance update changes exactly one field, so two rows are the same alarm when everything else matches. Ambiguous rows — identical apart from distance — are left alone rather than guessed, and they're interchangeable anyway once both carry the same distance.

### It took two live runs to get right, and both failures are now tests

1. Signatures compared full property sets, but outgoing writes omit `profile_no` (#411) while rows read back include it — so nothing ever matched.
2. PoracleNG also returns fields we never send, such as a rendered `description`, so even a fixed ignore-list was wrong.

Identity keys are now derived from the submitted payload and applied to both snapshots.

Worth being blunt about why the unit tests didn't catch either: the fixtures put identical keys on both sides, so they tested the code's assumption rather than reality. It shipped green and did nothing. The asymmetric case is now covered explicitly.

### Verification

Live, the issue's repro:

```
apply lure-glacial             -> trackedUids [176]
PUT /api/lures/distance/bulk   -> 200, live row is now uid 177
GET /api/quick-picks           -> trackedUids [177]    (was null — state wiped)
DELETE .../remove              -> 204, 0 rows remain   (was 404, alarm survived)
```

Backend 1713 passed. Nine tests cover the reversed-order case, an explicit assertion that positional pairing does *not* happen, the asymmetric key sets, the ambiguity refusal, and read failures being swallowed.

### Note

Monsters are excluded deliberately — PoracleNG upserts that type in place, so its uids don't rotate and `MonsterService` has no remapper to pass.

With this merged, #403 can close: both its routes are covered.