### PR TITLE
fix: a no-op alarm edit was reported as a collision with another alarm

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/BaseApiController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/BaseApiController.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -29,6 +30,23 @@ public abstract class BaseApiController : ControllerBase
                 error = "Distance must be zero or greater."
             })
             : null;
+
+    /// <summary>
+    /// True when applying an update leaves the stored alarm exactly as it was.
+    /// </summary>
+    /// <remarks>
+    /// Every edit dialog resubmits the whole form, so pressing Save with nothing changed sends the values
+    /// already stored. PoracleNG answers that with {alreadyPresent:1, insert:0, updates:0} -- the same
+    /// shape it uses when the edit collides with a DIFFERENT alarm -- which #463 turned into a 409 telling
+    /// the user another alarm was in the way when the only candidate was itself. Detected here, where both
+    /// sides are in hand, rather than guessed at from the response. Nothing to write means nothing to send.
+    /// See #498, #499, #501.
+    /// </remarks>
+    protected static bool LeavesAlarmUnchanged<TAlarm>(TAlarm before, Func<TAlarm> applyUpdate)
+    {
+        var original = JsonSerializer.Serialize(before);
+        return JsonSerializer.Serialize(applyUpdate()) == original;
+    }
 
     /// <summary>Checks that <paramref name="ownerId"/> matches the authenticated user. Returns true when NOT owned (i.e. should return 404).</summary>
     protected bool NotOwnedByCurrentUser(string? ownerId) => !string.Equals(ownerId, this.UserId, StringComparison.Ordinal);

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/EggController.cs
@@ -62,7 +62,16 @@ public class EggController(IEggService eggService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._eggService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/FortChangeController.cs
@@ -62,7 +62,16 @@ public class FortChangeController(IFortChangeService fortChangeService) : BaseAp
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._fortChangeService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/GymController.cs
@@ -62,7 +62,16 @@ public class GymController(IGymService gymService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._gymService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/InvasionController.cs
@@ -62,7 +62,16 @@ public class InvasionController(IInvasionService invasionService) : BaseApiContr
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._invasionService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/LureController.cs
@@ -62,7 +62,16 @@ public class LureController(ILureService lureService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._lureService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MaxBattleController.cs
@@ -62,7 +62,16 @@ public class MaxBattleController(IMaxBattleService maxBattleService) : BaseApiCo
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._maxBattleService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MonsterController.cs
@@ -69,7 +69,15 @@ public class MonsterController(IMonsterService monsterService) : BaseApiControll
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
 
         // Checked after the merge, not on the request: a PUT carrying only minIv inverts the window
         // against the value already stored, which validating the DTO alone cannot see. See #461.

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/NestController.cs
@@ -62,7 +62,16 @@ public class NestController(INestService nestService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._nestService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/QuestController.cs
@@ -62,7 +62,16 @@ public class QuestController(IQuestService questService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._questService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/RaidController.cs
@@ -62,7 +62,16 @@ public class RaidController(IRaidService raidService) : BaseApiController
             return this.NotFound();
         }
 
-        model.ApplyUpdate(existing);
+        // Nothing to write means nothing to send: see LeavesAlarmUnchanged.
+        if (LeavesAlarmUnchanged(existing, () =>
+        {
+            model.ApplyUpdate(existing);
+            return existing;
+        }))
+        {
+            return this.Ok(existing);
+        }
+
         var result = await this._raidService.UpdateAsync(this.UserId, existing);
         return this.Ok(result);
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Saving a raid, egg, quest, gym, nest or fort-change edit without changing anything was refused** ([#498](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/498), [#499](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/499), [#501](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/501)). Pressing Save with nothing edited, or changing only the ping, reported that another alarm already used those settings — the alarm it meant was the one being edited. Introduced by the duplicate detection added in v2.12.1.
+### Fixed
 - **The quest summary editor said an empty schedule meant a manual profile start** ([#457](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/457)). The schedule editor is shared with profiles, and its empty-state line contradicted the sentence directly above it about quests being delivered individually.
 ### Fixed
 - **A Pokemon alarm could be saved with a filter nothing can match** ([#461](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/461)). Transposing a pair — minimum IV 90 with maximum 10, say — saved without complaint and then went silent, with nothing to explain why the alerts stopped. Each bound was checked against the game's limits but never against its partner. Such a filter is now refused, including when the edit only changes one side of a pair.

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -53,7 +53,7 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -51,7 +51,7 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -51,7 +51,7 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -51,7 +51,7 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -51,7 +51,7 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -51,7 +51,7 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,
         // leaving the pre-edit row behind as a duplicate. Drop it and report the surviving uid.
         model.Uid = await TrackingUpdateReconciler.ReconcileAsync(
-            this._proxy, TrackingType, userId, oldUid, result, this._logger, this._uidRemapper);
+            this._proxy, TrackingType, userId, oldUid, result, this._logger, body, this._uidRemapper);
 
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -31,6 +32,7 @@ internal static partial class TrackingUpdateReconciler
         int oldUid,
         TrackingCreateResult result,
         ILogger logger,
+        JsonElement submitted,
         ITrackedUidRemapper? uidRemapper = null)
     {
         // oldUid <= 0 means this was not an edit, so there is nothing to reconcile.
@@ -42,8 +44,20 @@ internal static partial class TrackingUpdateReconciler
         // PoracleNG declined to write because the edited values collide with an alarm the user
         // already has. Nothing changed, so reporting success while echoing the requested values back
         // told the user their edit applied when it had not. See #463.
+        //
+        // But it reports the same {alreadyPresent:1, insert:0, updates:0} when the collision is with the
+        // row being edited -- pressing Save with nothing changed, which every edit dialog does by
+        // resubmitting the whole form. Reading that as a conflict told the user another alarm was in the
+        // way when the only candidate was itself. The two are told apart by asking whether the row at
+        // oldUid already holds what was submitted: if it does, the edit is a no-op and there is nothing
+        // to report. See #495.
         if (result.AlreadyPresent > 0 && result.Inserts == 0 && result.Updates == 0)
         {
+            if (await IsNoOpEditAsync(proxy, trackingType, userId, oldUid, submitted))
+            {
+                return oldUid;
+            }
+
             throw new TrackingConflictException(
                 trackingType,
                 "Another alarm of this type already uses those settings. Edit or remove that one instead.");
@@ -86,6 +100,137 @@ internal static partial class TrackingUpdateReconciler
         }
 
         return newUid;
+    }
+
+    /// <summary>
+    /// True when the row being edited already holds every value the update submitted, so PoracleNG's
+    /// "already present" was the row colliding with itself rather than with a different alarm.
+    /// </summary>
+    /// <remarks>
+    /// A missing row is not a no-op: something else removed it, and the caller should hear about the
+    /// conflict rather than be told the edit applied. Fields PoracleNG does not persist are excluded --
+    /// otherwise a ping-only edit, which PoracleNG drops on every tracking type, looks like a change and
+    /// reads as a conflict.
+    /// </remarks>
+    private static async Task<bool> IsNoOpEditAsync(
+        IPoracleTrackingProxy proxy,
+        string trackingType,
+        string userId,
+        int oldUid,
+        JsonElement submitted)
+    {
+        if (submitted.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        JsonElement rows;
+        try
+        {
+            rows = await proxy.GetByUserAsync(trackingType, userId);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // Cannot tell the two cases apart, so keep the conservative answer: report the conflict.
+            return false;
+        }
+
+        if (rows.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var row in rows.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object
+                || !row.TryGetProperty("uid", out var uid)
+                || uid.ValueKind != JsonValueKind.Number
+                || uid.GetInt32() != oldUid)
+            {
+                continue;
+            }
+
+            return MatchesStoredRow(submitted, row);
+        }
+
+        return false;
+    }
+
+    /// <summary>Fields the comparison ignores, because the stored row never reflects them.</summary>
+    private static readonly HashSet<string> IgnoredForNoOp = new(StringComparer.Ordinal)
+    {
+        // Assigned by PoracleNG, or rendered by it from the other fields.
+        "uid", "profile_no", "description",
+        // Never persisted, on any tracking type -- verified directly against PoracleNG. An edit that
+        // changes only this therefore leaves the row untouched, which is a no-op, not a conflict.
+        "ping",
+    };
+
+    private static bool MatchesStoredRow(JsonElement submitted, JsonElement stored)
+    {
+        foreach (var field in submitted.EnumerateObject())
+        {
+            if (IgnoredForNoOp.Contains(field.Name))
+            {
+                continue;
+            }
+
+            // A field the stored row does not carry cannot have changed it.
+            if (!stored.TryGetProperty(field.Name, out var storedValue))
+            {
+                continue;
+            }
+
+            if (!SameValue(field.Value, storedValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Equality that tolerates the shapes PoracleNG stores a value in.
+    /// </summary>
+    /// <remarks>
+    /// A list is written as an array and stored as its JSON text -- fort-change <c>change_types</c> comes
+    /// back as the string <c>["name"]</c> -- which is why the models carry StringOrArrayConverter. A byte
+    /// comparison would call that unchanged list a change.
+    /// </remarks>
+    private static bool SameValue(JsonElement submitted, JsonElement stored)
+    {
+        if (JsonElement.DeepEquals(submitted, stored))
+        {
+            return true;
+        }
+
+        if (stored.ValueKind == JsonValueKind.String && TryParse(stored.GetString(), out var reparsed))
+        {
+            return JsonElement.DeepEquals(submitted, reparsed);
+        }
+
+        return false;
+    }
+
+    private static bool TryParse(string? text, out JsonElement parsed)
+    {
+        parsed = default;
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        try
+        {
+            parsed = JsonDocument.Parse(text).RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     [LoggerMessage(

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -74,6 +74,93 @@ public class CreateResultSemanticsTests
         Assert.Equal(140, result.Uid);
     }
 
+    // ── #498, #499, #501: a row colliding with ITSELF is a no-op, not a conflict ────
+
+    /// <summary>
+    /// PoracleNG answers {alreadyPresent:1, insert:0, updates:0} both when the edit collides with a
+    /// different alarm and when it collides with the row being edited. Every edit dialog resubmits the
+    /// whole form, so pressing Save with nothing changed hit the second case and was told a non-existent
+    /// alarm was in the way.
+    /// </summary>
+    [Fact]
+    public async Task ResubmittingAnUnchangedRowIsNotAConflict()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 1, 0, 0));
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 134, id = "u1", team = 2, distance = 500, template = "1" }));
+
+        var result = await sut.UpdateAsync("u1", new Gym
+        {
+            Id = "u1",
+            Uid = 134,
+            Team = 2,
+            Distance = 500,
+            Template = "1",
+        });
+
+        Assert.Equal(134, result.Uid);
+    }
+
+    /// <summary>
+    /// ping is never persisted on any tracking type, so an edit changing only that leaves the row
+    /// untouched. It must not read as a collision with another alarm.
+    /// </summary>
+    [Fact]
+    public async Task APingOnlyEditIsNotAConflict()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 1, 0, 0));
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 134, id = "u1", team = 2, distance = 500, ping = "" }));
+
+        var result = await sut.UpdateAsync("u1", new Gym
+        {
+            Id = "u1",
+            Uid = 134,
+            Team = 2,
+            Distance = 500,
+            Ping = "<@&999>",
+        });
+
+        Assert.Equal(134, result.Uid);
+    }
+
+    /// <summary>A real collision with a different alarm still has to be reported.</summary>
+    [Fact]
+    public async Task AnEditOntoAnotherAlarmsSettingsIsStillAConflict()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 1, 0, 0));
+        // The row being edited still holds team 2; the submission moves it onto uid 135's team 4.
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 134, id = "u1", team = 2, distance = 500 },
+            new { uid = 135, id = "u1", team = 4, distance = 500 }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Gym { Id = "u1", Uid = 134, Team = 4, Distance = 500 }));
+    }
+
+    /// <summary>A vanished row is not a no-op: report the conflict rather than claim success.</summary>
+    [Fact]
+    public async Task AConflictIsStillReportedWhenTheEditedRowIsGone()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([], 1, 0, 0));
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 135, id = "u1", team = 4, distance = 500 }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Gym { Id = "u1", Uid = 134, Team = 4, Distance = 500 }));
+    }
     // ── #462: a colliding natural-key edit must not destroy either alarm ─────
 
     [Fact]


