### PR TITLE
fix: eight interface defects from the regression sweep (#426)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/app.ts
@@ -299,7 +299,12 @@ export class App implements OnInit {
   }
 
   ngOnInit(): void {
-    this.settingsService.loadOnce().subscribe({
+    // Signed-out visitors get the public subset. loadOnce() hits the authenticated endpoint, so
+    // calling it on the login page produced a 401 and an uncaught HttpErrorResponse on every visit.
+    // AuthService re-runs loadOnce() once a token exists, so nothing is lost by deferring. See #426.
+    const settings$ = this.auth.isAuthenticated() ? this.settingsService.loadOnce() : this.settingsService.loadPublic();
+    settings$.subscribe({
+      error: () => this.i18n.init(undefined),
       next: () => {
         const allowed = this.settingsService.siteSettings()['allowed_languages'];
         this.i18n.init(allowed);
@@ -317,7 +322,14 @@ export class App implements OnInit {
   onKeydown(event: KeyboardEvent): void {
     const tag = (event.target as HTMLElement)?.tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-    if (document.querySelector('.cdk-overlay-pane')) {
+    // Tooltips and snackbars are also .cdk-overlay-pane, so keying off that alone meant hovering a
+    // toolbar button silently swallowed [, ] and ?. Only overlays that take focus - dialogs, menus,
+    // selects, autocompletes - should suppress shortcuts.
+    if (
+      document.querySelector(
+        '.cdk-overlay-pane .mat-mdc-dialog-container, .cdk-overlay-pane .mat-mdc-menu-panel, .cdk-overlay-pane .mat-mdc-select-panel, .cdk-overlay-pane .mat-mdc-autocomplete-panel',
+      )
+    ) {
       if (event.key === 'Escape') {
         this.showShortcutHelp.set(false);
       }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.html
@@ -36,164 +36,166 @@
     </div>
 
     <!-- Authentication mode: Local (Discord/Telegram) vs external SSO (OIDC) -->
-    <section class="settings-section">
-      <div class="section-header" style="border-left: 4px solid #7c4dff">
-        <mat-icon class="section-icon" style="color: #7c4dff">vpn_key</mat-icon>
-        <span class="section-label">{{ 'ADMIN_SETTINGS.GROUP_AUTH' | translate }}</span>
-      </div>
-
-      <div class="auth-mode-row">
-        <div class="setting-info">
-          <span class="setting-label">{{ 'ADMIN_SETTINGS.AUTH_MODE_LABEL' | translate }}</span>
-          <span class="setting-desc">{{
-            (authMode() === 'oidc' ? 'ADMIN_SETTINGS.AUTH_MODE_OIDC_DESC' : 'ADMIN_SETTINGS.AUTH_MODE_LOCAL_DESC') | translate
-          }}</span>
-        </div>
-        <mat-button-toggle-group
-          class="auth-mode-toggle"
-          [value]="authMode()"
-          (change)="setAuthMode($event.value)"
-          [attr.aria-label]="'ADMIN_SETTINGS.AUTH_MODE_LABEL' | translate">
-          <mat-button-toggle value="local">
-            <mat-icon>group</mat-icon>
-            {{ 'ADMIN_SETTINGS.AUTH_MODE_LOCAL' | translate }}
-          </mat-button-toggle>
-          <mat-button-toggle
-            value="oidc"
-            [disabled]="!oidcConfigured()"
-            [matTooltip]="!oidcConfigured() ? ('ADMIN_SETTINGS.AUTH_OIDC_NOT_CONFIGURED' | translate) : ''">
-            <mat-icon>vpn_key</mat-icon>
-            {{ 'ADMIN_SETTINGS.AUTH_MODE_OIDC' | translate }}
-          </mat-button-toggle>
-        </mat-button-toggle-group>
-      </div>
-
-      @if (!oidcConfigured()) {
-        <div class="config-hint">
-          <mat-icon>info_outline</mat-icon>
-          <span>{{ 'ADMIN_SETTINGS.AUTH_OIDC_NOT_CONFIGURED' | translate }}</span>
-        </div>
-      }
-
-      @if (authMode() === 'oidc') {
-        <div class="config-hint">
-          <mat-icon>info_outline</mat-icon>
-          <span>{{ 'ADMIN_SETTINGS.AUTH_OIDC_HIDES_LOCAL' | translate }}</span>
+    @if (authSectionVisible()) {
+      <section class="settings-section">
+        <div class="section-header" style="border-left: 4px solid #7c4dff">
+          <mat-icon class="section-icon" style="color: #7c4dff">vpn_key</mat-icon>
+          <span class="section-label">{{ 'ADMIN_SETTINGS.GROUP_AUTH' | translate }}</span>
         </div>
 
-        @if (oidcConfig()?.forceLocal) {
-          <div class="config-hint warning">
-            <mat-icon>warning</mat-icon>
-            <span>{{ 'ADMIN_SETTINGS.AUTH_FORCE_LOCAL_ACTIVE' | translate }}</span>
+        <div class="auth-mode-row">
+          <div class="setting-info">
+            <span class="setting-label">{{ 'ADMIN_SETTINGS.AUTH_MODE_LABEL' | translate }}</span>
+            <span class="setting-desc">{{
+              (authMode() === 'oidc' ? 'ADMIN_SETTINGS.AUTH_MODE_OIDC_DESC' : 'ADMIN_SETTINGS.AUTH_MODE_LOCAL_DESC') | translate
+            }}</span>
           </div>
-        }
+          <mat-button-toggle-group
+            class="auth-mode-toggle"
+            [value]="authMode()"
+            (change)="setAuthMode($event.value)"
+            [attr.aria-label]="'ADMIN_SETTINGS.AUTH_MODE_LABEL' | translate">
+            <mat-button-toggle value="local">
+              <mat-icon>group</mat-icon>
+              {{ 'ADMIN_SETTINGS.AUTH_MODE_LOCAL' | translate }}
+            </mat-button-toggle>
+            <mat-button-toggle
+              value="oidc"
+              [disabled]="!oidcConfigured()"
+              [matTooltip]="!oidcConfigured() ? ('ADMIN_SETTINGS.AUTH_OIDC_NOT_CONFIGURED' | translate) : ''">
+              <mat-icon>vpn_key</mat-icon>
+              {{ 'ADMIN_SETTINGS.AUTH_MODE_OIDC' | translate }}
+            </mat-button-toggle>
+          </mat-button-toggle-group>
+        </div>
 
-        @if (oidcEndSessionConfigured()) {
-          <div class="setting-row" [class.modified]="modifiedSettings().has('enable_oidc_slo')">
-            <div class="setting-info">
-              <span class="setting-label">{{ 'ADMIN_SETTINGS.AUTH_SLO_LABEL' | translate }}</span>
-              <span class="setting-desc">{{ 'ADMIN_SETTINGS.AUTH_SLO_DESC' | translate }}</span>
-            </div>
-            <div class="setting-control">
-              <mat-slide-toggle
-                [checked]="oidcSloEnabled()"
-                (change)="onBoolChange('enable_oidc_slo', $event.checked)"
-                color="primary"></mat-slide-toggle>
-            </div>
-          </div>
-        } @else {
+        @if (!oidcConfigured()) {
           <div class="config-hint">
             <mat-icon>info_outline</mat-icon>
-            <span>{{ 'ADMIN_SETTINGS.AUTH_SLO_UNAVAILABLE' | translate }}</span>
+            <span>{{ 'ADMIN_SETTINGS.AUTH_OIDC_NOT_CONFIGURED' | translate }}</span>
           </div>
         }
 
-        @if (oidcConfig(); as oidc) {
-          <div class="server-config-block">
-            <div class="server-config-header">
-              <mat-icon class="server-config-icon">dns</mat-icon>
-              <span class="server-config-title">{{ 'ADMIN_SETTINGS.OIDC_SERVER_CONFIG' | translate }}</span>
-              <span class="server-config-badge" [matTooltip]="'ADMIN.READ_ONLY_TOOLTIP' | translate">
-                {{ 'ADMIN.READ_ONLY' | translate }}
-              </span>
-            </div>
-            <div class="server-config-rows">
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_PROVIDER_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.providerName">{{ oidc.providerName || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_AUTHORIZATION_URL_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.authorizationUrl">{{ oidc.authorizationUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_TOKEN_URL_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.tokenUrl">{{ oidc.tokenUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_USERINFO_URL_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.userInfoUrl">{{ oidc.userInfoUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_CLIENT_ID_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.clientId">{{ oidc.clientId || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_SCOPES_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.scopes">{{ oidc.scopes || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_IDENTITY_CLAIM_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code [class.empty]="!oidc.identityClaim">{{ oidc.identityClaim || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
-                </div>
-              </div>
-              <mat-divider></mat-divider>
-              <div class="server-config-row">
-                <div class="setting-info">
-                  <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_USE_PKCE_LABEL' | translate }}</span>
-                </div>
-                <div class="server-config-value">
-                  <code>{{ oidc.usePkce ? 'true' : 'false' }}</code>
-                </div>
-              </div>
-            </div>
+        @if (authMode() === 'oidc') {
+          <div class="config-hint">
+            <mat-icon>info_outline</mat-icon>
+            <span>{{ 'ADMIN_SETTINGS.AUTH_OIDC_HIDES_LOCAL' | translate }}</span>
           </div>
+
+          @if (oidcConfig()?.forceLocal) {
+            <div class="config-hint warning">
+              <mat-icon>warning</mat-icon>
+              <span>{{ 'ADMIN_SETTINGS.AUTH_FORCE_LOCAL_ACTIVE' | translate }}</span>
+            </div>
+          }
+
+          @if (oidcEndSessionConfigured()) {
+            <div class="setting-row" [class.modified]="modifiedSettings().has('enable_oidc_slo')">
+              <div class="setting-info">
+                <span class="setting-label">{{ 'ADMIN_SETTINGS.AUTH_SLO_LABEL' | translate }}</span>
+                <span class="setting-desc">{{ 'ADMIN_SETTINGS.AUTH_SLO_DESC' | translate }}</span>
+              </div>
+              <div class="setting-control">
+                <mat-slide-toggle
+                  [checked]="oidcSloEnabled()"
+                  (change)="onBoolChange('enable_oidc_slo', $event.checked)"
+                  color="primary"></mat-slide-toggle>
+              </div>
+            </div>
+          } @else {
+            <div class="config-hint">
+              <mat-icon>info_outline</mat-icon>
+              <span>{{ 'ADMIN_SETTINGS.AUTH_SLO_UNAVAILABLE' | translate }}</span>
+            </div>
+          }
+
+          @if (oidcConfig(); as oidc) {
+            <div class="server-config-block">
+              <div class="server-config-header">
+                <mat-icon class="server-config-icon">dns</mat-icon>
+                <span class="server-config-title">{{ 'ADMIN_SETTINGS.OIDC_SERVER_CONFIG' | translate }}</span>
+                <span class="server-config-badge" [matTooltip]="'ADMIN.READ_ONLY_TOOLTIP' | translate">
+                  {{ 'ADMIN.READ_ONLY' | translate }}
+                </span>
+              </div>
+              <div class="server-config-rows">
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_PROVIDER_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.providerName">{{ oidc.providerName || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_AUTHORIZATION_URL_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.authorizationUrl">{{ oidc.authorizationUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_TOKEN_URL_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.tokenUrl">{{ oidc.tokenUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_USERINFO_URL_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.userInfoUrl">{{ oidc.userInfoUrl || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_CLIENT_ID_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.clientId">{{ oidc.clientId || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_SCOPES_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.scopes">{{ oidc.scopes || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_IDENTITY_CLAIM_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code [class.empty]="!oidc.identityClaim">{{ oidc.identityClaim || ('ADMIN.NOT_CONFIGURED' | translate) }}</code>
+                  </div>
+                </div>
+                <mat-divider></mat-divider>
+                <div class="server-config-row">
+                  <div class="setting-info">
+                    <span class="setting-label">{{ 'ADMIN_SETTINGS.OIDC_USE_PKCE_LABEL' | translate }}</span>
+                  </div>
+                  <div class="server-config-value">
+                    <code>{{ oidc.usePkce ? 'true' : 'false' }}</code>
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
         }
-      }
-    </section>
+      </section>
+    }
     <div class="section-gap"></div>
 
     @for (group of visibleGroups(); track group.labelKey; let last = $last; let i = $index) {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -412,9 +412,27 @@ export class AdminSettingsComponent implements OnInit {
   /** Current sign-in mode, derived from enable_oidc (opt-in; absent/false = local). */
   readonly authMode = computed<'local' | 'oidc'>(() => (this.getBool('enable_oidc') ? 'oidc' : 'local'));
 
+  readonly searchQuery = signal('');
+  /**
+   * The Authentication section is hand-written rather than driven by SETTING_GROUPS, so the search
+   * box never touched it and a nonsense query still left it on screen. See #426.
+   */
+  readonly authSectionVisible = computed(() => {
+    const query = this.searchQuery().trim().toLowerCase();
+    if (!query) return true;
+    return [
+      'ADMIN_SETTINGS.GROUP_AUTH',
+      'ADMIN_SETTINGS.AUTH_MODE_LABEL',
+      'ADMIN_SETTINGS.AUTH_MODE_LOCAL',
+      'ADMIN_SETTINGS.AUTH_MODE_OIDC',
+    ].some(key => this.i18n.instant(key).toLowerCase().includes(query));
+  });
+
   readonly bulkSaving = signal(false);
   readonly collapsedGroups = signal<Set<string>>(AdminSettingsComponent.loadCollapsed());
+
   readonly discordConfig = signal<DiscordServerConfig | null>(null);
+
   readonly iconRepos = [
     {
       name: 'Whitewillem (Ingame)',
@@ -487,10 +505,8 @@ export class AdminSettingsComponent implements OnInit {
   readonly oidcSloEnabled = computed(() => (this.getSettingValue('enable_oidc_slo') ?? '').toLowerCase() !== 'false');
 
   @ViewChild('searchInput') searchInput?: ElementRef<HTMLInputElement>;
-
-  readonly searchQuery = signal('');
-
   readonly settingsLoading = signal(true);
+
   readonly telegramConfig = signal<TelegramServerConfig | null>(null);
 
   readonly unknownSettings = computed(() =>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/cleaning/cleaning.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/cleaning/cleaning.component.ts
@@ -23,6 +23,12 @@ interface CleaningItem {
   type: CleanAlarmType;
 }
 
+/** Cleaning row type -> the matching field on the dashboard counts payload. */
+const DASHBOARD_COUNT_KEYS: Record<string, string> = {
+  maxbattles: 'maxBattles',
+  monsters: 'pokemon',
+};
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -196,7 +202,9 @@ export class CleaningComponent implements OnInit {
         error: () => this.loading.set(false),
         next: counts => {
           for (const item of this.cleaningItems) {
-            const key = item.type === 'monsters' ? 'pokemon' : item.type;
+            // The dashboard counts are camelCase; the cleaning rows use the API route names. Without
+            // this map, 'maxbattles' never matched 'maxBattles' and the row was permanently greyed out.
+            const key = DASHBOARD_COUNT_KEYS[item.type] ?? item.type;
             const count = (counts as unknown as Record<string, number>)[key] ?? 0;
             item.hasAlarms.set(count > 0);
           }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-list.component.ts
@@ -122,7 +122,7 @@ export class GymListComponent implements OnInit {
         data: {
           confirmText: this.i18n.instant('COMMON.DELETE'),
           message: `${this.i18n.instant('COMMON.DELETE')} ${this.getTeamName(gym.team)}?`,
-          title: this.i18n.instant('GYMS.EDIT_DIALOG_TITLE'),
+          title: this.i18n.instant('GYMS.CONFIRM_DELETE_TITLE'),
           warn: true,
         } as ConfirmDialogData,
       })

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-add-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-add-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -23,6 +24,8 @@ describe('LureAddDialogComponent', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // delivery-preview links to /areas with routerLink, so a router is required.
+        provideRouter([]),
         provideTranslateService(),
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -34,6 +35,8 @@ describe('LureEditDialogComponent', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // delivery-preview links to /areas with routerLink, so a router is required.
+        provideRouter([]),
         provideTranslateService(),
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-list.component.ts
@@ -119,7 +119,7 @@ export class LureListComponent implements OnInit {
         data: {
           confirmText: this.i18n.instant('COMMON.DELETE'),
           message: `${this.i18n.instant('COMMON.DELETE')} ${this.getLureName(lure.lureId)} ${this.i18n.instant('LURES.LURE_SUFFIX')}?`,
-          title: this.i18n.instant('LURES.EDIT_DIALOG_TITLE'),
+          title: this.i18n.instant('LURES.CONFIRM_DELETE_TITLE'),
           warn: true,
         } as ConfirmDialogData,
       })

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-list.component.ts
@@ -124,7 +124,7 @@ export class NestListComponent implements OnInit {
         data: {
           confirmText: this.i18n.instant('COMMON.DELETE'),
           message: this.i18n.instant('POKEMON.CONFIRM_DELETE_MSG', { name: this.getPokemonName(nest.pokemonId) }),
-          title: this.i18n.instant('NESTS.EDIT_DIALOG_TITLE'),
+          title: this.i18n.instant('NESTS.CONFIRM_DELETE_TITLE'),
           warn: true,
         } as ConfirmDialogData,
       })

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-add-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-add-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -25,6 +26,8 @@ describe('QuestAddDialogComponent', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // delivery-preview links to /areas with routerLink, so a router is required.
+        provideRouter([]),
         provideTranslateService(),
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -38,6 +39,8 @@ describe('QuestEditDialogComponent', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // delivery-preview links to /areas with routerLink, so a router is required.
+        provideRouter([]),
         provideTranslateService(),
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.ts
@@ -208,7 +208,9 @@ export class QuestListComponent implements OnInit {
       return this.i18n.instant('QUESTS.CANDY_SUFFIX', { name: this.masterData.getPokemonName(pokemonId) });
     }
     if (quest.rewardType === 2) {
-      return this.masterData.getItemName(quest.reward);
+      // reward 0 is the dialog default, meaning any item. getItemName has no id 0, so this used to
+      // render as "Item #0" -- the Pokemon branch above already has the equivalent "any" case.
+      return quest.reward > 0 ? this.masterData.getItemName(quest.reward) : this.i18n.instant('QUESTS.ANY_ITEM');
     }
     if (quest.rewardType === 3) {
       return quest.reward > 0

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 
 import { QuickPickApplyDialogComponent } from './quick-pick-apply-dialog.component';
@@ -35,6 +36,8 @@ describe('QuickPickApplyDialogComponent', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // delivery-preview links to /areas with routerLink, so a router is required.
+        provideRouter([]),
         provideTranslateService(),
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.html
@@ -31,7 +31,11 @@
       <mat-label>{{ 'ALERT_DEFAULTS.DEFAULT_DISTANCE' | translate }}</mat-label>
       <input matInput type="number" [(ngModel)]="distanceKm" [min]="minKm" [max]="maxKm" step="0.1" />
       <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-      <mat-hint>{{ 'ALERT_DEFAULTS.DEFAULT_DISTANCE_HINT' | translate }}</mat-hint>
+      @if (distanceError) {
+        <mat-hint class="distance-error">{{ distanceError | translate }}</mat-hint>
+      } @else {
+        <mat-hint>{{ 'ALERT_DEFAULTS.DEFAULT_DISTANCE_HINT' | translate }}</mat-hint>
+      }
     </mat-form-field>
   }
 
@@ -45,5 +49,5 @@
 
 <mat-dialog-actions align="end">
   <button mat-button (click)="dialogRef.close(null)">{{ 'COMMON.CANCEL' | translate }}</button>
-  <button mat-raised-button color="primary" (click)="save()">{{ 'COMMON.SAVE' | translate }}</button>
+  <button mat-raised-button color="primary" [disabled]="!canSave" (click)="save()">{{ 'COMMON.SAVE' | translate }}</button>
 </mat-dialog-actions>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.scss
@@ -81,3 +81,9 @@ mat-dialog-content {
   height: 16px;
   font-size: 16px;
 }
+
+// Rides in the hint slot because <mat-error> only renders when the control reports an
+// error state, which a bare ngModel never does. See #426 / #427.
+.distance-error {
+  color: var(--mat-sys-error, #b3261e);
+}

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.spec.ts
@@ -53,12 +53,47 @@ describe('AlertDefaultsDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
-  it('clamps an out-of-range distance before persisting', () => {
+  // This used to assert the silent clamp: the dialog accepted 200 km, echoed "200 km" in the live
+  // preview, then stored 100. That WAS the bug -- the user was shown one number and given another.
+  // Out-of-range input is now refused instead. See #426.
+  it('refuses to save a distance above the maximum', () => {
     const component = create();
     component.mode.set('distance');
     component.distanceKm = 99999;
+
+    expect(component.distanceError).toBe('ALERT_DEFAULTS.DISTANCE_TOO_LARGE');
+    expect(component.canSave).toBe(false);
+
     component.save();
 
-    expect(localStorage.getItem('poracle-default-alert-distance-km')).toBe(String(component.maxKm));
+    expect(localStorage.getItem('poracle-default-alert-distance-km')).toBeNull();
+  });
+
+  it.each([0, -5, 0.05])('refuses %p, which used to be silently saved as 1', km => {
+    const component = create();
+    component.mode.set('distance');
+    component.distanceKm = km;
+
+    expect(component.distanceError).toBe('ALERT_DEFAULTS.DISTANCE_TOO_SMALL');
+    expect(component.canSave).toBe(false);
+  });
+
+  it('saves a valid distance', () => {
+    const component = create();
+    component.mode.set('distance');
+    component.distanceKm = 5;
+
+    expect(component.canSave).toBe(true);
+    component.save();
+
+    expect(localStorage.getItem('poracle-default-alert-distance-km')).toBe('5');
+  });
+
+  it('does not block saving in areas mode', () => {
+    const component = create();
+    component.mode.set('areas');
+    component.distanceKm = 99999;
+
+    expect(component.canSave).toBe(true);
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/alert-defaults-dialog/alert-defaults-dialog.component.ts
@@ -44,7 +44,24 @@ export class AlertDefaultsDialogComponent {
   readonly minKm = MIN_DEFAULT_DISTANCE_KM;
   mode = signal<AlertLocationMode>(this.alertDefaults.defaultMode());
 
+  get canSave(): boolean {
+    return this.distanceError === null;
+  }
+
+  /**
+   * The service clamps to 0.1-100 on save. Without surfacing that, the dialog accepted 200, showed
+   * "200 km" in the live preview, then stored 100 - and 0 or -5 silently became 1. See #426.
+   */
+  get distanceError(): string | null {
+    if (this.mode() !== 'distance') return null;
+    const km = this.distanceKm;
+    if (!Number.isFinite(km) || km < 0.1) return 'ALERT_DEFAULTS.DISTANCE_TOO_SMALL';
+    if (km > 100) return 'ALERT_DEFAULTS.DISTANCE_TOO_LARGE';
+    return null;
+  }
+
   save(): void {
+    if (!this.canSave) return;
     this.alertDefaults.save(this.mode(), this.distanceKm);
     this.dialogRef.close(true);
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.html
@@ -12,7 +12,7 @@
       </mat-chip-set>
     } @else {
       <p class="no-areas">
-        {{ 'DELIVERY_PREVIEW.NO_AREAS' | translate }} <a href="/areas">{{ 'DELIVERY_PREVIEW.SET_UP_AREAS' | translate }}</a>
+        {{ 'DELIVERY_PREVIEW.NO_AREAS' | translate }} <a routerLink="/areas">{{ 'DELIVERY_PREVIEW.SET_UP_AREAS' | translate }}</a>
         {{ 'DELIVERY_PREVIEW.FIRST' | translate }}
       </p>
     }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.ts
@@ -2,13 +2,14 @@ import { Component, Input, OnChanges, SimpleChanges, inject, signal } from '@ang
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import { AreaService } from '../../../core/services/area.service';
 import { LocationService } from '../../../core/services/location.service';
 
 @Component({
-  imports: [MatChipsModule, MatIconModule, MatProgressSpinnerModule, TranslatePipe],
+  imports: [RouterLink, MatChipsModule, MatIconModule, MatProgressSpinnerModule, TranslatePipe],
   selector: 'app-delivery-preview',
   standalone: true,
   styleUrl: './delivery-preview.component.scss',

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega-energi",
     "TAB_CANDY": "Slik",
     "ITEM_REWARD": "Genstandsbelønning",
-    "ANY_ITEM": "Alle genstande",
+    "ANY_ITEM": "Enhver genstand",
     "QUEST_TYPE_LABEL": "Quest-type:",
     "SNACK_CREATED": "Quest-alarm oprettet",
     "SNACK_UPDATED": "Quest-alarm opdateret",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Lokke #{{id}}",
     "EDIT_MODE": "Rediger beskeden på stedet",
     "EDIT_HINT": "Opdaterer den eksisterende Discord-besked, når lokkemodulet ændres, i stedet for at sende en ny.",
-    "EDIT_BADGE": "Rediger"
+    "EDIT_BADGE": "Rediger",
+    "CONFIRM_DELETE_TITLE": "Slet lokkemodul-alarm?"
   },
   "NESTS": {
     "PAGE_TITLE": "Rede-alarmer",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Rede-alarm slettet",
     "SNACK_FAILED_CREATE": "Kunne ikke oprette alarm",
     "SNACK_FAILED_UPDATE": "Kunne ikke opdatere alarm",
-    "SNACK_FAILED_DELETE": "Kunne ikke slette alarm"
+    "SNACK_FAILED_DELETE": "Kunne ikke slette alarm",
+    "CONFIRM_DELETE_TITLE": "Slet rede-alarm?"
   },
   "GYMS": {
     "PAGE_TITLE": "Gym-alarmer",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Mystic",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
-    "TEAM_UNKNOWN": "Hold {{id}}"
+    "TEAM_UNKNOWN": "Hold {{id}}",
+    "CONFIRM_DELETE_TITLE": "Slet gym-alarm?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-ændringsalarmer",
@@ -1687,7 +1690,9 @@
     "DESC": "Vælg, hvordan nye advarsler leveres som standard. Du kan stadig ændre dette for hver advarsel, når du opretter den.",
     "DEFAULT_DISTANCE": "Standardafstand",
     "DEFAULT_DISTANCE_HINT": "Bruges til at udfylde radius for nye afstandsbaserede advarsler på forhånd.",
-    "FOOTNOTE": "Gælder kun for nyoprettede advarsler — eksisterende ændres ikke."
+    "FOOTNOTE": "Gælder kun for nyoprettede advarsler — eksisterende ændres ikke.",
+    "DISTANCE_TOO_SMALL": "Skal være mindst 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Må højst være 100 km."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Elementer pr. side:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega-Energie",
     "TAB_CANDY": "Bonbons",
     "ITEM_REWARD": "Item-Belohnung",
-    "ANY_ITEM": "Beliebiges Item",
+    "ANY_ITEM": "Beliebiger Gegenstand",
     "QUEST_TYPE_LABEL": "Quest-Typ:",
     "SNACK_CREATED": "Quest-Alarm erstellt",
     "SNACK_UPDATED": "Quest-Alarm aktualisiert",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Modul #{{id}}",
     "EDIT_MODE": "Nachricht direkt bearbeiten",
     "EDIT_HINT": "Aktualisiert die vorhandene Discord-Nachricht bei Änderungen am Lockmodul, statt eine neue zu senden.",
-    "EDIT_BADGE": "Bearbeiten"
+    "EDIT_BADGE": "Bearbeiten",
+    "CONFIRM_DELETE_TITLE": "Lockmodul-Alarm löschen?"
   },
   "NESTS": {
     "PAGE_TITLE": "Nest-Alarme",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Nest-Alarm gelöscht",
     "SNACK_FAILED_CREATE": "Alarm konnte nicht erstellt werden",
     "SNACK_FAILED_UPDATE": "Alarm konnte nicht aktualisiert werden",
-    "SNACK_FAILED_DELETE": "Alarm konnte nicht gelöscht werden"
+    "SNACK_FAILED_DELETE": "Alarm konnte nicht gelöscht werden",
+    "CONFIRM_DELETE_TITLE": "Nest-Alarm löschen?"
   },
   "GYMS": {
     "PAGE_TITLE": "Arena-Alarme",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Weisheit",
     "TEAM_VALOR": "Wagemut",
     "TEAM_INSTINCT": "Intuition",
-    "TEAM_UNKNOWN": "Team {{id}}"
+    "TEAM_UNKNOWN": "Team {{id}}",
+    "CONFIRM_DELETE_TITLE": "Arena-Alarm löschen?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-Änderungs-Alarme",
@@ -1687,7 +1690,9 @@
     "DESC": "Lege fest, wie neue Benachrichtigungen standardmäßig zugestellt werden. Beim Erstellen jeder Benachrichtigung kannst du dies weiterhin ändern.",
     "DEFAULT_DISTANCE": "Standard-Entfernung",
     "DEFAULT_DISTANCE_HINT": "Wird verwendet, um den Radius für neue entfernungsbasierte Benachrichtigungen vorzubelegen.",
-    "FOOTNOTE": "Gilt nur für neu erstellte Benachrichtigungen – bestehende bleiben unverändert."
+    "FOOTNOTE": "Gilt nur für neu erstellte Benachrichtigungen – bestehende bleiben unverändert.",
+    "DISTANCE_TOO_SMALL": "Muss mindestens 0,1 km sein.",
+    "DISTANCE_TOO_LARGE": "Darf höchstens 100 km sein."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Einträge pro Seite:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Lure #{{id}}",
     "EDIT_MODE": "Edit message in place",
     "EDIT_HINT": "Update the existing Discord message when the lure changes instead of sending a new one.",
-    "EDIT_BADGE": "Edit"
+    "EDIT_BADGE": "Edit",
+    "CONFIRM_DELETE_TITLE": "Delete Lure Alarm?"
   },
   "NESTS": {
     "PAGE_TITLE": "Nest Alarms",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Nest alarm deleted",
     "SNACK_FAILED_CREATE": "Failed to create alarm",
     "SNACK_FAILED_UPDATE": "Failed to update alarm",
-    "SNACK_FAILED_DELETE": "Failed to delete alarm"
+    "SNACK_FAILED_DELETE": "Failed to delete alarm",
+    "CONFIRM_DELETE_TITLE": "Delete Nest Alarm?"
   },
   "GYMS": {
     "PAGE_TITLE": "Gym Alarms",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Mystic",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
-    "TEAM_UNKNOWN": "Team {{id}}"
+    "TEAM_UNKNOWN": "Team {{id}}",
+    "CONFIRM_DELETE_TITLE": "Delete Gym Alarm?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort Change Alarms",
@@ -1687,7 +1690,9 @@
     "DESC": "Choose how new alerts are delivered by default. You can still change this for each alert when you create it.",
     "DEFAULT_DISTANCE": "Default distance",
     "DEFAULT_DISTANCE_HINT": "Used to pre-fill the radius for new distance-based alerts.",
-    "FOOTNOTE": "Applies to newly created alerts only — existing alerts are unchanged."
+    "FOOTNOTE": "Applies to newly created alerts only — existing alerts are unchanged.",
+    "DISTANCE_TOO_SMALL": "Must be at least 0.1 km.",
+    "DISTANCE_TOO_LARGE": "Must be 100 km or less."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Items per page:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Señuelo #{{id}}",
     "EDIT_MODE": "Editar el mensaje en su lugar",
     "EDIT_HINT": "Actualiza el mensaje de Discord existente cuando cambia el cebo en lugar de enviar uno nuevo.",
-    "EDIT_BADGE": "Editar"
+    "EDIT_BADGE": "Editar",
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de cebo?"
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmas de Nido",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Alarma de Nido eliminada",
     "SNACK_FAILED_CREATE": "Error al crear la alarma",
     "SNACK_FAILED_UPDATE": "Error al actualizar la alarma",
-    "SNACK_FAILED_DELETE": "Error al eliminar la alarma"
+    "SNACK_FAILED_DELETE": "Error al eliminar la alarma",
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de nido?"
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmas de Gimnasio",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Sabiduría",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
-    "TEAM_UNKNOWN": "Equipo {{id}}"
+    "TEAM_UNKNOWN": "Equipo {{id}}",
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de gimnasio?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmas de Cambio de Fort",
@@ -1687,7 +1690,9 @@
     "DESC": "Elige cómo se entregan las nuevas alertas de forma predeterminada. Podrás cambiarlo para cada alerta al crearla.",
     "DEFAULT_DISTANCE": "Distancia predeterminada",
     "DEFAULT_DISTANCE_HINT": "Se usa para rellenar el radio de las nuevas alertas basadas en distancia.",
-    "FOOTNOTE": "Solo se aplica a las alertas nuevas; las existentes no se modifican."
+    "FOOTNOTE": "Solo se aplica a las alertas nuevas; las existentes no se modifican.",
+    "DISTANCE_TOO_SMALL": "Debe ser al menos 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Debe ser 100 km o menos."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Elementos por página:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Méga-Énergie",
     "TAB_CANDY": "Bonbons",
     "ITEM_REWARD": "Récompense objet",
-    "ANY_ITEM": "Tout objet",
+    "ANY_ITEM": "Objet quelconque",
     "QUEST_TYPE_LABEL": "Type de quête :",
     "SNACK_CREATED": "Alarme Quête créée",
     "SNACK_UPDATED": "Alarme Quête mise à jour",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Module #{{id}}",
     "EDIT_MODE": "Modifier le message sur place",
     "EDIT_HINT": "Met à jour le message Discord existant lorsque le leurre change au lieu d’en envoyer un nouveau.",
-    "EDIT_BADGE": "Modifier"
+    "EDIT_BADGE": "Modifier",
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de module leurre ?"
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes Nid",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Alarme Nid supprimée",
     "SNACK_FAILED_CREATE": "Échec de la création de l'alarme",
     "SNACK_FAILED_UPDATE": "Échec de la mise à jour de l'alarme",
-    "SNACK_FAILED_DELETE": "Échec de la suppression de l'alarme"
+    "SNACK_FAILED_DELETE": "Échec de la suppression de l'alarme",
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de nid ?"
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes Arène",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Sagesse",
     "TEAM_VALOR": "Bravoure",
     "TEAM_INSTINCT": "Intuition",
-    "TEAM_UNKNOWN": "Équipe {{id}}"
+    "TEAM_UNKNOWN": "Équipe {{id}}",
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte d'arène ?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes Changement de fort",
@@ -1687,7 +1690,9 @@
     "DESC": "Choisissez le mode de diffusion par défaut des nouvelles alertes. Vous pourrez toujours le modifier pour chaque alerte lors de sa création.",
     "DEFAULT_DISTANCE": "Distance par défaut",
     "DEFAULT_DISTANCE_HINT": "Utilisée pour préremplir le rayon des nouvelles alertes basées sur la distance.",
-    "FOOTNOTE": "S'applique uniquement aux nouvelles alertes — les alertes existantes ne sont pas modifiées."
+    "FOOTNOTE": "S'applique uniquement aux nouvelles alertes — les alertes existantes ne sont pas modifiées.",
+    "DISTANCE_TOO_SMALL": "Doit être d’au moins 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Doit être de 100 km au maximum."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Éléments par page :",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega Energia",
     "TAB_CANDY": "Caramelle",
     "ITEM_REWARD": "Ricompensa Oggetto",
-    "ANY_ITEM": "Qualsiasi Oggetto",
+    "ANY_ITEM": "Qualsiasi oggetto",
     "QUEST_TYPE_LABEL": "Tipo Missione:",
     "SNACK_CREATED": "Allarme missione creato",
     "SNACK_UPDATED": "Allarme missione aggiornato",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Esca #{{id}}",
     "EDIT_MODE": "Modifica il messaggio sul posto",
     "EDIT_HINT": "Aggiorna il messaggio Discord esistente quando il modulo esca cambia invece di inviarne uno nuovo.",
-    "EDIT_BADGE": "Modifica"
+    "EDIT_BADGE": "Modifica",
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso esca?"
   },
   "NESTS": {
     "PAGE_TITLE": "Allarmi Nidi",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Allarme nido eliminato",
     "SNACK_FAILED_CREATE": "Creazione allarme fallita",
     "SNACK_FAILED_UPDATE": "Aggiornamento allarme fallito",
-    "SNACK_FAILED_DELETE": "Eliminazione allarme fallita"
+    "SNACK_FAILED_DELETE": "Eliminazione allarme fallita",
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso nido?"
   },
   "GYMS": {
     "PAGE_TITLE": "Allarmi Palestre",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Saggezza",
     "TEAM_VALOR": "Coraggio",
     "TEAM_INSTINCT": "Istinto",
-    "TEAM_UNKNOWN": "Squadra {{id}}"
+    "TEAM_UNKNOWN": "Squadra {{id}}",
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso palestra?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Allarmi Modifiche Forte",
@@ -1687,7 +1690,9 @@
     "DESC": "Scegli come vengono recapitati i nuovi avvisi per impostazione predefinita. Potrai comunque modificarlo per ogni avviso al momento della creazione.",
     "DEFAULT_DISTANCE": "Distanza predefinita",
     "DEFAULT_DISTANCE_HINT": "Usata per precompilare il raggio dei nuovi avvisi basati sulla distanza.",
-    "FOOTNOTE": "Si applica solo agli avvisi appena creati: quelli esistenti restano invariati."
+    "FOOTNOTE": "Si applica solo agli avvisi appena creati: quelli esistenti restano invariati.",
+    "DISTANCE_TOO_SMALL": "Deve essere almeno 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Deve essere al massimo 100 km."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Elementi per pagina:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega Energie",
     "TAB_CANDY": "Snoep",
     "ITEM_REWARD": "Itembeloning",
-    "ANY_ITEM": "Elk Item",
+    "ANY_ITEM": "Elk voorwerp",
     "QUEST_TYPE_LABEL": "Questtype:",
     "SNACK_CREATED": "Quest alarm aangemaakt",
     "SNACK_UPDATED": "Quest alarm bijgewerkt",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Lokmodule #{{id}}",
     "EDIT_MODE": "Bericht ter plekke bewerken",
     "EDIT_HINT": "Werk het bestaande Discord-bericht bij wanneer de lokmodule verandert in plaats van een nieuw bericht te sturen.",
-    "EDIT_BADGE": "Bewerken"
+    "EDIT_BADGE": "Bewerken",
+    "CONFIRM_DELETE_TITLE": "Lokmodule-alarm verwijderen?"
   },
   "NESTS": {
     "PAGE_TITLE": "Nest Alarmen",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Nest alarm verwijderd",
     "SNACK_FAILED_CREATE": "Alarm aanmaken mislukt",
     "SNACK_FAILED_UPDATE": "Alarm bijwerken mislukt",
-    "SNACK_FAILED_DELETE": "Alarm verwijderen mislukt"
+    "SNACK_FAILED_DELETE": "Alarm verwijderen mislukt",
+    "CONFIRM_DELETE_TITLE": "Nest-alarm verwijderen?"
   },
   "GYMS": {
     "PAGE_TITLE": "Gym Alarmen",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Mystic",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
-    "TEAM_UNKNOWN": "Team {{id}}"
+    "TEAM_UNKNOWN": "Team {{id}}",
+    "CONFIRM_DELETE_TITLE": "Gym-alarm verwijderen?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fortwijziging Alarmen",
@@ -1687,7 +1690,9 @@
     "DESC": "Kies hoe nieuwe meldingen standaard worden bezorgd. Je kunt dit nog steeds per melding aanpassen bij het aanmaken.",
     "DEFAULT_DISTANCE": "Standaardafstand",
     "DEFAULT_DISTANCE_HINT": "Wordt gebruikt om de straal voor nieuwe afstandsmeldingen vooraf in te vullen.",
-    "FOOTNOTE": "Geldt alleen voor nieuw aangemaakte meldingen — bestaande meldingen blijven ongewijzigd."
+    "FOOTNOTE": "Geldt alleen voor nieuw aangemaakte meldingen — bestaande meldingen blijven ongewijzigd.",
+    "DISTANCE_TOO_SMALL": "Moet minimaal 0,1 km zijn.",
+    "DISTANCE_TOO_LARGE": "Mag maximaal 100 km zijn."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Items per pagina:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Wabik #{{id}}",
     "EDIT_MODE": "Edytuj wiadomość w miejscu",
     "EDIT_HINT": "Aktualizuje istniejącą wiadomość na Discordzie przy zmianie wabika zamiast wysyłać nową.",
-    "EDIT_BADGE": "Edycja"
+    "EDIT_BADGE": "Edycja",
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm wabika?"
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmy gniazd",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Alarm gniazda usunięty",
     "SNACK_FAILED_CREATE": "Nie udało się utworzyć alarmu",
     "SNACK_FAILED_UPDATE": "Nie udało się zaktualizować alarmu",
-    "SNACK_FAILED_DELETE": "Nie udało się usunąć alarmu"
+    "SNACK_FAILED_DELETE": "Nie udało się usunąć alarmu",
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm gniazda?"
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmy aren",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Mystic",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
-    "TEAM_UNKNOWN": "Drużyna {{id}}"
+    "TEAM_UNKNOWN": "Drużyna {{id}}",
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm areny?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmy zmian fortów",
@@ -1687,7 +1690,9 @@
     "DESC": "Wybierz, jak domyślnie dostarczane są nowe alerty. Nadal możesz to zmienić dla każdego alertu podczas jego tworzenia.",
     "DEFAULT_DISTANCE": "Domyślna odległość",
     "DEFAULT_DISTANCE_HINT": "Używana do wstępnego wypełnienia promienia dla nowych alertów opartych na odległości.",
-    "FOOTNOTE": "Dotyczy tylko nowo utworzonych alertów — istniejące pozostają bez zmian."
+    "FOOTNOTE": "Dotyczy tylko nowo utworzonych alertów — istniejące pozostają bez zmian.",
+    "DISTANCE_TOO_SMALL": "Musi wynosić co najmniej 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Musi wynosić maksymalnie 100 km."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Elementów na stronę:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega Energia",
     "TAB_CANDY": "Doce",
     "ITEM_REWARD": "Recompensa de Item",
-    "ANY_ITEM": "Qualquer Item",
+    "ANY_ITEM": "Qualquer item",
     "QUEST_TYPE_LABEL": "Tipo de Quest:",
     "SNACK_CREATED": "Alarme de quest criado",
     "SNACK_UPDATED": "Alarme de quest atualizado",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Módulo #{{id}}",
     "EDIT_MODE": "Editar a mensagem no local",
     "EDIT_HINT": "Atualiza a mensagem existente do Discord quando a isca muda em vez de enviar uma nova.",
-    "EDIT_BADGE": "Editar"
+    "EDIT_BADGE": "Editar",
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de isca?"
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes de Ninho",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Alarme de ninho excluído",
     "SNACK_FAILED_CREATE": "Falha ao criar alarme",
     "SNACK_FAILED_UPDATE": "Falha ao atualizar alarme",
-    "SNACK_FAILED_DELETE": "Falha ao excluir alarme"
+    "SNACK_FAILED_DELETE": "Falha ao excluir alarme",
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de ninho?"
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes de Ginásio",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Sabedoria",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
-    "TEAM_UNKNOWN": "Time {{id}}"
+    "TEAM_UNKNOWN": "Time {{id}}",
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de ginásio?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes de Mudança de Forte",
@@ -1687,7 +1690,9 @@
     "DESC": "Escolha como os novos alertas são entregues por padrão. Você ainda pode alterar isso para cada alerta ao criá-lo.",
     "DEFAULT_DISTANCE": "Distância padrão",
     "DEFAULT_DISTANCE_HINT": "Usada para preencher previamente o raio de novos alertas baseados em distância.",
-    "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados."
+    "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados.",
+    "DISTANCE_TOO_SMALL": "Deve ser pelo menos 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Deve ser 100 km ou menos."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Itens por página:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega Energia",
     "TAB_CANDY": "Doces",
     "ITEM_REWARD": "Recompensa de Item",
-    "ANY_ITEM": "Qualquer Item",
+    "ANY_ITEM": "Qualquer item",
     "QUEST_TYPE_LABEL": "Tipo de Missão:",
     "SNACK_CREATED": "Alarme de missão criado",
     "SNACK_UPDATED": "Alarme de missão atualizado",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Módulo #{{id}}",
     "EDIT_MODE": "Editar a mensagem no local",
     "EDIT_HINT": "Atualiza a mensagem existente do Discord quando o engodo muda em vez de enviar uma nova.",
-    "EDIT_BADGE": "Editar"
+    "EDIT_BADGE": "Editar",
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de isco?"
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes de Ninhos",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Alarme de ninho eliminado",
     "SNACK_FAILED_CREATE": "Falha ao criar alarme",
     "SNACK_FAILED_UPDATE": "Falha ao atualizar alarme",
-    "SNACK_FAILED_DELETE": "Falha ao eliminar alarme"
+    "SNACK_FAILED_DELETE": "Falha ao eliminar alarme",
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ninho?"
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes de Ginásios",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Sabedoria",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
-    "TEAM_UNKNOWN": "Equipa {{id}}"
+    "TEAM_UNKNOWN": "Equipa {{id}}",
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ginásio?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes de Alterações de Forte",
@@ -1687,7 +1690,9 @@
     "DESC": "Escolha como os novos alertas são entregues por padrão. Ainda poderá alterar isto para cada alerta ao criá-lo.",
     "DEFAULT_DISTANCE": "Distância padrão",
     "DEFAULT_DISTANCE_HINT": "Usada para preencher previamente o raio de novos alertas baseados em distância.",
-    "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados."
+    "FOOTNOTE": "Aplica-se apenas a alertas recém-criados — os existentes não são alterados.",
+    "DISTANCE_TOO_SMALL": "Tem de ser pelo menos 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Tem de ser 100 km ou menos."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Itens por página:",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -472,7 +472,7 @@
     "TAB_MEGA_ENERGY": "Mega-energi",
     "TAB_CANDY": "Godis",
     "ITEM_REWARD": "Föremålsbelöning",
-    "ANY_ITEM": "Alla föremål",
+    "ANY_ITEM": "Valfritt föremål",
     "QUEST_TYPE_LABEL": "Quest-typ:",
     "SNACK_CREATED": "Quest-larm skapat",
     "SNACK_UPDATED": "Quest-larm uppdaterat",
@@ -635,7 +635,8 @@
     "TYPE_UNKNOWN": "Lockbete #{{id}}",
     "EDIT_MODE": "Redigera meddelandet på plats",
     "EDIT_HINT": "Uppdaterar det befintliga Discord-meddelandet när betet ändras i stället för att skicka ett nytt.",
-    "EDIT_BADGE": "Redigera"
+    "EDIT_BADGE": "Redigera",
+    "CONFIRM_DELETE_TITLE": "Ta bort lockbete-larm?"
   },
   "NESTS": {
     "PAGE_TITLE": "Nästlarm",
@@ -652,7 +653,8 @@
     "SNACK_DELETED": "Nästlarm raderat",
     "SNACK_FAILED_CREATE": "Kunde inte skapa larm",
     "SNACK_FAILED_UPDATE": "Kunde inte uppdatera larm",
-    "SNACK_FAILED_DELETE": "Kunde inte radera larm"
+    "SNACK_FAILED_DELETE": "Kunde inte radera larm",
+    "CONFIRM_DELETE_TITLE": "Ta bort bo-larm?"
   },
   "GYMS": {
     "PAGE_TITLE": "Gymlarm",
@@ -677,7 +679,8 @@
     "TEAM_MYSTIC": "Mystic",
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
-    "TEAM_UNKNOWN": "Lag {{id}}"
+    "TEAM_UNKNOWN": "Lag {{id}}",
+    "CONFIRM_DELETE_TITLE": "Ta bort gym-larm?"
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-ändringslarm",
@@ -1687,7 +1690,9 @@
     "DESC": "Välj hur nya aviseringar levereras som standard. Du kan fortfarande ändra detta för varje avisering när du skapar den.",
     "DEFAULT_DISTANCE": "Standardavstånd",
     "DEFAULT_DISTANCE_HINT": "Används för att förifylla radien för nya avståndsbaserade aviseringar.",
-    "FOOTNOTE": "Gäller endast nyskapade aviseringar — befintliga ändras inte."
+    "FOOTNOTE": "Gäller endast nyskapade aviseringar — befintliga ändras inte.",
+    "DISTANCE_TOO_SMALL": "Måste vara minst 0,1 km.",
+    "DISTANCE_TOO_LARGE": "Får vara högst 100 km."
   },
   "PAGINATOR": {
     "ITEMS_PER_PAGE": "Objekt per sida:",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A batch of interface defects** ([#426](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/426)). Deleting a Gym, Lure or Nest alarm asked "Edit … Alarm?" instead of a delete confirmation. A quest tracking any item showed as "Item #0". Hovering a toolbar button silently disabled every keyboard shortcut, because the tooltip counted as a blocking overlay. The Alert Defaults dialog accepted 200 km, showed "200 km" in its preview, then quietly saved 100 — and 0 or a negative saved as 1; it now says what the limits are and refuses instead. The "Set up areas" link inside an add-alarm dialog reloaded the whole page and threw away everything typed. The Cleaning page always greyed out the Max Battles row even when alarms existed. Searching admin settings never filtered the Authentication section. And the login page made a signed-in-only request on every visit, failing with an error in the console.
+
+### Fixed
 - **Error messages, admin settings and table pagination stayed in English regardless of your language** ([#425](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/425)). Three separate gaps. Every error toast came from a message table that was never translated, even though a fully translated one sat beside it doing the same job for a different part of the app — both now use the translated one. Twelve strings were missing from every non-English locale, so the Authentication settings group, the PvP level-cap labels and a few hints rendered in English inside otherwise-translated pages; the English fallback made this invisible rather than obviously broken. And the table paginator on the admin pages kept Material's built-in English wording. A test now fails the build if any locale drifts from English again, or if the error toasts go untranslated.
 
 ### Fixed


### PR DESCRIPTION
Closes #426.

| # | Defect | Fix |
|---|---|---|
| 1 | Gym/Lure/Nest delete prompts titled "Edit … Alarm?" | Those three namespaces had **no** delete title at all, which is why they borrowed the edit one. Added and translated in all 11 locales. |
| 2 | A quest tracking any item showed "Item #0" | `getItemName` has no id 0, and reward 0 is the add dialog's own default. The Pokemon branch beside it already had the equivalent "any" case. |
| 4 | Hovering a toolbar button killed every keyboard shortcut | The guard keyed off any `.cdk-overlay-pane`; tooltips and snackbars are overlay panes. Narrowed to overlays that actually take focus. |
| 5 | Alert Defaults accepted 200 km, then saved 100 | It also echoed "200 km" in the live preview first, and 0 or -5 saved as 1. Now states the limits and disables Save. |
| 6→7 | "Set up areas" reloaded the page from inside a dialog | A plain `<a href>`, so it discarded everything typed across all tabs. Now a `routerLink`. |
| 8 | Admin settings search never filtered Authentication | That section is hand-written rather than driven by `SETTING_GROUPS`, so the query never reached it. |
| 9 | Cleaning always greyed the Max Battles row | It looked up `'maxbattles'` against the dashboard's `'maxBattles'`. |
| 10 | Login page 401'd on every visit | `app.ts` bootstrapped with the authenticated settings endpoint. Signed-out visitors now get the public subset; `AuthService` already re-runs the authenticated load once a token exists. |

## Two things worth calling out

**A test was asserting defect 5.** `clamps an out-of-range distance before persisting` pinned the silent clamp in place — being shown one number and given another *was* the bug. Replaced with tests that the input is refused, including the 0 / -5 / 0.05 cases that used to save as 1.

**The `routerLink` change broke five dialog specs.** They render `delivery-preview`, which now needs a router. That's a genuine fixture gap rather than a regression, so they got `provideRouter([])` — worth noting because it means five suites were previously rendering a component whose link they never exercised.

## Not fixed here

Item 3 — the reused Active Hours editor showing "Profile will require manual start" to quest-summary users. It's the same shared component serving two contexts with different meanings, so the fix is to parameterise its copy rather than special-case it, and it deserves its own change. Everything else in the report is covered.

Frontend 939 passed, ESLint and Prettier clean.