### PR TITLE
fix: error toasts, 12 settings strings and the paginator were never translated (#425)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.config.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.config.ts
@@ -1,17 +1,22 @@
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { MatPaginatorIntl } from '@angular/material/paginator';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
 import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader, provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { routes } from './app.routes';
+import { TranslatedPaginatorIntl } from './core/i18n/translated-paginator-intl';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { errorInterceptor } from './core/interceptors/error.interceptor';
 import { oidcRefreshInterceptor } from './core/interceptors/oidc-refresh.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    // Material ships English paginator labels; without this the admin tables stay partly
+    // English in every other locale. See #425.
+    { provide: MatPaginatorIntl, useClass: TranslatedPaginatorIntl },
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
     // oidcRefreshInterceptor sits closest to the backend so it catches a 401 (and can silently

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/locale-parity.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/locale-parity.spec.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Every locale had drifted to exactly 12 keys behind English, which the English fallback hid — the
+ * affected strings simply rendered in English inside otherwise-translated pages, so nothing looked
+ * broken. This fails the build the next time that happens. See #425.
+ */
+describe('locale parity', () => {
+  const dir = path.join(__dirname, '../../../assets/i18n');
+
+  const flatten = (value: unknown, prefix = ''): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      const dotted = prefix ? `${prefix}.${key}` : key;
+      if (child !== null && typeof child === 'object') {
+        Object.assign(out, flatten(child, dotted));
+      } else {
+        out[dotted] = String(child);
+      }
+    }
+    return out;
+  };
+
+  const load = (locale: string) => flatten(JSON.parse(fs.readFileSync(path.join(dir, `${locale}.json`), 'utf8')));
+
+  const english = load('en');
+  const locales = fs
+    .readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .map(f => f.replace('.json', ''))
+    .filter(l => l !== 'en');
+
+  it('ships more than one locale', () => {
+    expect(locales.length).toBeGreaterThan(0);
+  });
+
+  it.each(locales)('%s has exactly the same keys as en', locale => {
+    const keys = load(locale);
+    expect(Object.keys(keys).filter(k => !(k in english))).toEqual([]);
+    expect(Object.keys(english).filter(k => !(k in keys))).toEqual([]);
+  });
+
+  it.each(locales)('%s translates the error toasts the interceptor uses', locale => {
+    // These are the strings a user sees when something fails, so English here is the most visible
+    // kind of gap. HTTP_ERROR.* is the single namespace both the interceptor and ToastService use.
+    const keys = load(locale);
+    const untranslated = Object.keys(english)
+      .filter(k => k.startsWith('HTTP_ERROR.') || k === 'ERROR.FEATURE_DISABLED')
+      .filter(k => keys[k] === english[k]);
+
+    expect(untranslated).toEqual([]);
+  });
+
+  it.each(locales)('%s translates the paginator', locale => {
+    const keys = load(locale);
+    // RANGE strings are mostly interpolation tokens, so only the prose label is checked.
+    expect(keys['PAGINATOR.ITEMS_PER_PAGE']).not.toBe(english['PAGINATOR.ITEMS_PER_PAGE']);
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/translated-paginator-intl.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/translated-paginator-intl.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { TranslateService, provideTranslateService } from '@ngx-translate/core';
+
+import { TranslatedPaginatorIntl } from './translated-paginator-intl';
+
+/**
+ * Without a provided MatPaginatorIntl the paginator keeps Material's built-in English, so the admin
+ * tables stayed partly English in every other locale. See #425.
+ */
+describe('TranslatedPaginatorIntl', () => {
+  let intl: TranslatedPaginatorIntl;
+  let translate: TranslateService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideTranslateService(), TranslatedPaginatorIntl],
+    });
+    translate = TestBed.inject(TranslateService);
+    translate.setTranslation('en', {
+      PAGINATOR: {
+        FIRST_PAGE: 'First page',
+        ITEMS_PER_PAGE: 'Items per page:',
+        LAST_PAGE: 'Last page',
+        NEXT_PAGE: 'Next page',
+        PREVIOUS_PAGE: 'Previous page',
+        RANGE: '{{start}} - {{end}} of {{total}}',
+        RANGE_EMPTY: '0 of {{total}}',
+      },
+    });
+    translate.setTranslation('de', {
+      PAGINATOR: {
+        FIRST_PAGE: 'Erste Seite',
+        ITEMS_PER_PAGE: 'Einträge pro Seite:',
+        LAST_PAGE: 'Letzte Seite',
+        NEXT_PAGE: 'Nächste Seite',
+        PREVIOUS_PAGE: 'Vorherige Seite',
+        RANGE: '{{start}} - {{end}} von {{total}}',
+        RANGE_EMPTY: '0 von {{total}}',
+      },
+    });
+    translate.use('en');
+    intl = TestBed.inject(TranslatedPaginatorIntl);
+  });
+
+  it('translates the labels', () => {
+    expect(intl.itemsPerPageLabel).toBe('Items per page:');
+    expect(intl.nextPageLabel).toBe('Next page');
+    expect(intl.firstPageLabel).toBe('First page');
+  });
+
+  it('builds a 1-based inclusive range', () => {
+    expect(intl.getRangeLabel(0, 25, 120)).toBe('1 - 25 of 120');
+    expect(intl.getRangeLabel(1, 25, 120)).toBe('26 - 50 of 120');
+  });
+
+  it('clamps the final page to the total rather than overshooting', () => {
+    expect(intl.getRangeLabel(4, 25, 110)).toBe('101 - 110 of 110');
+  });
+
+  it('handles an empty table', () => {
+    expect(intl.getRangeLabel(0, 25, 0)).toBe('0 of 0');
+  });
+
+  it('re-reads its labels when the language changes mid-session', () => {
+    translate.use('de');
+
+    expect(intl.itemsPerPageLabel).toBe('Einträge pro Seite:');
+    expect(intl.getRangeLabel(0, 25, 120)).toBe('1 - 25 von 120');
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/translated-paginator-intl.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/i18n/translated-paginator-intl.ts
@@ -1,0 +1,53 @@
+import { Injectable, OnDestroy, inject } from '@angular/core';
+import { MatPaginatorIntl } from '@angular/material/paginator';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
+
+/**
+ * Localises the Material paginator.
+ *
+ * Without a provided `MatPaginatorIntl` the paginator keeps Material's built-in English — "Items per
+ * page:", "1 - 25 of 120", and the English aria-labels on the navigation buttons — so the admin tables
+ * stayed partly English in every other locale. See #425.
+ *
+ * Re-reads its labels whenever the active language changes, because the user can switch language
+ * without a reload.
+ */
+@Injectable()
+export class TranslatedPaginatorIntl extends MatPaginatorIntl implements OnDestroy {
+  private readonly subscription: Subscription;
+  private readonly translate = inject(TranslateService);
+
+  override getRangeLabel = (page: number, pageSize: number, length: number): string => {
+    const total = Math.max(length, 0);
+
+    if (total === 0 || pageSize === 0) {
+      return this.translate.instant('PAGINATOR.RANGE_EMPTY', { total });
+    }
+
+    const start = page * pageSize;
+    // The last page is usually short, and a rounding slip here is visible on every table.
+    const end = start < total ? Math.min(start + pageSize, total) : start + pageSize;
+
+    return this.translate.instant('PAGINATOR.RANGE', { end, start: start + 1, total });
+  };
+
+  constructor() {
+    super();
+    this.subscription = this.translate.onLangChange.subscribe(() => this.applyTranslations());
+    this.applyTranslations();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  private applyTranslations(): void {
+    this.itemsPerPageLabel = this.translate.instant('PAGINATOR.ITEMS_PER_PAGE');
+    this.nextPageLabel = this.translate.instant('PAGINATOR.NEXT_PAGE');
+    this.previousPageLabel = this.translate.instant('PAGINATOR.PREVIOUS_PAGE');
+    this.firstPageLabel = this.translate.instant('PAGINATOR.FIRST_PAGE');
+    this.lastPageLabel = this.translate.instant('PAGINATOR.LAST_PAGE');
+    this.changes.next();
+  }
+}

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.spec.ts
@@ -46,7 +46,7 @@ describe('errorInterceptor', () => {
 
     expect(localStorage.getItem('poracle_token')).toBeNull();
     expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: {} });
-    expect(toast.error).toHaveBeenCalledWith('ERROR.SESSION_EXPIRED');
+    expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.UNAUTHORIZED');
   });
 
   it('should show permission toast for 403 without disableKey', () => {
@@ -57,7 +57,7 @@ describe('errorInterceptor', () => {
       statusText: 'Forbidden',
     });
 
-    expect(toast.error).toHaveBeenCalledWith('ERROR.PERMISSION_DENIED');
+    expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.FORBIDDEN');
     expect(router.navigate).not.toHaveBeenCalled();
   });
 
@@ -86,7 +86,7 @@ describe('errorInterceptor', () => {
       statusText: 'Not Found',
     });
 
-    expect(toast.error).toHaveBeenCalledWith('ERROR.NOT_FOUND');
+    expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.NOT_FOUND');
   });
 
   it('should show server error toast for 500', () => {
@@ -97,7 +97,7 @@ describe('errorInterceptor', () => {
       statusText: 'Error',
     });
 
-    expect(toast.error).toHaveBeenCalledWith('ERROR.GENERIC');
+    expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.SERVER_ERROR');
   });
 
   it('should show unavailable toast for 502/503/504', () => {
@@ -110,7 +110,7 @@ describe('errorInterceptor', () => {
         statusText: 'Unavailable',
       });
 
-      expect(toast.error).toHaveBeenCalledWith('ERROR.SERVER_UNAVAILABLE');
+      expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.UNAVAILABLE');
     }
   });
 