### PR DESCRIPTION
Closes #498, #499, #501. Regression from the duplicate detection added in #463.

PoracleNG answers `{alreadyPresent:1, insert:0, updates:0}` in two different situations: when an edit collides with a **different** alarm, and when it collides with **the row being edited**. #463 read every one of those as the first case. Since every edit dialog resubmits the whole form, pressing Save with nothing changed produced a 409 saying another alarm already used those settings — the alarm it meant was the one in front of the user. Raids, eggs, quests, gyms, nests and fort changes were all affected; monsters and the natural-key types were not.

### The fix
Detected in the controller, where both sides are in hand, rather than inferred from the response: apply the update to the stored alarm and compare. Nothing to write means nothing to send, so PoracleNG is not called at all.

The reconciler keeps a narrower version for the one case the controller cannot see — a ping-only edit. That genuinely changes the model, so it does reach PoracleNG, but it cannot collide with anything because `ping` is never persisted on any tracking type (verified directly against PoracleNG while investigating #494). Its comparison ignores fields PoracleNG assigns or renders, and tolerates a list stored as its JSON text: fort-change `change_types` comes back as the string `["name"]`, which is why the models carry `StringOrArrayConverter`.

### Verified against a live API
```
                 resubmit what the dialog holds   ping-only edit
  raids                     200                        200
  eggs                      200                        200
  quests                    200                        200
  gyms                      200                        200
  fort-changes              200                        200
```
All ten were 409 before. Nests share the code path and the unit tests; the live instance has them disabled by an admin toggle, so they could not be exercised there.

Suite green: 1769 passed, with four new cases — an unchanged resubmit, a ping-only edit, a genuine collision with a different row, and a vanished row (which must still report the conflict rather than claim success).

### Not in scope
While verifying, editing a gym onto another gym's team was found to make PoracleNG collapse the two rows and report an insert — so it never reaches the refusal branch this PR touches, and the other alarm is destroyed. That is the same class as #502 and will be handled there.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX