### PR TITLE
fix: quest summary editor showed the profile scheduler's empty state

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.spec.ts
@@ -118,6 +118,16 @@ describe('SummaryScheduleDialogComponent', () => {
   });
 
   describe('editor reuse', () => {
+    // The editor's default empty state says the profile will need a manual start, which contradicts this
+    // dialog's own line about quests being delivered individually. See #457.
+    it('passes the quest empty-state line to the shared editor', () => {
+      setup();
+      component.editSchedule();
+
+      const [, openConfig] = matDialog.open.mock.calls[0];
+      expect(openConfig.data.emptyStateKey).toBe('QUESTS.SUMMARY_SCHEDULE_EMPTY');
+    });
+
     it('opens ActiveHoursEditorDialogComponent seeded with the current entries and a profileName label', () => {
       setup();
       component.editSchedule();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
@@ -111,6 +111,9 @@ export class SummaryScheduleDialogComponent {
       width: '560px',
       data: {
         activeHours: this.entries(),
+        // Without this the editor said the profile would need a manual start, directly beneath this
+        // dialog's own line about quests being delivered individually. See #457.
+        emptyStateKey: 'QUESTS.SUMMARY_SCHEDULE_EMPTY',
         profileName: this.i18n.instant('QUESTS.SUMMARY_SCHEDULE_ALERT_LABEL'),
       } as ActiveHoursEditorData,
     });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/active-hours-editor-dialog/active-hours-editor-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/active-hours-editor-dialog/active-hours-editor-dialog.component.html
@@ -62,7 +62,7 @@
   <section class="section">
     <label class="section-label">{{ 'PROFILES.ACTIVE_HOURS_RULES' | translate }} ({{ groups().length }})</label>
     @if (groups().length === 0) {
-      <div class="empty-rules">{{ 'PROFILES.ACTIVE_HOURS_NO_RULES' | translate }}</div>
+      <div class="empty-rules">{{ data.emptyStateKey ?? 'PROFILES.ACTIVE_HOURS_NO_RULES' | translate }}</div>
     } @else {
       <div class="rules-list">
         @for (group of groups(); track formatGroupLabel(group)) {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/active-hours-editor-dialog/active-hours-editor-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/active-hours-editor-dialog/active-hours-editor-dialog.component.ts
@@ -19,6 +19,12 @@ import {
 
 export interface ActiveHoursEditorData {
   activeHours: ActiveHourEntry[];
+  /**
+   * Translation key for the line shown when there are no rules. The editor serves two contexts that mean
+   * different things by a schedule: profile rules drive PoracleNG's profile scheduler, quest rules drive
+   * summary delivery. The default keeps the profile wording, so profile callers need no change. See #457.
+   */
+  emptyStateKey?: string;
   profileColor?: string;
   profileName: string;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The quest summary editor said an empty schedule meant a manual profile start** ([#457](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/457)). The schedule editor is shared with profiles, and its empty-state line contradicted the sentence directly above it about quests being delivered individually.
+### Fixed
 - **A Pokemon alarm could be saved with a filter nothing can match** ([#461](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/461)). Transposing a pair — minimum IV 90 with maximum 10, say — saved without complaint and then went silent, with nothing to explain why the alerts stopped. Each bound was checked against the game's limits but never against its partner. Such a filter is now refused, including when the edit only changes one side of a pair.
 - **Deleting a quick pick left a record of it behind** ([#470](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/470)). The definition went and its applied state stayed, unreachable, so a new pick created with the same name inherited an "applied" badge pointing at the old pick's alarms. The delete confirmation now also says that the alarms it created stay, and that Remove is what deletes those.
 ### Fixed


### PR DESCRIPTION
Closes #457. Split out of #426 as a shared-component change rather than a caller special-case.

The active-hours editor serves two contexts that mean different things by a schedule: profile rules drive PoracleNG's profile scheduler, quest rules drive summary delivery. Its empty state was hard-coded to the profile wording, so the quest dialog read "No activation rules. Profile will require manual start." directly beneath its own line about quests being delivered individually.

The editor's data now takes an optional `emptyStateKey`, defaulting to the profile wording so every profile call site is unchanged. The quest dialog passes `QUESTS.SUMMARY_SCHEDULE_EMPTY`, which already carries exactly the right sentence — so no new key and no eleven locales of guessed translation.

Cosmetic only; the schedule itself already saved and applied correctly in both contexts.

Frontend suite green: 940 passed, including a new spec pinning the key the quest dialog passes. Lint and production build clean.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX