### PR TITLE
fix: profile import, duplicate and name validation (#465, #466, #467)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -24,6 +24,9 @@ public class ProfileController(
     private readonly IProfileRepository _profileRepository = profileRepository;
     private readonly IJwtService _jwtService = jwtService;
 
+    /// <summary>Matches the profiles.name column, so an over-long name is refused rather than 500ing.</summary>
+    private const int MaxProfileNameLength = 255;
+
     [HttpGet]
     public async Task<IActionResult> GetAll()
     {
@@ -47,6 +50,16 @@ public class ProfileController(
             return this.BadRequest(new
             {
                 error = "Profile name is required."
+            });
+        }
+
+        // profiles.name is varchar(255); anything longer reached the database and came back as an
+        // opaque 500. See #467.
+        if (profile.Name.Trim().Length > MaxProfileNameLength)
+        {
+            return this.BadRequest(new
+            {
+                error = $"Profile name must be {MaxProfileNameLength} characters or fewer."
             });
         }
 
@@ -93,6 +106,14 @@ public class ProfileController(
         if (existing == null)
         {
             return this.NotFound();
+        }
+
+        if (profile.Name is not null && profile.Name.Trim().Length > MaxProfileNameLength)
+        {
+            return this.BadRequest(new
+            {
+                error = $"Profile name must be {MaxProfileNameLength} characters or fewer."
+            });
         }
 
         var (isValid, validationError) = ActiveHoursValidator.Validate(profile.ActiveHours);
@@ -191,6 +212,29 @@ public class ProfileController(
         }
 
         var newProfileNo = resolved.Value;
+
+        // PoracleNG's addProfile ignores area, latitude and longitude while honouring active_hours
+        // from the same payload, so a duplicate silently inherited the ACTIVE profile's geography
+        // instead of the source's: the right alarms over the wrong map, and a location that also
+        // feeds the active-hours timezone. Write them directly, the same way rename has to (#406).
+        // See #466.
+        try
+        {
+            await this._profileRepository.UpdateAsync(new Profile
+            {
+                Id = this.UserId,
+                ProfileNo = newProfileNo,
+                Name = request.Name.Trim(),
+                Area = sourceProfile.Area ?? "[]",
+                Latitude = sourceProfile.Latitude,
+                Longitude = sourceProfile.Longitude,
+            });
+        }
+        catch (InvalidOperationException)
+        {
+            // The row is not there yet in some PoracleNG timings; the profile still exists and the
+            // alarms still copy, so this must not fail the duplicate.
+        }
 
         // Copy all alarms from source to new profile; clean up on failure
         try

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
@@ -101,6 +101,23 @@ public partial class ProfileOverviewController(
     [HttpPost("import")]
     public async Task<IActionResult> ImportProfile([FromBody] ProfileOverviewImportRequest request)
     {
+        // Import used to 500 on a blank or over-long name, where create answers a clean 400. See #467.
+        if (string.IsNullOrWhiteSpace(request.ProfileName))
+        {
+            return this.BadRequest(new
+            {
+                error = "Profile name is required."
+            });
+        }
+
+        if (request.ProfileName.Trim().Length > 255)
+        {
+            return this.BadRequest(new
+            {
+                error = "Profile name must be 255 characters or fewer."
+            });
+        }
+
         var existing = (await this._profileService.GetByUserAsync(this.UserId)).ToList();
         var existingNames = existing.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
         var profileName = request.ProfileName;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Importing a profile put the alarms on whatever profile the file named** ([#465](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/465)). A backup carrying a profile number wrote its alarms there instead of into the profile just created, leaving them orphaned on a profile that might not exist — and inherited by a future profile created at that number. The file no longer chooses the profile or the owner.
+- **Duplicating a profile copied the wrong areas and location** ([#466](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/466)). The copy silently inherited whichever profile was active rather than the one being duplicated, so you got the right alarms over the wrong map — and since the coordinates also drive the active-hours timezone, a schedule on the copy could run against the wrong clock.
+- **Blank or over-long profile names returned a server error** ([#467](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/467)) on rename and import, where creating a profile already explained the problem properly.
+
+### Fixed
 - **A cleaning toggle broke any quick pick covering those alarms** ([#471](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/471)). Toggling auto-delete rewrites every alarm of that type under a new identifier, and the quick pick that created them kept pointing at the old ones — so the pick showed as never applied, Remove deleted nothing, and re-applying failed because the leftover alarms were still there. Cleaning was the one bulk operation that never followed the rewrite.
 - **The cleaning endpoints accepted values that are not on or off** ([#472](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/472)). Any even number silently switched cleaning *off* while reporting the alarms updated, and the write is not free — it rewrites every alarm, and for Max Battles deletes and recreates them.
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/ProfileOverviewService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/ProfileOverviewService.cs
@@ -69,6 +69,12 @@ public class ProfileOverviewService(
         return totalCreated;
     }
 
+    /// <summary>
+    /// Fields an imported alarm may not dictate: they identify the owner and the profile, which are
+    /// determined by who is importing and where. See #465.
+    /// </summary>
+    private static readonly string[] ImportIgnoredFields = ["uid", "profile_no", "id"];
+
     public async Task<int> ImportAlarmsAsync(string userId, int targetProfileNo, JsonElement alarms)
     {
         // Pre-validate the import payload before any state mutation. See DuplicateProfileAsync above
@@ -93,10 +99,19 @@ public class ProfileOverviewService(
 
                 foreach (var alarm in alarmsArray.EnumerateArray())
                 {
-                    // Strip uid defensively — export removes it client-side but manually edited backups may include it
-                    var cleaned = alarm.TryGetProperty("uid", out _)
-                        ? PoracleJsonHelper.StripProperty(alarm, "uid")
-                        : alarm;
+                    // The file decides none of these. PoracleNG takes a submitted profile_no at face
+                    // value (#411), so an alarm carrying profile_no: 7 landed on profile 7 instead of
+                    // the profile just created -- an orphan that a future profile 7 would inherit. id
+                    // is stripped for the same reason: it names the owner, and the URL already does
+                    // that. uid is stripped because a hand-edited backup may still carry one. See #465.
+                    var cleaned = alarm;
+                    foreach (var owned in ImportIgnoredFields)
+                    {
+                        if (cleaned.TryGetProperty(owned, out _))
+                        {
+                            cleaned = PoracleJsonHelper.StripProperty(cleaned, owned);
+                        }
+                    }
                     await this._trackingProxy.CreateAsync(type, userId, cleaned);
                     totalCreated++;
                 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
@@ -351,4 +351,58 @@ public class ProfileControllerTests : ControllerTestBase
         this._profileRepository.Verify(
             r => r.RenameAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
     }
+
+    // ── Name length and duplicate geography (#466, #467) ────────────────────
+
+    [Fact]
+    public async Task CreateRejectsANameLongerThanTheColumn()
+    {
+        // 256 chars reached the database and came back as an opaque 500.
+        var result = await this._sut.Create(new Profile { Name = new string('a', 256) });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task CreateStillAcceptsANameAtTheLimit()
+    {
+        this.SetupCreateAssigns(1, new string('a', 255));
+
+        var result = await this._sut.Create(new Profile { Name = new string('a', 255) });
+
+        Assert.IsType<CreatedAtActionResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateRejectsANameLongerThanTheColumn()
+    {
+        this._profileService.Setup(s => s.GetByUserAndProfileNoAsync("123456789", 1))
+            .ReturnsAsync(P(1, "Old"));
+
+        var result = await this._sut.Update(1, new Profile { Name = new string('a', 256) });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task DuplicateCarriesTheSourceProfilesAreasAndLocation()
+    {
+        // PoracleNG drops area/latitude/longitude from addProfile, so the copy silently inherited the
+        // ACTIVE profile's geography: the right alarms over the wrong map. See #466.
+        var source = new Profile
+        {
+            Id = "123456789", ProfileNo = 1, Name = "Work",
+            Area = "[\"downtown\",\"fan\"]", Latitude = 37.5, Longitude = -77.4,
+        };
+        this._profileService.Setup(s => s.GetByUserAndProfileNoAsync("123456789", 1)).ReturnsAsync(source);
+        this.SetupCreateAssigns(2, "Copy", source);
+
+        await this._sut.Duplicate(new DuplicateProfileRequest { FromProfileNo = 1, Name = "Copy" });
+
+        this._profileRepository.Verify(r => r.UpdateAsync(It.Is<Profile>(x =>
+            x.ProfileNo == 2
+            && x.Area == source.Area
+            && x.Latitude == source.Latitude
+            && x.Longitude == source.Longitude)), Times.Once);
+    }
 }


### PR DESCRIPTION
Closes #465, #466, #467.

**#465 — the file chose which profile it landed on.** `ImportAlarmsAsync` stripped only `uid`. PoracleNG takes a submitted `profile_no` at face value (established in #411), so an alarm carrying `profile_no: 7` wrote to profile 7 rather than the profile just created — an orphan a future profile 7 would inherit. `id` was trusted the same way, and that's a cross-user field. Both are now stripped: who is importing and where are decided by the request, not the upload.

**#466 — a duplicate copied the wrong geography.** PoracleNG's `addProfile` ignores `area`, `latitude` and `longitude` while honouring `active_hours` from the same payload, so the copy inherited the *active* profile's geography — the right alarms over the wrong map, and coordinates that also feed the active-hours timezone lookup. Written directly after creation, the same workaround rename needs (#406).

**#467 — 500 where create already returns 400.** Rename and import failed opaquely on a blank or over-long name. The boundary is 255, matching the `profiles.name` column.

### Verification

```
import carrying profile_no 7 and a foreign id
    -> alarm landed on profile 2 (the new one), owner id rewritten to the caller

duplicate of profile 1 (18 areas, its own coordinates)
    -> copy has 18 areas and profile 1's coordinates, not profile 0's 11

import blank name / 300 chars  -> 400   (was 500)
create 256 chars               -> 400   (was 500)
create 255 chars               -> 201
```

Both live checks were confirmed at the database level, not just through the API.

Backend 1735 passed.