### PR TITLE
fix: ungated geofence toggles, and a language selector caught by the wrong gate (#478, #479)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/LocationController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/LocationController.cs
@@ -71,45 +71,6 @@ public class LocationController(
         });
     }
 
-    [HttpGet("language")]
-    public async Task<IActionResult> GetLanguage()
-    {
-        var human = await this._humanService.GetByIdAsync(this.UserId);
-        if (human == null)
-        {
-            return this.NotFound();
-        }
-
-        return this.Ok(new
-        {
-            language = human.Language
-        });
-    }
-
-    [HttpPut("language")]
-    public async Task<IActionResult> UpdateLanguage([FromBody] LanguageUpdateRequest request)
-    {
-        var human = await this._humanService.GetByIdAsync(this.UserId);
-        if (human == null)
-        {
-            return this.NotFound();
-        }
-
-        // humans.language is varchar(255); a longer value used to overflow on write.
-        if (request.Language is { Length: > 255 })
-        {
-            return this.BadRequest(new { error = "Language must be 255 characters or fewer." });
-        }
-
-        human.Language = request.Language;
-        await this._humanService.UpdateAsync(human);
-
-        return this.Ok(new
-        {
-            language = human.Language
-        });
-    }
-
     [RequireFeatureEnabled(DisableFeatureKeys.Geocoding)]
     [HttpGet("geocode")]
     public async Task<IActionResult> Geocode([FromQuery] string q)
@@ -305,8 +266,5 @@ public class LocationController(
         }
     }
 
-    public class LanguageUpdateRequest
-    {
-        public string Language { get; set; } = string.Empty;
-    }
+
 }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/NotificationLanguageController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/NotificationLanguageController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Mvc;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Api.Controllers;