@@ -119,7 +119,7 @@ describe('errorInterceptor', () => {
 
     httpMock.expectOne('/api/dashboard').error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
 
-    expect(toast.error).toHaveBeenCalledWith('ERROR.NETWORK');
+    expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.NETWORK');
   });
 
   describe('silent endpoints', () => {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
@@ -44,11 +44,14 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         router.navigate(['/login'], { queryParams: Object.fromEntries(params) });
       }
 
+      // Messages come from HTTP_ERROR.*, which ToastService already uses and which is translated in
+      // every locale. This interceptor used a parallel ERROR.* table carrying verbatim English in all
+      // ten locales, so a German user saw an English toast for the same status. See #425.
       // Don't show toasts for silent endpoints
       if (!silent) {
         switch (error.status) {
           case 401:
-            toast.error(translate.instant('ERROR.SESSION_EXPIRED'));
+            toast.error(translate.instant('HTTP_ERROR.UNAUTHORIZED'));
             break;
           case 403:
             // The backend tags "feature disabled" 403s by including a `disableKey` in the body
@@ -58,22 +61,22 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
               toast.error(translate.instant('ERROR.FEATURE_DISABLED'));
               router.navigate(['/dashboard']);
             } else {
-              toast.error(translate.instant('ERROR.PERMISSION_DENIED'));
+              toast.error(translate.instant('HTTP_ERROR.FORBIDDEN'));
             }
             break;
           case 404:
-            toast.error(translate.instant('ERROR.NOT_FOUND'));
+            toast.error(translate.instant('HTTP_ERROR.NOT_FOUND'));
             break;
           case 0:
-            toast.error(translate.instant('ERROR.NETWORK'));
+            toast.error(translate.instant('HTTP_ERROR.NETWORK'));
             break;
           case 500:
-            toast.error(translate.instant('ERROR.GENERIC'));
+            toast.error(translate.instant('HTTP_ERROR.SERVER_ERROR'));
             break;
           case 502:
           case 503:
           case 504:
-            toast.error(translate.instant('ERROR.SERVER_UNAVAILABLE'));
+            toast.error(translate.instant('HTTP_ERROR.UNAVAILABLE'));
             break;
         }
       }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Niveaugrænse",
