### PR TITLE
fix: read what PoracleNG says it did with a create (#459, #462, #463, #468, #469)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
@@ -39,6 +39,14 @@ public class EggController(IEggService eggService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._eggService.CreateAsync(this.UserId, egg);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
@@ -39,6 +39,14 @@ public class FortChangeController(IFortChangeService fortChangeService) : BaseAp
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._fortChangeService.CreateAsync(this.UserId, fortChange);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
@@ -39,6 +39,14 @@ public class GymController(IGymService gymService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._gymService.CreateAsync(this.UserId, gym);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
@@ -39,6 +39,14 @@ public class InvasionController(IInvasionService invasionService) : BaseApiContr
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._invasionService.CreateAsync(this.UserId, invasion);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
@@ -39,6 +39,14 @@ public class LureController(ILureService lureService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._lureService.CreateAsync(this.UserId, lure);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
@@ -39,6 +39,14 @@ public class MaxBattleController(IMaxBattleService maxBattleService) : BaseApiCo
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._maxBattleService.CreateAsync(this.UserId, maxBattle);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
@@ -39,6 +39,14 @@ public class MonsterController(IMonsterService monsterService) : BaseApiControll
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._monsterService.CreateAsync(this.UserId, monster);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
@@ -39,6 +39,14 @@ public class NestController(INestService nestService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._nestService.CreateAsync(this.UserId, nest);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
@@ -39,6 +39,14 @@ public class QuestController(IQuestService questService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._questService.CreateAsync(this.UserId, quest);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
@@ -39,6 +39,14 @@ public class RaidController(IRaidService raidService) : BaseApiController
         // PoracleNG files the alarm under the live current_profile_no. Echoing a possibly-stale
         // claim back would assert a profile the row was never written to. See #411.
         var result = await this._raidService.CreateAsync(this.UserId, raid);
+
+        // PoracleNG assigns no uid when the submission duplicates an alarm the user already has, so
+        // nothing was created. Answering 201 with a Location of /0 advertised a resource that 404s.
+        // 200 keeps multi-select creates working while no longer claiming a creation. See #459.
+        if (result.Uid <= 0)
+        {
+            return this.Ok(result);
+        }
         return this.CreatedAtAction(nameof(GetByUid), new
         {
             uid = result.Uid

--- a/Applications/Pgan.PoracleWebNet.Api/Filters/TrackingConflictExceptionFilter.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Filters/TrackingConflictExceptionFilter.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Api.Filters;
+
+/// <summary>
+/// Turns a refused-because-it-collides write into 409 Conflict.
+/// </summary>
+/// <remarks>
+/// Registered globally so every alarm controller reports a collision the same way. Without it the
+/// services' <see cref="TrackingConflictException"/> would surface as an opaque 500 - and before the
+/// exception existed at all, the collision was reported as success. See #462 and #463.
+/// </remarks>
+public sealed class TrackingConflictExceptionFilter : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Exception is not TrackingConflictException ex)
+        {
+            return;
+        }
+
+        context.Result = new ConflictObjectResult(new
+        {
+            error = ex.Message,
+            trackingType = ex.TrackingType,
+        });
+        context.ExceptionHandled = true;
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -179,6 +179,7 @@ builder.Services.AddControllers(options =>
 {
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.FeatureDisabledExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.SummaryBackendUnavailableExceptionFilter>();
+    options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.TrackingConflictExceptionFilter>();
 });
 
 // Add Poracle services (DbContext, repositories, services, settings)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Editing an alarm onto settings another alarm already used destroyed one of them** ([#462](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/462)). Lures and invasions are replaced rather than updated, so changing one onto a combination another alarm already held — flipping an invasion's gender dropdown was enough — deleted the alarm being edited and silently overwrote the other one. The clash is now detected before anything is removed and the edit is refused with an explanation.
+- **Edits that clashed were reported as successful** ([#463](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/463)). For gyms, fort changes and the other types, an edit onto settings another alarm already used was declined upstream, but the response echoed the requested values back so it could never disagree with the request. The clash is now reported.
+- **Applying a quick pick could delete an alarm you built yourself** ([#469](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/469), [#468](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/468)). If a pick matched an alarm you already had, the pick claimed it as its own — so removing the pick deleted your alarm. It also recorded an unusable reference when the match was exact, which wiped the pick's applied state on the next page load and left no way to remove it. A pick now claims only alarms it actually created.
+- **Creating an alarm that already exists no longer reports it as newly created** ([#459](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/459)). The response claimed a created resource and pointed at an address that did not exist.
+
+### Fixed
 - **Editing a raid, egg, quest, gym, fort change or nest returned an alarm ID that no longer existed** ([#460](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/460), [#464](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/464)). PoracleNG re-creates the row under a new ID when you edit one of these, while reporting zero inserts. PoracleWeb keyed off that count rather than the ID it was handed, so the response advertised the old ID — which then failed on the next read, edit or delete — and any quick pick tracking the alarm was left pointing at it. Pokemon alarms were unaffected, because PoracleNG genuinely updates those in place.
 
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleTrackingProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleTrackingProxy.cs
@@ -57,8 +57,25 @@ public interface IPoracleTrackingProxy
 /// <summary>
 /// Result from PoracleNG's tracking create endpoint.
 /// </summary>
+/// <summary>
+/// PoracleNG's answer to a tracking create. It reports exactly what it did; PoracleWeb used to read
+/// almost none of it, which is the shared root of #459, #462, #463, #468 and #469.
+/// </summary>
 public record TrackingCreateResult(
     List<long> NewUids,
     int AlreadyPresent,
     int Updates,
-    int Inserts);
+    int Inserts)
+{
+    /// <summary>The uid the row now lives under, or <c>null</c> when PoracleNG named none.</summary>
+    public int? PrimaryUid => this.NewUids.Count > 0 ? (int)this.NewUids[0] : null;
+
+    /// <summary>
+    /// PoracleNG wrote no new row: it either matched an existing one or found the submission
+    /// already present. On a create that means the alarm was NOT created by this call.
+    /// </summary>
+    public bool InsertedNothing => this.Inserts == 0;
+
+    /// <summary>The submission duplicated an existing row exactly, so nothing was named or written.</summary>
+    public bool WasRejectedAsDuplicate => this.AlreadyPresent > 0 && this.Inserts == 0 && this.NewUids.Count == 0;
+}

--- a/Core/Pgan.PoracleWebNet.Core.Models/TrackingConflictException.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/TrackingConflictException.cs
@@ -1,0 +1,40 @@
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// The write was refused because it collides with an alarm that already exists.
+/// </summary>
+/// <remarks>
+/// PoracleNG dedups on a per-type natural key. When an edit moves an alarm onto a key another alarm
+/// already holds, PoracleNG declines to write and answers 200 with <c>alreadyPresent</c> set. PoracleWeb
+/// used to return that as success while echoing the requested values back from its in-memory model, so
+/// the response could not disagree with the request and the user believed the edit had applied. For the
+/// natural-key types the same collision was actively destructive: the row was deleted before the
+/// colliding create, so the alarm vanished. See #462 and #463.
+/// </remarks>
+public sealed class TrackingConflictException : Exception
+{
+    public TrackingConflictException(string trackingType, string detail)
+        : base(detail)
+    {
+        this.TrackingType = trackingType;
+    }
+
+    public TrackingConflictException()
+    {
+    }
+
+    public TrackingConflictException(string message)
+        : base(message)
+    {
+    }
+
+    public TrackingConflictException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public string? TrackingType
+    {
+        get;
+    }
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -50,6 +50,23 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
 
         // PoracleNG guards this type with a natural unique key and its create has no upsert path, so
         // changing a field outside that key collides (Error 1062) and returns 500. Replace the row instead.
+        // Refuse a collision BEFORE the delete. PoracleNG dedups invasions on
+        // (id, profile_no, gender, grunt_type), so editing one onto a pair another alarm already
+        // holds made the replace merge into that alarm - this one deleted, the other one silently
+        // overwritten. Changing the gender dropdown is enough to trigger it. See #462.
+        if (oldUid > 0)
+        {
+            var siblings = await this.GetByUserAsync(userId, model.ProfileNo);
+            if (siblings.Any(x => x.Uid != oldUid
+                && x.Gender == model.Gender
+                && string.Equals(x.GruntType, model.GruntType, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new TrackingConflictException(
+                    TrackingType,
+                    "You already have an invasion alarm for that grunt type and gender. Edit or remove that one instead.");
+            }
+        }
+
         var original = oldUid > 0 ? await this.GetByUidAsync(userId, oldUid) : null;
 
         model.Uid = await NaturalKeyTrackingUpdate.ReplaceAsync(

--- a/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
@@ -48,6 +48,20 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
 
         // PoracleNG guards this type with a natural unique key and its create has no upsert path, so
         // changing a field outside that key collides (Error 1062) and returns 500. Replace the row instead.
+        // Refuse a collision BEFORE the delete. PoracleNG dedups lures on (id, profile_no, lure_id),
+        // so editing one onto a lure_id another alarm already holds made the replace merge into that
+        // alarm - this one deleted, the other one silently overwritten. See #462.
+        if (oldUid > 0)
+        {
+            var siblings = await this.GetByUserAsync(userId, model.ProfileNo);
+            if (siblings.Any(x => x.Uid != oldUid && x.LureId == model.LureId))
+            {
+                throw new TrackingConflictException(
+                    TrackingType,
+                    "You already have a lure alarm for that lure type. Edit or remove that one instead.");
+            }
+        }
+
         var original = oldUid > 0 ? await this.GetByUidAsync(userId, oldUid) : null;
 
         model.Uid = await NaturalKeyTrackingUpdate.ReplaceAsync(

--- a/Core/Pgan.PoracleWebNet.Core.Services/NaturalKeyTrackingUpdate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NaturalKeyTrackingUpdate.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
@@ -53,6 +54,25 @@ internal static partial class NaturalKeyTrackingUpdate
         try
         {
             var result = await proxy.CreateAsync(trackingType, userId, updated);
+
+            // The row was deleted a moment ago, so its natural key is free and a genuine replace
+            // always inserts. Inserting nothing means the edited values collide with a DIFFERENT
+            // alarm, and PoracleNG merged into that one instead - leaving this alarm deleted and the
+            // other one silently overwritten. Put ours back and refuse. The services pre-check for
+            // this so it should not be reachable; it is here because the cost of missing it is a
+            // destroyed alarm. See #462.
+            if (result.InsertedNothing)
+            {
+                if (original.HasValue)
+                {
+                    await proxy.CreateAsync(trackingType, userId, original.Value);
+                }
+
+                throw new TrackingConflictException(
+                    trackingType,
+                    "Another alarm of this type already uses those settings. Edit or remove that one instead.");
+            }
+
             var newUid = result.NewUids.Count > 0 ? (int)result.NewUids[0] : oldUid;
 
             // Quick-pick applied state stores uids captured at apply time; follow the row. See #403.
@@ -62,6 +82,11 @@ internal static partial class NaturalKeyTrackingUpdate
             }
 
             return newUid;
+        }
+        catch (TrackingConflictException)
+        {
+            // Already restored above; re-restoring would duplicate the row.
+            throw;
         }
         catch (Exception ex)
         {

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -236,7 +236,15 @@ public partial class QuickPickService(
     {
         var definition = await this.LoadDefinitionAsync(userId, quickPickId) ?? throw new InvalidOperationException($"Quick pick '{quickPickId}' not found.");
 
-        var trackedUids = definition.AlarmType switch
+        // Snapshot first: the tracked set is what this apply ADDED, not what the create calls
+        // reported. PoracleNG hands back the existing row's uid when a pick matches an alarm the
+        // user built by hand, so trusting the reported uid made the pick adopt that alarm - and
+        // Remove then deleted it. It also reports no uid at all for an exact duplicate, which
+        // recorded a tracked uid of 0 that no lookup could resolve, so the applied state was wiped
+        // on the next page load. Diffing sidesteps both. See #468, #469.
+        var existingUids = await this.ExistingUidsAsync(userId, profileNo, definition.AlarmType);
+
+        var reportedUids = definition.AlarmType switch
         {
             "monster" => await this.ApplyMonsterAsync(userId, profileNo, definition, request),
             "raid" => await this.ApplyRaidAsync(userId, profileNo, definition, request),
@@ -249,6 +257,25 @@ public partial class QuickPickService(
             "maxbattle" => await this.ApplyMaxBattleAsync(userId, profileNo, definition, request),
             _ => throw new InvalidOperationException($"Unknown alarm type '{definition.AlarmType}'."),
         };
+
+        var afterUids = await this.ExistingUidsAsync(userId, profileNo, definition.AlarmType);
+        var addedUids = afterUids.Except(existingUids).ToList();
+        var displacedUids = existingUids.Except(afterUids).ToList();
+
+        // A uid that appeared is not automatically ours. When a pick matches an alarm the user built by
+        // hand, PoracleNG does not add a row - it RE-KEYS theirs, so the old uid disappears and a new one
+        // appears and the diff looks identical to a creation. Removing the pick then deleted the user's
+        // alarm. If anything was displaced we claim nothing: an untracked leftover is recoverable by
+        // hand, a deleted alarm is not. See #469.
+        var trackedUids = displacedUids.Count == 0 ? addedUids : [];
+
+        if (displacedUids.Count > 0)
+        {
+            LogQuickPickDisplaced(this._logger, quickPickId, displacedUids.Count, addedUids.Count);
+        }
+
+        LogQuickPickTracking(this._logger, quickPickId, reportedUids.Count, trackedUids.Count);
+
         var appliedState = new QuickPickAppliedState
         {
             UserId = userId,
@@ -266,6 +293,24 @@ public partial class QuickPickService(
 
         return appliedState;
     }
+
+    /// <summary>
+    /// The uids the user currently holds for an alarm type. Used either side of an apply so the
+    /// pick claims only the rows it actually created.
+    /// </summary>
+    private async Task<List<int>> ExistingUidsAsync(string userId, int profileNo, string alarmType) => alarmType switch
+    {
+        "monster" => [.. (await this._monsterService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "raid" => [.. (await this._raidService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "egg" => [.. (await this._eggService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "quest" => [.. (await this._questService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "invasion" => [.. (await this._invasionService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "lure" => [.. (await this._lureService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "nest" => [.. (await this._nestService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "gym" => [.. (await this._gymService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        "maxbattle" => [.. (await this._maxBattleService.GetByUserAsync(userId, profileNo)).Select(x => x.Uid)],
+        _ => [],
+    };
 
     public async Task<QuickPickAppliedState> ReapplyAsync(
         string userId, int profileNo, string quickPickId, QuickPickApplyRequest request)
@@ -930,6 +975,11 @@ public partial class QuickPickService(
         new() { Id = "lure-golden", Name = "Golden Lures", Description = "Track Golden Lure Modules at PokeStops", Icon = "stars", Category = "Lures", AlarmType = "lure", SortOrder = 64, Filters = new() { ["lureId"] = 505 } },
     ];
 
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Quick pick {QuickPickId} matched {DisplacedCount} alarm(s) the user already had; claiming none of the {AddedCount} resulting row(s) so removing the pick cannot delete them.")]
+    private static partial void LogQuickPickDisplaced(ILogger logger, string quickPickId, int displacedCount, int addedCount);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Applied quick pick '{QuickPickId}' for user {UserId} profile {ProfileNo}, created {Count} alarm(s).")]
     private static partial void LogQuickPickApplied(ILogger logger, string quickPickId, string userId, int profileNo, int count);
 
@@ -938,4 +988,9 @@ public partial class QuickPickService(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Seeding {Count} default quick picks (replaced {Existing} existing).")]
     private static partial void LogSeedingDefaults(ILogger logger, int count, int existing);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Quick pick {QuickPickId}: PoracleNG named {ReportedCount} uid(s), {TrackedCount} of which are new rows this apply created.")]
+    private static partial void LogQuickPickTracking(ILogger logger, string quickPickId, int reportedCount, int trackedCount);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
@@ -33,7 +34,22 @@ internal static partial class TrackingUpdateReconciler
         ITrackedUidRemapper? uidRemapper = null)
     {
         // oldUid <= 0 means this was not an edit, so there is nothing to reconcile.
-        if (oldUid <= 0 || result.NewUids.Count == 0)
+        if (oldUid <= 0)
+        {
+            return oldUid;
+        }
+
+        // PoracleNG declined to write because the edited values collide with an alarm the user
+        // already has. Nothing changed, so reporting success while echoing the requested values back
+        // told the user their edit applied when it had not. See #463.
+        if (result.AlreadyPresent > 0 && result.Inserts == 0 && result.Updates == 0)
+        {
+            throw new TrackingConflictException(
+                trackingType,
+                "Another alarm of this type already uses those settings. Edit or remove that one instead.");
+        }
+
+        if (result.NewUids.Count == 0)
         {
             return oldUid;
         }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// PoracleNG reports exactly what it did with a create — <c>alreadyPresent</c>, <c>updates</c>,
+/// <c>insert</c> and <c>newUids</c>. Reading almost none of it was the shared root of #459, #462, #463,
+/// #468 and #469, two of which destroyed user data.
+/// </summary>
+public class CreateResultSemanticsTests
+{
+    private readonly Mock<IPoracleTrackingProxy> _proxy = new();
+    private readonly Mock<IFeatureGate> _gate = new();
+    private readonly Mock<ITrackedUidRemapper> _remapper = new();
+
+    public CreateResultSemanticsTests() =>
+        this._gate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+    private static JsonElement Rows(params object[] rows) => JsonSerializer.SerializeToElement(rows);
+
+    // ── The record itself ───────────────────────────────────────────────────
+
+    [Fact]
+    public void PrimaryUidIsNullWhenPoracleNgNamedNoRow()
+    {
+        Assert.Null(new TrackingCreateResult([], 1, 0, 0).PrimaryUid);
+        Assert.Equal(42, new TrackingCreateResult([42], 0, 0, 1).PrimaryUid);
+    }
+
+    [Fact]
+    public void InsertedNothingDistinguishesAMatchFromACreate()
+    {
+        Assert.True(new TrackingCreateResult([7], 0, 1, 0).InsertedNothing);
+        Assert.False(new TrackingCreateResult([7], 0, 0, 1).InsertedNothing);
+    }
+
+    [Fact]
+    public void AnExactDuplicateIsRecognisable()
+    {
+        Assert.True(new TrackingCreateResult([], 1, 0, 0).WasRejectedAsDuplicate);
+        Assert.False(new TrackingCreateResult([7], 0, 0, 1).WasRejectedAsDuplicate);
+    }
+
+    // ── #463: a refused edit must not report success ─────────────────────────
+
+    [Fact]
+    public async Task AnEditRefusedAsADuplicateRaisesAConflictRatherThanEchoingTheRequest()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        // PoracleNG declined: the edited values collide with another alarm the user already has.
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 1, 0, 0));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Gym { Uid = 134, Team = 2 }));
+    }
+
+    [Fact]
+    public async Task AnOrdinaryEditIsUnaffected()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([140], 0, 1, 0));
+
+        var result = await sut.UpdateAsync("u1", new Gym { Uid = 139, Team = 2 });
+
+        Assert.Equal(140, result.Uid);
+    }
+
+    // ── #462: a colliding natural-key edit must not destroy either alarm ─────
+
+    [Fact]
+    public async Task EditingALureOntoAnotherAlarmsLureIdIsRefusedBeforeAnythingIsDeleted()
+    {
+        var sut = new LureService(this._proxy.Object, this._gate.Object,
+            NullLogger<LureService>.Instance, this._remapper.Object);
+        // The user holds two lures; the edit would move uid 10 onto uid 11's lure_id.
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows(
+            new { uid = 10, id = "u1", lure_id = 501, distance = 500 },
+            new { uid = 11, id = "u1", lure_id = 502, distance = 500 }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Lure { Uid = 10, LureId = 502 }));
+
+        // Nothing may be deleted: the destructive step is what lost the alarm.
+        this._proxy.Verify(p => p.DeleteByUidAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EditingALureWithoutChangingItsLureIdStillWorks()
+    {
+        var sut = new LureService(this._proxy.Object, this._gate.Object,
+            NullLogger<LureService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("lure", "u1")).ReturnsAsync(Rows(
+            new { uid = 10, id = "u1", lure_id = 501, distance = 500 }));
+        this._proxy.Setup(p => p.CreateAsync("lure", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([12], 0, 0, 1));
+
+        var result = await sut.UpdateAsync("u1", new Lure { Uid = 10, LureId = 501, Distance = 900 });
+
+        Assert.Equal(12, result.Uid);
+    }
+
+    [Fact]
+    public async Task EditingAnInvasionOntoAnotherAlarmsGenderAndGruntIsRefused()
+    {
+        var sut = new InvasionService(this._proxy.Object, this._gate.Object,
+            NullLogger<InvasionService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("invasion", "u1")).ReturnsAsync(Rows(
+            new { uid = 20, id = "u1", gender = 1, grunt_type = "fire", distance = 500 },
+            new { uid = 21, id = "u1", gender = 2, grunt_type = "fire", distance = 500 }));
+
+        // Flipping uid 20's gender to 2 collides with uid 21 - reachable from the gender dropdown.
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Invasion { Uid = 20, Gender = 2, GruntType = "fire" }));
+
+        this._proxy.Verify(p => p.DeleteByUidAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -77,8 +77,10 @@ public class InvasionServiceTests
     public async Task UpdateAsyncDelegates()
     {
         var i = new Invasion { Uid = 1, GruntType = "fire" };
+        // A real replace frees the natural key then inserts, so insert=1. A response of insert=0 now
+        // means PoracleNG merged into a DIFFERENT alarm, which is a conflict rather than success (#462).
         this._proxy.Setup(p => p.CreateAsync("invasion", "user1", It.IsAny<JsonElement>()))
-            .ReturnsAsync(new TrackingCreateResult([], 0, 1, 0));
+            .ReturnsAsync(new TrackingCreateResult([2], 0, 0, 1));
 
         await this._sut.UpdateAsync("user1", i);
         this._proxy.Verify(p => p.CreateAsync("invasion", "user1", It.IsAny<JsonElement>()), Times.Once);


### PR DESCRIPTION
Closes #459, #462, #463, #468, #469 — five issues, one root cause. `TrackingCreateResult` already carried `alreadyPresent`, `updates`, `insert` and `newUids`; almost none of it was read. Two of the five were destructive.

### #462 — a colliding edit destroyed an alarm

Lures and invasions are *replaced*, not updated. Editing one onto a natural key another alarm held made the create merge into that alarm: the edited row stayed deleted and the other row was silently overwritten. **Flipping an invasion's gender dropdown was enough.**

Both services now check for the clash **before** the delete and refuse. The replace helper keeps a post-check that restores and refuses, because the cost of missing this is a destroyed alarm.

### #463 — a refused edit reported success

For the reconciler types PoracleNG declines a colliding edit and answers `alreadyPresent`. The controllers returned `Ok()` on the in-memory mutated model, so **the response could not disagree with the request**. Now a `TrackingConflictException` mapped to 409 by a global filter.

### #469 / #468 — a quick pick could delete an alarm you made

Apply trusted the uid PoracleNG named. When a pick matches a hand-made alarm, PoracleNG **re-keys that row** rather than adding one — so the pick adopted it and Remove deleted it.

Tracking is now computed by diffing the user's uids either side of the apply. Crucially it claims **nothing** when the apply displaced an existing row, because a re-key is indistinguishable from a creation by uid alone. An untracked leftover is recoverable by hand; a deleted alarm is not.

That distinction cost me a round: my first version diffed uids and still deleted the user's alarm, because `before={198}, after={199}` looks exactly like a creation. The live check caught it.

### #459 — 201 for something that was not created

An exact duplicate creates nothing, so `201` with `Location: .../0` advertised a resource that 404s. Now `200`. Multi-select creates keep working — a 409 here would have failed the whole batch, which would be a functional regression.

### Verification

```
invasion gender 1 -> 2 colliding   -> 409, both alarms still present
gym team 1 -> 2 colliding          -> 409, stored teams still [1, 2]
duplicate gym create               -> 200 (was 201 + Location /0)
pick matching a hand-made alarm    -> trackedUids [], alarm survives Remove
pick with no match (control)       -> tracks its own alarm, Remove deletes it
```

Backend 1724 passed. One fixture was mocking `insert:0` for a successful replace, which is now correctly read as a collision — made realistic rather than adapted.

### Deliberately unchanged

When a pick matches an existing alarm, PoracleNG still merges the pick's distance onto it. That is upstream dedup and is arguably what "apply" should do. The destructive half — Remove deleting it — is what's fixed here.