+
+/// <summary>
+/// The user's notification language.
+/// </summary>
+/// <remarks>
+/// Deliberately its own controller rather than an action on <c>LocationController</c>. That controller
+/// carries a class-level <c>disable_location</c> gate, which also blocked these two endpoints even
+/// though they only touch <c>humans.language</c> and have nothing to do with a location. The Areas page
+/// hosts the language selector and calls this on init, so with locations disabled the 403 carried a
+/// disableKey, the error interceptor read it as a dead page and redirected to the dashboard - making an
+/// enabled feature unreachable. Authentication is unchanged: BaseApiController is [Authorize]. See #479.
+/// </remarks>
+[Route("api/location/language")]
+public class NotificationLanguageController(IHumanService humanService) : BaseApiController
+{
+    private readonly IHumanService _humanService = humanService;
+
+    [HttpGet]
+    public async Task<IActionResult> GetLanguage()
+    {
+        var human = await this._humanService.GetByIdAsync(this.UserId);
+        if (human == null)
+        {
+            return this.NotFound();
+        }
+
+        return this.Ok(new
+        {
+            language = human.Language
+        });
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateLanguage([FromBody] LanguageUpdateRequest request)
+    {
+        var human = await this._humanService.GetByIdAsync(this.UserId);
+        if (human == null)
+        {
+            return this.NotFound();
+        }
+
+        // humans.language is varchar(255); a longer value used to overflow on write.
+        if (request.Language is { Length: > 255 })
+        {
+            return this.BadRequest(new { error = "Language must be 255 characters or fewer." });
+        }
+
+        human.Language = request.Language;
+        await this._humanService.UpdateAsync(human);
+
+        return this.Ok(new
+        {
+            language = human.Language
+        });
+    }
+
+    public class LanguageUpdateRequest
+    {
+        public string Language { get; set; } = string.Empty;
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
@@ -94,6 +94,10 @@ public partial class UserGeofenceController(
         }
     }
 
+    // These write area subscriptions, so they answer to the same switch the Areas page does.
+    // Gated per-action because the reads on this controller stay open; disable_areas is
+    // enforced in the service, since the attribute does not allow two keys. See #478.
+    [RequireFeatureEnabled(DisableFeatureKeys.UserGeofences)]
     [HttpPost("custom/{id:int}/activate")]
     public async Task<IActionResult> ActivateGeofence(int id)
     {
@@ -116,6 +120,10 @@ public partial class UserGeofenceController(
         }
     }
 
+    // These write area subscriptions, so they answer to the same switch the Areas page does.
+    // Gated per-action because the reads on this controller stay open; disable_areas is
+    // enforced in the service, since the attribute does not allow two keys. See #478.
+    [RequireFeatureEnabled(DisableFeatureKeys.UserGeofences)]
     [HttpPost("custom/{id:int}/deactivate")]
     public async Task<IActionResult> DeactivateGeofence(int id)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Turning off areas or custom geofences did not stop geofences being switched on and off** ([#478](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/478)). Those two buttons wrote area subscriptions without checking either switch, so the Areas page refused while the same change went through elsewhere. Both are now enforced, at the endpoint and in the service.
+- **Turning off locations broke the notification language selector** ([#479](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/479)). The language endpoints sat behind the location switch despite having nothing to do with a location, and the Areas page loads the selector on open — so with locations off, opening Areas bounced you to the dashboard. Language is now independent of it.
+
+### Fixed
 - **Importing a profile put the alarms on whatever profile the file named** ([#465](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/465)). A backup carrying a profile number wrote its alarms there instead of into the profile just created, leaving them orphaned on a profile that might not exist — and inherited by a future profile created at that number. The file no longer chooses the profile or the owner.
 - **Duplicating a profile copied the wrong areas and location** ([#466](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/466)). The copy silently inherited whichever profile was active rather than the one being duplicated, so you got the right alarms over the wrong map — and since the coordinates also drive the active-hours timezone, a schedule on the copy could run against the wrong clock.
 - **Blank or over-long profile names returned a server error** ([#467](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/467)) on rename and import, where creating a profile already explained the problem properly.

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -625,6 +625,13 @@ public partial class UserGeofenceService(
 
     public async Task AddToProfileAsync(string humanId, int profileNo, int geofenceId)
     {
+        // Activating or deactivating writes an area subscription, so it must answer to
+        // disable_areas as well as disable_user_geofences. Enforced here rather than as a second
+        // attribute (the filter disallows two), which also covers service-to-service callers.
+        // See #478.
+        await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Areas);
+        await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.UserGeofences);
+
         var geofence = await this._repository.GetByIdAsync(geofenceId)
             ?? throw new GeofenceNotFoundException(geofenceId);
 
@@ -648,6 +655,13 @@ public partial class UserGeofenceService(
 
     public async Task RemoveFromProfileAsync(string humanId, int profileNo, int geofenceId)
     {
+        // Activating or deactivating writes an area subscription, so it must answer to
+        // disable_areas as well as disable_user_geofences. Enforced here rather than as a second
+        // attribute (the filter disallows two), which also covers service-to-service callers.
+        // See #478.
+        await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Areas);
+        await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.UserGeofences);
+
         var geofence = await this._repository.GetByIdAsync(geofenceId)
             ?? throw new GeofenceNotFoundException(geofenceId);
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/LocationControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/LocationControllerTests.cs
@@ -93,7 +93,7 @@ public class LocationControllerTests : ControllerTestBase
         this._humanService.Setup(s => s.GetByIdAsync("123456789")).ReturnsAsync(human);
         this._humanService.Setup(s => s.UpdateAsync(human)).ReturnsAsync(human);
 
-        var result = await this._sut.UpdateLanguage(new LocationController.LanguageUpdateRequest { Language = "de" });
+        var result = await this.LanguageSut().UpdateLanguage(new NotificationLanguageController.LanguageUpdateRequest { Language = "de" });
 
         Assert.IsType<OkObjectResult>(result);
         Assert.Equal("de", human.Language);
@@ -104,7 +104,7 @@ public class LocationControllerTests : ControllerTestBase
     {
         this._humanService.Setup(s => s.GetByIdAsync("123456789")).ReturnsAsync((Human?)null);
         Assert.IsType<NotFoundResult>(
-            await this._sut.UpdateLanguage(new LocationController.LanguageUpdateRequest { Language = "de" }));
+            await this.LanguageSut().UpdateLanguage(new NotificationLanguageController.LanguageUpdateRequest { Language = "de" }));
     }
 
     // --- Geocode ---
@@ -186,5 +186,13 @@ public class LocationControllerTests : ControllerTestBase
         this._proxy.Setup(p => p.GetDistanceMapUrlAsync(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<int>()))
             .ThrowsAsync(new InvalidOperationException());
         Assert.IsType<NotFoundResult>(await this._sut.GetDistanceMap(0, 0, 0));
+    }
+
+    /// <summary>Language moved to its own controller so disable_location stops blocking it (#479).</summary>
+    private NotificationLanguageController LanguageSut()
+    {
+        var c = new NotificationLanguageController(this._humanService.Object);
+        SetupUser(c);
+        return c;
     }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Filters/FeatureGateCoverageTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Filters/FeatureGateCoverageTests.cs
@@ -106,4 +106,69 @@ public class FeatureGateCoverageTests
         [.. ApiAssembly.GetTypes()
             .Where(t => typeof(ControllerBase).IsAssignableFrom(t) && !t.IsAbstract)
             .SelectMany(t => KeysEnforcedBy(t).Select(k => (controller: t, key: k)))];
+
+    /// <summary>
+    /// The per-key test above only asks whether SOME action on SOME controller carries the attribute, so
+    /// a controller gated on one action and open on another passes it. That is exactly how
+    /// <c>UserGeofenceController</c>'s activate/deactivate shipped ungated while its create was gated:
+    /// the write endpoints bypassed both disable_areas and disable_user_geofences. See #478.
+    /// </summary>
+    [Fact]
+    public void EveryMutatingActionOnAPartiallyGatedControllerIsGated()
+    {
+        var offenders = new List<string>();
+
+        foreach (var controller in ApiAssembly.GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t) && !t.IsAbstract))
+        {
+            // Only controllers that gate per-action are in scope; a class-level attribute covers
+            // everything, and a controller with no gate at all is a separate question.
+            if (controller.GetCustomAttributes(typeof(RequireFeatureEnabledAttribute), inherit: true).Length > 0)
+            {
+                continue;
+            }
+
+            var actions = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => !m.IsSpecialName)
+                .ToList();
+
+            var gated = actions.Where(m => m.GetCustomAttributes(typeof(RequireFeatureEnabledAttribute), inherit: true).Length > 0).ToList();
+            if (gated.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var action in actions.Except(gated).Where(IsMutating))
+            {
+                var name = $"{controller.Name}.{action.Name}";
+                if (!IntentionallyUngatedWrites.Contains(name))
+                {
+                    offenders.Add(name);
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "These write endpoints sit on a controller that gates some of its actions but not these: "
+            + string.Join(", ", offenders)
+            + ". A partially gated controller is the shape that hides bypasses - gate them or move them.");
+    }
+
+    /// <summary>
+    /// Writes that are deliberately reachable while their feature is off, with the reason. Anything not
+    /// listed here has to be gated, so an exemption is a decision someone made on purpose rather than an
+    /// oversight nobody noticed.
+    /// </summary>
+    private static readonly HashSet<string> IntentionallyUngatedWrites = new(StringComparer.Ordinal)
+    {
+        // Turning off custom geofences stops people making new ones. It must not trap users with
+        // existing geofences they can no longer delete - blocking cleanup prevents no harm.
+        "UserGeofenceController.DeleteGeofence",
+    };
+
+    /// <summary>A write, by HTTP verb. Reads are deliberately left open on some gated controllers.</summary>
+    private static bool IsMutating(MethodInfo action) =>
+        action.GetCustomAttributes(inherit: true).Any(a =>
+            a is HttpPostAttribute or HttpPutAttribute or HttpDeleteAttribute or HttpPatchAttribute);
 }


### PR DESCRIPTION
Closes #478 and #479.

**#478 — the geofence toggles bypassed both switches.** Activate/deactivate write area subscriptions and carried no `[RequireFeatureEnabled]` at all, so with `disable_areas` on, `PUT /api/areas` answered 403 while the same subscription change went through here. The attribute is `AllowMultiple = false`, so the endpoints carry `disable_user_geofences` and the service enforces `disable_areas` — which also covers service-to-service callers.

**#479 — an enabled page made unreachable by an unrelated switch.** `GET/PUT /api/location/language` only touch `humans.language`, but sat under `LocationController`'s class-level `disable_location` gate. The Areas page hosts the language selector and calls it on open, so the 403's `disableKey` made the error interceptor redirect to the dashboard. Moved to their own controller rather than weakening the filter — authentication is unchanged and verified.

### The coverage test was the real problem

`FeatureGateCoverageTests` only asked whether **some** action on a controller carried the attribute. That's precisely why #478 was invisible: `UserGeofenceController` gates its create, so the controller looked covered while two writes sat open. I cited that test as proof this bug class couldn't return, in #414 and again in #420.

It now requires every *mutating* action on a partially gated controller to be gated.

**It immediately found a second one:** `DeleteGeofence`. That's a genuine exemption, not a bug — disabling custom geofences should stop new ones, not trap users with existing ones they can't remove — so it's allowlisted with the reason, rather than quietly passing.

### Verification

```
disable_areas ON            PUT /api/areas          -> 403
                            activate / deactivate   -> 403   (were 204)
disable_user_geofences ON   activate                -> 403

disable_location ON         GET /api/location       -> 403
                            GET/PUT .../language    -> 200   (were 403)
unauthenticated             GET .../language        -> 401
```

Backend 1736 passed. All toggles restored to their original values, confirmed by reading them back.