+    "PVP_CAP_ALL": "Alle",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Standard — fra Poracle-konfigurationen"
   },
   "ALARM": {
     "LOCATION_MODE": "Placeringstilstand",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Vælg region",
     "SEARCH_REGIONS": "Søg regioner...",
     "TOGGLE_TOOLTIP": "Slå notifikationer til/fra for dette geofence i nuværende profil",
-    "CREATED_PREFIX": "Oprettet"
+    "CREATED_PREFIX": "Oprettet",
+    "REGION_OPTIONAL_HINT": "Valgfrit. Vælg en region, hvis dit geofence hører til en."
   },
   "CLEANING": {
     "PAGE_TITLE": "Oprydningstilstand",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Godkendelsesfejl: {{error}}",
     "ERR_NO_TOKEN": "Intet godkendelsestoken modtaget.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Log ind igen"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Denne funktion er deaktiveret af administratoren."
   },
   "ADMIN": {
     "USERS_TITLE": "Brugeradministration",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Kunne ikke godkende indsendelse",
     "SNACK_APPROVED": "\"{{name}}\" godkendt",
     "SNACK_FAILED_REJECT": "Kunne ikke afvise indsendelse",
-    "SNACK_REJECTED": "\"{{name}}\" afvist"
+    "SNACK_REJECTED": "\"{{name}}\" afvist",
+    "APPROVAL_REGION_HINT": "Vælg den region, dette geofence skal vises under."
   },
   "DIALOG": {
     "CANCEL": "Annuller",
@@ -1612,7 +1613,12 @@
     "DISCORD_ADMIN_IDS_LABEL": "Admin-ID'er",
     "DISCORD_ADMIN_IDS_DESC": "Discord-bruger-ID'er med admin-adgang (maskeret).",
     "DISCORD_GEOFENCE_FORUM_LABEL": "Geofence-forumkanal",
-    "DISCORD_GEOFENCE_FORUM_DESC": "Discord-forumkanal til geofence-indsendelsestråde."
+    "DISCORD_GEOFENCE_FORUM_DESC": "Discord-forumkanal til geofence-indsendelsestråde.",
+    "GROUP_AUTH": "Godkendelse",
+    "AUTH_MODE_LABEL": "Loginmetode",
+    "AUTH_MODE_LOCAL": "Lokal",
+    "AUTH_MODE_LOCAL_DESC": "Log ind direkte med Discord eller Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "Lokalt login er gennemtvunget af serverkonfigurationen."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Navn",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Standardafstand",
     "DEFAULT_DISTANCE_HINT": "Bruges til at udfylde radius for nye afstandsbaserede advarsler på forhånd.",
     "FOOTNOTE": "Gælder kun for nyoprettede advarsler — eksisterende ændres ikke."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Elementer pr. side:",
+    "RANGE": "{{start}} - {{end}} af {{total}}",
+    "RANGE_EMPTY": "0 af {{total}}",
+    "NEXT_PAGE": "Næste side",
+    "PREVIOUS_PAGE": "Forrige side",
+    "FIRST_PAGE": "Første side",
+    "LAST_PAGE": "Sidste side"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Level-Cap",
+    "PVP_CAP_ALL": "Alle",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Standard — aus der Poracle-Konfiguration"
   },
   "ALARM": {
     "LOCATION_MODE": "Standortmodus",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Region auswählen",
     "SEARCH_REGIONS": "Regionen suchen...",
     "TOGGLE_TOOLTIP": "Benachrichtigungen für dieses Geofence im aktuellen Profil umschalten",
-    "CREATED_PREFIX": "Erstellt"
+    "CREATED_PREFIX": "Erstellt",
+    "REGION_OPTIONAL_HINT": "Optional. Wähle eine Region, falls dein Geofence zu einer gehört."
   },
   "CLEANING": {
     "PAGE_TITLE": "Aufräummodus",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Authentifizierungsfehler: {{error}}",
     "ERR_NO_TOKEN": "Kein Authentifizierungstoken erhalten.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Erneut anmelden"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Diese Funktion wurde vom Administrator deaktiviert."
   },
   "ADMIN": {
     "USERS_TITLE": "Benutzerverwaltung",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Einreichung konnte nicht genehmigt werden",
     "SNACK_APPROVED": "\"{{name}}\" genehmigt",
     "SNACK_FAILED_REJECT": "Einreichung konnte nicht abgelehnt werden",
-    "SNACK_REJECTED": "\"{{name}}\" abgelehnt"
+    "SNACK_REJECTED": "\"{{name}}\" abgelehnt",
+    "APPROVAL_REGION_HINT": "Wähle die Region, unter der dieses Geofence erscheinen soll."
   },
   "DIALOG": {
     "CANCEL": "Abbrechen",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Verwerfen",
     "COLLAPSE_SECTION": "Abschnitt einklappen",
     "EXPAND_SECTION": "Abschnitt ausklappen",
-    "SUMMARY_ENABLED": "{{count}} von {{total}} aktiviert"
+    "SUMMARY_ENABLED": "{{count}} von {{total}} aktiviert",
+    "GROUP_AUTH": "Authentifizierung",
+    "AUTH_MODE_LABEL": "Anmeldemodus",
+    "AUTH_MODE_LOCAL": "Lokal",
+    "AUTH_MODE_LOCAL_DESC": "Direkt mit Discord oder Telegram anmelden.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "Die lokale Anmeldung wird durch die Serverkonfiguration erzwungen."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Name",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Standard-Entfernung",
     "DEFAULT_DISTANCE_HINT": "Wird verwendet, um den Radius für neue entfernungsbasierte Benachrichtigungen vorzubelegen.",
     "FOOTNOTE": "Gilt nur für neu erstellte Benachrichtigungen – bestehende bleiben unverändert."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Einträge pro Seite:",
+    "RANGE": "{{start}} - {{end}} von {{total}}",
+    "RANGE_EMPTY": "0 von {{total}}",
+    "NEXT_PAGE": "Nächste Seite",
+    "PREVIOUS_PAGE": "Vorherige Seite",
+    "FIRST_PAGE": "Erste Seite",
+    "LAST_PAGE": "Letzte Seite"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1189,13 +1189,7 @@
     "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "This feature has been disabled by the administrator."
   },
   "ADMIN": {
     "USERS_TITLE": "User Management",
@@ -1694,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Default distance",
     "DEFAULT_DISTANCE_HINT": "Used to pre-fill the radius for new distance-based alerts.",
     "FOOTNOTE": "Applies to newly created alerts only — existing alerts are unchanged."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Items per page:",
+    "RANGE": "{{start}} - {{end}} of {{total}}",
+    "RANGE_EMPTY": "0 of {{total}}",
+    "NEXT_PAGE": "Next page",
+    "PREVIOUS_PAGE": "Previous page",
+    "FIRST_PAGE": "First page",
+    "LAST_PAGE": "Last page"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Límite de nivel",
+    "PVP_CAP_ALL": "Todos",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Predeterminado — de la configuración de Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Modo de ubicación",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Seleccionar región",
     "SEARCH_REGIONS": "Buscar regiones...",
     "TOGGLE_TOOLTIP": "Activar/desactivar notificaciones para este geocerca en el perfil actual",
-    "CREATED_PREFIX": "Creado"
+    "CREATED_PREFIX": "Creado",
+    "REGION_OPTIONAL_HINT": "Opcional. Elige una región si tu geocerca pertenece a una."
   },
   "CLEANING": {
     "PAGE_TITLE": "Modo limpieza",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Error de autenticación: {{error}}",
     "ERR_NO_TOKEN": "No se recibió token de autenticación.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Iniciar sesión de nuevo"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "El administrador ha desactivado esta función."
   },
   "ADMIN": {
     "USERS_TITLE": "Gestión de usuarios",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Error al aprobar el envío",
     "SNACK_APPROVED": "\"{{name}}\" aprobada",
     "SNACK_FAILED_REJECT": "Error al rechazar el envío",
-    "SNACK_REJECTED": "\"{{name}}\" rechazada"
+    "SNACK_REJECTED": "\"{{name}}\" rechazada",
+    "APPROVAL_REGION_HINT": "Elige la región bajo la que aparecerá esta geocerca."
   },
   "DIALOG": {
     "CANCEL": "Cancelar",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Descartar",
     "COLLAPSE_SECTION": "Contraer sección",
     "EXPAND_SECTION": "Expandir sección",
-    "SUMMARY_ENABLED": "{{count}} de {{total}} activados"
+    "SUMMARY_ENABLED": "{{count}} de {{total}} activados",
+    "GROUP_AUTH": "Autenticación",
+    "AUTH_MODE_LABEL": "Modo de inicio de sesión",
+    "AUTH_MODE_LOCAL": "Local",
+    "AUTH_MODE_LOCAL_DESC": "Inicia sesión directamente con Discord o Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "El inicio de sesión local está forzado por la configuración del servidor."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nombre",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Distancia predeterminada",
     "DEFAULT_DISTANCE_HINT": "Se usa para rellenar el radio de las nuevas alertas basadas en distancia.",
     "FOOTNOTE": "Solo se aplica a las alertas nuevas; las existentes no se modifican."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Elementos por página:",
+    "RANGE": "{{start}} - {{end}} de {{total}}",
+    "RANGE_EMPTY": "0 de {{total}}",
+    "NEXT_PAGE": "Página siguiente",
+    "PREVIOUS_PAGE": "Página anterior",
+    "FIRST_PAGE": "Primera página",
+    "LAST_PAGE": "Última página"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normale",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Plafond de niveau",
+    "PVP_CAP_ALL": "Tous",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Par défaut — depuis la configuration Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Mode de localisation",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Sélectionner la région",
     "SEARCH_REGIONS": "Rechercher des régions...",
     "TOGGLE_TOOLTIP": "Activer/désactiver les notifications pour ce geofence sur le profil actuel",
-    "CREATED_PREFIX": "Créé"
+    "CREATED_PREFIX": "Créé",
+    "REGION_OPTIONAL_HINT": "Facultatif. Choisissez une région si votre géorepère appartient à l’une d’elles."
   },
   "CLEANING": {
     "PAGE_TITLE": "Mode nettoyage",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Erreur d'authentification : {{error}}",
     "ERR_NO_TOKEN": "Aucun jeton d'authentification reçu.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Se reconnecter"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Cette fonctionnalité a été désactivée par l’administrateur."
   },
   "ADMIN": {
     "USERS_TITLE": "Gestion des utilisateurs",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Échec de l'approbation de la soumission",
     "SNACK_APPROVED": "\"{{name}}\" approuvée",
     "SNACK_FAILED_REJECT": "Échec du rejet de la soumission",
-    "SNACK_REJECTED": "\"{{name}}\" rejetée"
+    "SNACK_REJECTED": "\"{{name}}\" rejetée",
+    "APPROVAL_REGION_HINT": "Choisissez la région sous laquelle ce géorepère apparaîtra."
   },
   "DIALOG": {
     "CANCEL": "Annuler",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Annuler",
     "COLLAPSE_SECTION": "Réduire la section",
     "EXPAND_SECTION": "Développer la section",
-    "SUMMARY_ENABLED": "{{count}} sur {{total}} activé(s)"
+    "SUMMARY_ENABLED": "{{count}} sur {{total}} activé(s)",
+    "GROUP_AUTH": "Authentification",
+    "AUTH_MODE_LABEL": "Mode de connexion",
+    "AUTH_MODE_LOCAL": "Local",
+    "AUTH_MODE_LOCAL_DESC": "Connexion directe avec Discord ou Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "La connexion locale est imposée par la configuration du serveur."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nom",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Distance par défaut",
     "DEFAULT_DISTANCE_HINT": "Utilisée pour préremplir le rayon des nouvelles alertes basées sur la distance.",
     "FOOTNOTE": "S'applique uniquement aux nouvelles alertes — les alertes existantes ne sont pas modifiées."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Éléments par page :",
+    "RANGE": "{{start}} - {{end}} sur {{total}}",
+    "RANGE_EMPTY": "0 sur {{total}}",
+    "NEXT_PAGE": "Page suivante",
+    "PREVIOUS_PAGE": "Page précédente",
+    "FIRST_PAGE": "Première page",
+    "LAST_PAGE": "Dernière page"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normale",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Limite di livello",
+    "PVP_CAP_ALL": "Tutti",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Predefinito — dalla configurazione di Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Modalità Posizione",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Seleziona Regione",
     "SEARCH_REGIONS": "Cerca regioni...",
     "TOGGLE_TOOLTIP": "Attiva/disattiva notifiche per questo geofence sul profilo corrente",
-    "CREATED_PREFIX": "Creato"
+    "CREATED_PREFIX": "Creato",
+    "REGION_OPTIONAL_HINT": "Facoltativo. Scegli una regione se il tuo geofence ne fa parte."
   },
   "CLEANING": {
     "PAGE_TITLE": "Modalità Pulizia",
@@ -1180,16 +1185,11 @@
     "ERR_OIDC_DISABLED": "L'accesso esterno è attualmente disabilitato.",
     "ERR_OIDC_NO_IDENTITY": "Il tuo provider di accesso esterno non ha restituito un account che possiamo associare. Assicurati che il tuo account Discord sia collegato.",
     "ERR_OIDC_TOKEN_EXCHANGE": "Accesso esterno non riuscito. Riprova.",
-    "ERR_OIDC_USERINFO": "Impossibile recuperare il tuo profilo dal provider di accesso esterno. Riprova."
+    "ERR_OIDC_USERINFO": "Impossibile recuperare il tuo profilo dal provider di accesso esterno. Riprova.",
+    "SIGN_IN_AGAIN": "Accedi di nuovo"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Questa funzione è stata disattivata dall'amministratore."
   },
   "ADMIN": {
     "USERS_TITLE": "Gestione Utenti",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Approvazione invio fallita",
     "SNACK_APPROVED": "\"{{name}}\" approvata",
     "SNACK_FAILED_REJECT": "Rifiuto invio fallito",
-    "SNACK_REJECTED": "\"{{name}}\" rifiutata"
+    "SNACK_REJECTED": "\"{{name}}\" rifiutata",
+    "APPROVAL_REGION_HINT": "Scegli la regione sotto cui apparirà questo geofence."
   },
   "DIALOG": {
     "CANCEL": "Annulla",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Annulla",
     "COLLAPSE_SECTION": "Comprimi sezione",
     "EXPAND_SECTION": "Espandi sezione",
-    "SUMMARY_ENABLED": "{{count}} di {{total}} attive"
+    "SUMMARY_ENABLED": "{{count}} di {{total}} attive",
+    "GROUP_AUTH": "Autenticazione",
+    "AUTH_MODE_LABEL": "Modalità di accesso",
+    "AUTH_MODE_LOCAL": "Locale",
+    "AUTH_MODE_LOCAL_DESC": "Accedi direttamente con Discord o Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "L'accesso locale è imposto dalla configurazione del server."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nome",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Distanza predefinita",
     "DEFAULT_DISTANCE_HINT": "Usata per precompilare il raggio dei nuovi avvisi basati sulla distanza.",
     "FOOTNOTE": "Si applica solo agli avvisi appena creati: quelli esistenti restano invariati."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Elementi per pagina:",
+    "RANGE": "{{start}} - {{end}} di {{total}}",
+    "RANGE_EMPTY": "0 di {{total}}",
+    "NEXT_PAGE": "Pagina successiva",
+    "PREVIOUS_PAGE": "Pagina precedente",
+    "FIRST_PAGE": "Prima pagina",
+    "LAST_PAGE": "Ultima pagina"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normaal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Levellimiet",
+    "PVP_CAP_ALL": "Alle",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Standaard — uit de Poracle-configuratie"
   },
   "ALARM": {
     "LOCATION_MODE": "Locatiemodus",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Regio Selecteren",
     "SEARCH_REGIONS": "Regio's zoeken...",
     "TOGGLE_TOOLTIP": "Meldingen voor deze geofence op het huidige profiel in-/uitschakelen",
-    "CREATED_PREFIX": "Gemaakt"
+    "CREATED_PREFIX": "Gemaakt",
+    "REGION_OPTIONAL_HINT": "Optioneel. Kies een regio als je geofence bij een regio hoort."
   },
   "CLEANING": {
     "PAGE_TITLE": "Opschoonmodus",
@@ -1180,16 +1185,11 @@
     "ERR_OIDC_DISABLED": "Externe login is momenteel uitgeschakeld.",
     "ERR_OIDC_NO_IDENTITY": "Je externe loginprovider heeft geen account teruggegeven dat we kunnen koppelen. Zorg ervoor dat je Discord-account is gekoppeld.",
     "ERR_OIDC_TOKEN_EXCHANGE": "Externe login mislukt. Probeer het opnieuw.",
-    "ERR_OIDC_USERINFO": "Kon je profiel niet ophalen van de externe loginprovider. Probeer het opnieuw."
+    "ERR_OIDC_USERINFO": "Kon je profiel niet ophalen van de externe loginprovider. Probeer het opnieuw.",
+    "SIGN_IN_AGAIN": "Opnieuw aanmelden"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Deze functie is uitgeschakeld door de beheerder."
   },
   "ADMIN": {
     "USERS_TITLE": "Gebruikersbeheer",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Inzending goedkeuren mislukt",
     "SNACK_APPROVED": "\"{{name}}\" goedgekeurd",
     "SNACK_FAILED_REJECT": "Inzending afwijzen mislukt",
-    "SNACK_REJECTED": "\"{{name}}\" afgewezen"
+    "SNACK_REJECTED": "\"{{name}}\" afgewezen",
+    "APPROVAL_REGION_HINT": "Kies de regio waaronder deze geofence verschijnt."
   },
   "DIALOG": {
     "CANCEL": "Annuleren",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Verwerpen",
     "COLLAPSE_SECTION": "Sectie inklappen",
     "EXPAND_SECTION": "Sectie uitklappen",
-    "SUMMARY_ENABLED": "{{count}} van {{total}} ingeschakeld"
+    "SUMMARY_ENABLED": "{{count}} van {{total}} ingeschakeld",
+    "GROUP_AUTH": "Authenticatie",
+    "AUTH_MODE_LABEL": "Aanmeldmodus",
+    "AUTH_MODE_LOCAL": "Lokaal",
+    "AUTH_MODE_LOCAL_DESC": "Meld je rechtstreeks aan met Discord of Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "Lokaal aanmelden wordt afgedwongen door de serverconfiguratie."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Naam",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Standaardafstand",
     "DEFAULT_DISTANCE_HINT": "Wordt gebruikt om de straal voor nieuwe afstandsmeldingen vooraf in te vullen.",
     "FOOTNOTE": "Geldt alleen voor nieuw aangemaakte meldingen — bestaande meldingen blijven ongewijzigd."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Items per pagina:",
+    "RANGE": "{{start}} - {{end}} van {{total}}",
+    "RANGE_EMPTY": "0 van {{total}}",
+    "NEXT_PAGE": "Volgende pagina",
+    "PREVIOUS_PAGE": "Vorige pagina",
+    "FIRST_PAGE": "Eerste pagina",
+    "LAST_PAGE": "Laatste pagina"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normalny",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Limit poziomu",
+    "PVP_CAP_ALL": "Wszystkie",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Domyślnie — z konfiguracji Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Tryb lokalizacji",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Wybierz region",
     "SEARCH_REGIONS": "Szukaj regionów...",
     "TOGGLE_TOOLTIP": "Włącz/wyłącz powiadomienia dla tego geofence w bieżącym profilu",
-    "CREATED_PREFIX": "Utworzono"
+    "CREATED_PREFIX": "Utworzono",
+    "REGION_OPTIONAL_HINT": "Opcjonalne. Wybierz region, jeśli twój geofence do niego należy."
   },
   "CLEANING": {
     "PAGE_TITLE": "Tryb czyszczenia",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Błąd uwierzytelniania: {{error}}",
     "ERR_NO_TOKEN": "Nie otrzymano tokenu uwierzytelniania.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Zaloguj się ponownie"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Ta funkcja została wyłączona przez administratora."
   },
   "ADMIN": {
     "USERS_TITLE": "Zarządzanie użytkownikami",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Nie udało się zatwierdzić zgłoszenia",
     "SNACK_APPROVED": "\"{{name}}\" zatwierdzony",
     "SNACK_FAILED_REJECT": "Nie udało się odrzucić zgłoszenia",
-    "SNACK_REJECTED": "\"{{name}}\" odrzucony"
+    "SNACK_REJECTED": "\"{{name}}\" odrzucony",
+    "APPROVAL_REGION_HINT": "Wybierz region, w którym pojawi się ten geofence."
   },
   "DIALOG": {
     "CANCEL": "Anuluj",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Odrzuć",
     "COLLAPSE_SECTION": "Zwiń sekcję",
     "EXPAND_SECTION": "Rozwiń sekcję",
-    "SUMMARY_ENABLED": "Włączono {{count}} z {{total}}"
+    "SUMMARY_ENABLED": "Włączono {{count}} z {{total}}",
+    "GROUP_AUTH": "Uwierzytelnianie",
+    "AUTH_MODE_LABEL": "Tryb logowania",
+    "AUTH_MODE_LOCAL": "Lokalne",
+    "AUTH_MODE_LOCAL_DESC": "Zaloguj się bezpośrednio przez Discord lub Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "Logowanie lokalne jest wymuszone przez konfigurację serwera."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nazwa",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Domyślna odległość",
     "DEFAULT_DISTANCE_HINT": "Używana do wstępnego wypełnienia promienia dla nowych alertów opartych na odległości.",
     "FOOTNOTE": "Dotyczy tylko nowo utworzonych alertów — istniejące pozostają bez zmian."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Elementów na stronę:",
+    "RANGE": "{{start}} - {{end}} z {{total}}",
+    "RANGE_EMPTY": "0 z {{total}}",
+    "NEXT_PAGE": "Następna strona",
+    "PREVIOUS_PAGE": "Poprzednia strona",
+    "FIRST_PAGE": "Pierwsza strona",
+    "LAST_PAGE": "Ostatnia strona"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Limite de nível",
+    "PVP_CAP_ALL": "Todos",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Padrão — da configuração do Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Modo de Localização",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Selecionar Região",
     "SEARCH_REGIONS": "Buscar regiões...",
     "TOGGLE_TOOLTIP": "Ativar/desativar notificações para este geofence no perfil atual",
-    "CREATED_PREFIX": "Criado"
+    "CREATED_PREFIX": "Criado",
+    "REGION_OPTIONAL_HINT": "Opcional. Escolha uma região se sua geocerca pertencer a uma."
   },
   "CLEANING": {
     "PAGE_TITLE": "Modo de Limpeza",
@@ -1180,16 +1185,11 @@
     "ERR_GENERIC": "Erro de autenticação: {{error}}",
     "ERR_NO_TOKEN": "Nenhum token de autenticação recebido.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Entrar novamente"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Este recurso foi desativado pelo administrador."
   },
   "ADMIN": {
     "USERS_TITLE": "Gerenciamento de Usuários",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Falha ao aprovar envio",
     "SNACK_APPROVED": "\"{{name}}\" aprovada",
     "SNACK_FAILED_REJECT": "Falha ao rejeitar envio",
-    "SNACK_REJECTED": "\"{{name}}\" rejeitada"
+    "SNACK_REJECTED": "\"{{name}}\" rejeitada",
+    "APPROVAL_REGION_HINT": "Escolha a região sob a qual esta geocerca aparecerá."
   },
   "DIALOG": {
     "CANCEL": "Cancelar",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Descartar",
     "COLLAPSE_SECTION": "Recolher seção",
     "EXPAND_SECTION": "Expandir seção",
-    "SUMMARY_ENABLED": "{{count}} de {{total}} ativadas"
+    "SUMMARY_ENABLED": "{{count}} de {{total}} ativadas",
+    "GROUP_AUTH": "Autenticação",
+    "AUTH_MODE_LABEL": "Modo de login",
+    "AUTH_MODE_LOCAL": "Local",
+    "AUTH_MODE_LOCAL_DESC": "Faça login diretamente com Discord ou Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "O login local é forçado pela configuração do servidor."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nome",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Distância padrão",
     "DEFAULT_DISTANCE_HINT": "Usada para preencher previamente o raio de novos alertas baseados em distância.",
     "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Itens por página:",
+    "RANGE": "{{start}} - {{end}} de {{total}}",
+    "RANGE_EMPTY": "0 de {{total}}",
+    "NEXT_PAGE": "Próxima página",
+    "PREVIOUS_PAGE": "Página anterior",
+    "FIRST_PAGE": "Primeira página",
+    "LAST_PAGE": "Última página"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Limite de nível",
+    "PVP_CAP_ALL": "Todos",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Predefinido — da configuração do Poracle"
   },
   "ALARM": {
     "LOCATION_MODE": "Modo de Localização",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Selecionar Região",
     "SEARCH_REGIONS": "Pesquisar regiões...",
     "TOGGLE_TOOLTIP": "Ativar/desativar notificações para este geofence no perfil atual",
-    "CREATED_PREFIX": "Criado"
+    "CREATED_PREFIX": "Criado",
+    "REGION_OPTIONAL_HINT": "Opcional. Escolhe uma região se a tua geocerca pertencer a uma."
   },
   "CLEANING": {
     "PAGE_TITLE": "Modo de Limpeza",
@@ -1180,16 +1185,11 @@
     "ERR_OIDC_TOKEN_EXCHANGE": "O início de sessão externo falhou. Tenta novamente.",
     "ERR_OIDC_USERINFO": "Não foi possível obter o teu perfil do fornecedor de início de sessão externo. Tenta novamente.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Iniciar sessão novamente"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Esta funcionalidade foi desativada pelo administrador."
   },
   "ADMIN": {
     "USERS_TITLE": "Gestão de Utilizadores",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Falha ao aprovar submissão",
     "SNACK_APPROVED": "\"{{name}}\" aprovada",
     "SNACK_FAILED_REJECT": "Falha ao rejeitar submissão",
-    "SNACK_REJECTED": "\"{{name}}\" rejeitada"
+    "SNACK_REJECTED": "\"{{name}}\" rejeitada",
+    "APPROVAL_REGION_HINT": "Escolhe a região sob a qual esta geocerca aparecerá."
   },
   "DIALOG": {
     "CANCEL": "Cancelar",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Descartar",
     "COLLAPSE_SECTION": "Recolher secção",
     "EXPAND_SECTION": "Expandir secção",
-    "SUMMARY_ENABLED": "{{count}} de {{total}} ativos"
+    "SUMMARY_ENABLED": "{{count}} de {{total}} ativos",
+    "GROUP_AUTH": "Autenticação",
+    "AUTH_MODE_LABEL": "Modo de início de sessão",
+    "AUTH_MODE_LOCAL": "Local",
+    "AUTH_MODE_LOCAL_DESC": "Inicia sessão diretamente com o Discord ou o Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "O início de sessão local é imposto pela configuração do servidor."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Nome",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Distância padrão",
     "DEFAULT_DISTANCE_HINT": "Usada para preencher previamente o raio de novos alertas baseados em distância.",
     "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Itens por página:",
+    "RANGE": "{{start}} - {{end}} de {{total}}",
+    "RANGE_EMPTY": "0 de {{total}}",
+    "NEXT_PAGE": "Página seguinte",
+    "PREVIOUS_PAGE": "Página anterior",
+    "FIRST_PAGE": "Primeira página",
+    "LAST_PAGE": "Última página"
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -297,7 +297,11 @@
     "SIZE_LABEL_XS": "XS",
     "SIZE_LABEL_NORMAL": "Normal",
     "SIZE_LABEL_XL": "XL",
-    "SIZE_LABEL_XXL": "XXL"
+    "SIZE_LABEL_XXL": "XXL",
+    "PVP_CAP": "Nivågräns",
+    "PVP_CAP_ALL": "Alla",
+    "PVP_CAP_LEVEL": "L{{level}}",
+    "PVP_CAP_HINT_DEFAULT": "Standard — från Poracle-konfigurationen"
   },
   "ALARM": {
     "LOCATION_MODE": "Platsläge",
@@ -975,7 +979,8 @@
     "SELECT_REGION": "Välj region",
     "SEARCH_REGIONS": "Sök regioner...",
     "TOGGLE_TOOLTIP": "Aktivera/inaktivera aviseringar för denna geofence i aktuell profil",
-    "CREATED_PREFIX": "Skapad"
+    "CREATED_PREFIX": "Skapad",
+    "REGION_OPTIONAL_HINT": "Valfritt. Välj en region om ditt geostängsel hör till en."
   },
   "CLEANING": {
     "PAGE_TITLE": "Städningsläge",
@@ -1180,16 +1185,11 @@
     "ERR_OIDC_TOKEN_EXCHANGE": "Extern inloggning misslyckades. Försök igen.",
     "ERR_OIDC_USERINFO": "Kunde inte hämta din profil från den externa inloggningsleverantören. Försök igen.",
     "SIGN_UP": "Sign Up",
-    "SIGN_UP_DESC": "Don't have an account? Sign up to get started."
+    "SIGN_UP_DESC": "Don't have an account? Sign up to get started.",
+    "SIGN_IN_AGAIN": "Logga in igen"
   },
   "ERROR": {
-    "SESSION_EXPIRED": "Session expired. Please log in again.",
-    "PERMISSION_DENIED": "You don't have permission for this action.",
-    "FEATURE_DISABLED": "This feature has been disabled by the administrator.",
-    "NOT_FOUND": "The requested resource was not found.",
-    "NETWORK": "Network error. Check your connection.",
-    "GENERIC": "Something went wrong. Please try again.",
-    "SERVER_UNAVAILABLE": "Server is temporarily unavailable."
+    "FEATURE_DISABLED": "Den här funktionen har inaktiverats av administratören."
   },
   "ADMIN": {
     "USERS_TITLE": "Användarhantering",
@@ -1341,7 +1341,8 @@
     "SNACK_FAILED_APPROVE": "Kunde inte godkänna inskickning",
     "SNACK_APPROVED": "\"{{name}}\" godkänd",
     "SNACK_FAILED_REJECT": "Kunde inte avvisa inskickning",
-    "SNACK_REJECTED": "\"{{name}}\" avvisad"
+    "SNACK_REJECTED": "\"{{name}}\" avvisad",
+    "APPROVAL_REGION_HINT": "Välj den region som detta geostängsel ska visas under."
   },
   "DIALOG": {
     "CANCEL": "Avbryt",
@@ -1612,7 +1613,12 @@
     "DISCARD_CHANGES": "Ångra",
     "COLLAPSE_SECTION": "Fäll ihop sektion",
     "EXPAND_SECTION": "Expandera sektion",
-    "SUMMARY_ENABLED": "{{count}} av {{total}} aktiverade"
+    "SUMMARY_ENABLED": "{{count}} av {{total}} aktiverade",
+    "GROUP_AUTH": "Autentisering",
+    "AUTH_MODE_LABEL": "Inloggningsläge",
+    "AUTH_MODE_LOCAL": "Lokal",
+    "AUTH_MODE_LOCAL_DESC": "Logga in direkt med Discord eller Telegram.",
+    "AUTH_FORCE_LOCAL_ACTIVE": "Lokal inloggning tvingas av serverkonfigurationen."
   },
   "GEOFENCE_DETAIL": {
     "NAME": "Namn",
@@ -1682,5 +1688,14 @@
     "DEFAULT_DISTANCE": "Standardavstånd",
     "DEFAULT_DISTANCE_HINT": "Används för att förifylla radien för nya avståndsbaserade aviseringar.",
     "FOOTNOTE": "Gäller endast nyskapade aviseringar — befintliga ändras inte."
+  },
+  "PAGINATOR": {
+    "ITEMS_PER_PAGE": "Objekt per sida:",
+    "RANGE": "{{start}} - {{end}} av {{total}}",
+    "RANGE_EMPTY": "0 av {{total}}",
+    "NEXT_PAGE": "Nästa sida",
+    "PREVIOUS_PAGE": "Föregående sida",
+    "FIRST_PAGE": "Första sidan",
+    "LAST_PAGE": "Sista sidan"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Error messages, admin settings and table pagination stayed in English regardless of your language** ([#425](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/425)). Three separate gaps. Every error toast came from a message table that was never translated, even though a fully translated one sat beside it doing the same job for a different part of the app — both now use the translated one. Twelve strings were missing from every non-English locale, so the Authentication settings group, the PvP level-cap labels and a few hints rendered in English inside otherwise-translated pages; the English fallback made this invisible rather than obviously broken. And the table paginator on the admin pages kept Material's built-in English wording. A test now fails the build if any locale drifts from English again, or if the error toasts go untranslated.
+
+### Fixed
 - **A bulk distance change still made a quick pick impossible to remove** ([#443](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/443)). The single-edit case was fixed in [#403](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/403), but the Update All and bulk-distance actions rewrite every row too, so the same stale-uid failure came back through them: Remove reported success, deleted nothing, and the next page load cleared the applied state so there was no way to try again. The replacement rows are now matched by their contents rather than their position, because the batch response comes back in a different order than it was sent — matching by position would have repointed a quick pick at somebody else's alarm and deleted the wrong one. Where two alarms are genuinely indistinguishable, nothing is moved rather than guessed.
 
 ### Fixed


### PR DESCRIPTION
Closes #425. Three gaps — and the first has a different cause than reported.

## The error toasts

`ERROR.*` and `HTTP_ERROR.*` are two parallel tables for the same HTTP statuses. The report calls `HTTP_ERROR.*` "dead code with no callers" — it isn't. It's what `ToastService.httpError()` uses, and it's fully translated in all ten locales. The *untranslated* table is `ERROR.*`, used by `errorInterceptor` and `disabled-feature.guard`.

So the app had a translated path and an untranslated path for the same failures, depending on which one reported it.

Consolidated onto the translated namespace rather than translating the duplicate: the interceptor now uses `HTTP_ERROR.*`, and the six `ERROR.*` keys it no longer needs are removed from every locale. `ERROR.FEATURE_DISABLED` stays — it has no HTTP equivalent — and is now translated.

## The 12 missing keys

Back-filled with real translations, not English copies: the Authentication settings group, the four PvP level-cap labels, the region hints, and `AUTH.SIGN_IN_AGAIN`. All 11 locales now have identical key sets — 0 missing, 0 extra.

## The paginator

Added `TranslatedPaginatorIntl`. Without a provided `MatPaginatorIntl`, Material keeps its built-in English, so the admin tables read "Items per page:" and "1 - 25 of 120" in every locale. It re-reads on language change, since the language can be switched without a reload.

## The guard matters more than the fix

`locale-parity.spec.ts` fails the build if any locale drifts from English again, if an error-toast string goes untranslated, or if the paginator does.

That's the point of this one. The English fallback meant the gap degraded *silently* — strings rendered in English inside otherwise-translated pages rather than showing raw keys — which is exactly why it survived long enough to be found by an audit rather than a user.

## Verification

Frontend 934 passed (up from 898: 36 new), ESLint and Prettier clean.