### PR TITLE
fix: the update reconciler trusted an insert counter over the uid (#460, #464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Editing a raid, egg, quest, gym, fort change or nest returned an alarm ID that no longer existed** ([#460](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/460), [#464](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/464)). PoracleNG re-creates the row under a new ID when you edit one of these, while reporting zero inserts. PoracleWeb keyed off that count rather than the ID it was handed, so the response advertised the old ID — which then failed on the next read, edit or delete — and any quick pick tracking the alarm was left pointing at it. Pokemon alarms were unaffected, because PoracleNG genuinely updates those in place.
+
+### Fixed
 - **A batch of interface defects** ([#426](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/426)). Deleting a Gym, Lure or Nest alarm asked "Edit … Alarm?" instead of a delete confirmation. A quest tracking any item showed as "Item #0". Hovering a toolbar button silently disabled every keyboard shortcut, because the tooltip counted as a blocking overlay. The Alert Defaults dialog accepted 200 km, showed "200 km" in its preview, then quietly saved 100 — and 0 or a negative saved as 1; it now says what the limits are and refuses instead. The "Set up areas" link inside an add-alarm dialog reloaded the whole page and threw away everything typed. The Cleaning page always greyed out the Max Battles row even when alarms existed. Searching admin settings never filtered the Authentication section. And the login page made a signed-in-only request on every visit, failing with an error in the console.
 
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -32,12 +32,18 @@ internal static partial class TrackingUpdateReconciler
         ILogger logger,
         ITrackedUidRemapper? uidRemapper = null)
     {
-        // oldUid <= 0 means this was not an edit. No insert, or the same uid back, means the upsert worked.
-        if (oldUid <= 0 || result.Inserts <= 0 || result.NewUids.Count == 0)
+        // oldUid <= 0 means this was not an edit, so there is nothing to reconcile.
+        if (oldUid <= 0 || result.NewUids.Count == 0)
         {
             return oldUid;
         }
 
+        // Trust newUids, not the insert counter. PoracleNG re-keys a row on edit while reporting
+        // {"insert":0,"updates":1,"newUids":[<new>]} -- verified directly against it. Gating on
+        // Inserts > 0 therefore skipped both the uid correction and the remap for raids, eggs,
+        // quests, gyms, fort changes and nests: the PUT answered 200 with a uid that 404s on the very
+        // next GET, and any quick pick tracking the row kept pointing at the dead uid. Monsters were
+        // unaffected because PoracleNG genuinely updates that type in place. See #460, #464.
         var newUid = (int)result.NewUids[0];
         if (newUid == oldUid)
         {
@@ -46,6 +52,8 @@ internal static partial class TrackingUpdateReconciler
 
         try
         {
+            // Idempotent: when PoracleNG replaced the row in place rather than inserting a duplicate,
+            // the old uid is already gone and the proxy swallows the resulting 404.
             await proxy.DeleteByUidAsync(trackingType, userId, oldUid);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
@@ -311,4 +311,42 @@ public class RaidServiceTests
         this._proxy.Verify(p => p.DeleteByUidAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
     }
 
+    // PoracleNG re-keys a row on edit while reporting insert:0 / updates:1 and putting the new uid in
+    // newUids -- verified against it directly. The reconciler used to gate on Inserts > 0, so it
+    // returned the DEAD uid and skipped the remap. See #460, #464.
+
+    [Fact]
+    public async Task UpdateAsyncReportsTheNewUidWhenPoracleNgReKeysWithoutReportingAnInsert()
+    {
+        this._proxy.Setup(p => p.CreateAsync("raid", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([418], 0, 1, 0));
+
+        var result = await this._sut.UpdateAsync("user1", new Raid { Uid = 417 });
+
+        Assert.Equal(418, result.Uid);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncRemapsQuickPickUidsWhenPoracleNgReKeysWithoutReportingAnInsert()
+    {
+        this._proxy.Setup(p => p.CreateAsync("raid", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([418], 0, 1, 0));
+
+        await this._sut.UpdateAsync("user1", new Raid { Uid = 417 });
+
+        this._uidRemapper.Verify(r => r.RemapAsync("user1", "raid", 417, 418), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsyncStillLeavesTheUidAloneWhenPoracleNgReturnsNoNewUid()
+    {
+        this._proxy.Setup(p => p.CreateAsync("raid", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
+
+        var result = await this._sut.UpdateAsync("user1", new Raid { Uid = 417 });
+
+        Assert.Equal(417, result.Uid);
+        this._uidRemapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
 }


### PR DESCRIPTION
Closes #460 and #464.

`TrackingUpdateReconciler` gated on `result.Inserts > 0` before correcting the uid or remapping quick-pick state. Measured against PoracleNG directly, an edit answers:

```json
{"alreadyPresent":0,"insert":0,"newUids":[418],"status":"ok","updates":1}
```

It **re-keys the row while reporting zero inserts**, and puts the correct new uid in `newUids` — where nothing read it. So `PUT` answered 200 with the pre-edit uid, which 404s on the very next `GET`, and `RemapAsync` — the whole point of #403 — never ran for raids, eggs, quests, gyms, fort changes or nests. Pokemon alarms were unaffected because PoracleNG updates that type in place.

Now keyed off `newUids`. The stale-row delete is attempted whenever the uid moved and is idempotent: when PoracleNG replaced in place, the old uid is already gone and the proxy swallows the 404.

### This is a hole in my own #403 fix

I verified that one against **lures**, which take the `NaturalKeyTrackingUpdate` path and genuinely worked, and never exercised a reconciler-path type. So the gap survived a live verification that looked convincing, and I reported #403 as fully closed when it wasn't. Three tests now pin the exact upstream response shape, which is what should have been there originally.

### Verification

Live, all four reconciler types — before the fix the same probe returned the created uid and 404'd on it:

```
raids    created 421   PUT returned 422   GET 200   live 422
eggs     created 160   PUT returned 161   GET 200   live 161
quests   created 446   PUT returned 447   GET 200   live 447
gyms     created 139   PUT returned 140   GET 200   live 140
```

Backend 1716 passed.

Nests could not be exercised — `disable_nests` is on in production — but `NestService.UpdateAsync` is line-for-line identical to Gym and FortChange, both verified above, and it shares the same reconciler.