### PR TITLE
fix: deleting a user left their alarms, geofences, quick picks and delegate grants behind

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFortChangeService, FortChangeService>();
         services.AddScoped<IMaxBattleService, MaxBattleService>();
         services.AddScoped<IHumanService, HumanService>();
+        services.AddScoped<IUserPurgeService, UserPurgeService>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<IDashboardService, DashboardService>();
         services.AddScoped<ICleaningService, CleaningService>();

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -9,6 +9,7 @@ namespace Pgan.PoracleWebNet.Api.Controllers;
 [Route("api/admin")]
 public partial class AdminController(
     IHumanService humanService,
+    IUserPurgeService userPurgeService,
     IWebhookDelegateService webhookDelegateService,
     IPoracleApiProxy poracleApiProxy,
     IPoracleHumanProxy humanProxy,
@@ -17,6 +18,7 @@ public partial class AdminController(
     ILogger<AdminController> logger) : BaseApiController
 {
     private readonly IHumanService _humanService = humanService;
+    private readonly IUserPurgeService _userPurgeService = userPurgeService;
     private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
     private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
@@ -459,6 +461,20 @@ public partial class AdminController(
             return this.BadRequest(new { error = "userId is required and must be 100 characters or fewer." });
         }
 
+        // Neither id was checked against anything, so a typo created a grant over a webhook that does not
+        // exist, for a user who does not exist, and the admin delegates view then listed it as real. A
+        // grant is only meaningful between two accounts that exist. See #514.
+        var webhook = await this._humanService.GetByIdAsync(request.WebhookId);
+        if (webhook is null || !string.Equals(webhook.Type, "webhook", StringComparison.OrdinalIgnoreCase))
+        {
+            return this.BadRequest(new { error = "webhookId does not name an existing webhook." });
+        }
+
+        if (!await this._humanService.ExistsAsync(request.UserId))
+        {
+            return this.BadRequest(new { error = "userId does not name an existing user." });
+        }
+
         var delegates = await this._webhookDelegateService.AddDelegateAsync(request.WebhookId, request.UserId);
         return this.Ok(delegates);
     }
@@ -524,7 +540,11 @@ public partial class AdminController(
             return this.Forbid();
         }
 
-        var deleted = await this._humanService.DeleteUserAsync(id);
+        // Everything the account owns goes with it: alarms, geofences, delegate grants, quick picks and
+        // their applied state. Removing the humans row alone left all of it behind, unreachable but
+        // intact, and re-creating the same id adopted the lot -- including impersonation rights over a
+        // recreated webhook URL. See #510, #511, #512.
+        var deleted = await this._userPurgeService.PurgeAsync(id);
         if (!deleted)
         {
             return this.NotFound();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Deleting a user left almost everything they owned behind** ([#510](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/510), [#511](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/511), [#512](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/512)). Alarms, custom geofences, quick picks and webhook delegate grants all survived the delete. Nothing could reach them, so the account looked gone — until the same ID was created again and inherited the lot, including delegate rights over a recreated webhook URL. A deleted user's geofences also kept being published to Poracle.
+- **Webhook delegation accepted IDs that name nothing** ([#514](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/514)). A typo created a grant over a webhook that does not exist, for a user who does not exist, and the admin list then showed it as real.
+- **"Delete all alarms" skipped fort changes and max battles** ([#510](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/510)), leaving those two types behind on every path that clears a user's alarms.
+### Fixed
 - **Saving a raid, egg, quest, gym, nest or fort-change edit without changing anything was refused** ([#498](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/498), [#499](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/499), [#501](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/501)). Pressing Save with nothing edited, or changing only the ping, reported that another alarm already used those settings — the alarm it meant was the one being edited. Introduced by the duplicate detection added in v2.12.1.
 ### Fixed
 - **The quest summary editor said an empty schedule meant a manual profile start** ([#457](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/457)). The schedule editor is shared with profiles, and its empty-state line contradicted the sentence directly above it about quests being delivered individually.

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IQuickPickAppliedStateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IQuickPickAppliedStateRepository.cs
@@ -24,4 +24,7 @@ public interface IQuickPickAppliedStateRepository
     /// badge pointing at alarm uids from the old one. See #470.
     /// </remarks>
     public Task DeleteByQuickPickIdAsync(string quickPickId, string? userId = null);
+
+    /// <summary>Removes every applied-state row belonging to a user. See #510.</summary>
+    public Task DeleteByUserAsync(string userId);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IWebhookDelegateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IWebhookDelegateRepository.cs
@@ -10,4 +10,7 @@ public interface IWebhookDelegateRepository
     public Task<WebhookDelegate> AddAsync(string webhookId, string userId);
     public Task<bool> RemoveAsync(string webhookId, string userId);
     public Task<bool> RemoveAllForWebhookAsync(string webhookId);
+
+    /// <summary>Removes every grant naming this id, as the webhook or as the delegate. See #512.</summary>
+    public Task<int> RemoveAllForIdAsync(string id);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IUserPurgeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IUserPurgeService.cs
@@ -1,0 +1,20 @@
+namespace Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+/// <summary>
+/// Removes everything PoracleWeb holds about a user when their account is deleted.
+/// </summary>
+/// <remarks>
+/// The delete used to remove the <c>humans</c> row alone. Everything else stayed: alarms in the Poracle DB,
+/// and geofences, webhook delegate grants, quick picks and their applied state in <c>poracle_web</c>. None of
+/// it was reachable through any API surface afterwards, so it looked deleted — until the same id was created
+/// again, which adopted the lot. The delegate grants are the sharp end: re-creating a webhook URL silently
+/// restored impersonation rights over it, and a deleted user's geofences kept being published in the feed
+/// PoracleJS reads. See #510, #511, #512.
+/// </remarks>
+public interface IUserPurgeService
+{
+    /// <summary>
+    /// Erases the user's data everywhere PoracleWeb stores it. Returns false when no such user exists.
+    /// </summary>
+    public Task<bool> PurgeAsync(string userId);
+}

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/QuickPickAppliedStateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/QuickPickAppliedStateRepository.cs
@@ -108,6 +108,19 @@ public class QuickPickAppliedStateRepository(PoracleWebContext context) : IQuick
         await this._context.SaveChangesAsync();
     }
 
+    public async Task DeleteByUserAsync(string userId)
+    {
+        var rows = await this._context.QuickPickAppliedStates.Where(s => s.UserId == userId).ToListAsync();
+
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        this._context.QuickPickAppliedStates.RemoveRange(rows);
+        await this._context.SaveChangesAsync();
+    }
+
     private static QuickPickAppliedState MapToModel(QuickPickAppliedStateEntity entity) => new()
     {
         UserId = entity.UserId,

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/WebhookDelegateRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/WebhookDelegateRepository.cs
@@ -90,4 +90,20 @@ public class WebhookDelegateRepository(PoracleWebContext context) : IWebhookDele
         await this._context.SaveChangesAsync();
         return true;
     }
+
+    public async Task<int> RemoveAllForIdAsync(string id)
+    {
+        var entities = await this._context.WebhookDelegates
+            .Where(d => d.WebhookId == id || d.UserId == id)
+            .ToListAsync();
+
+        if (entities.Count == 0)
+        {
+            return 0;
+        }
+
+        this._context.WebhookDelegates.RemoveRange(entities);
+        await this._context.SaveChangesAsync();
+        return entities.Count;
+    }
 }

--- a/Core/Pgan.PoracleWebNet.Core.Services/HumanService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/HumanService.cs
@@ -20,7 +20,10 @@ public class HumanService(
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly IPoracleTrackingProxy _trackingProxy = trackingProxy;
 
-    private static readonly string[] AlarmTypes = ["pokemon", "raid", "egg", "quest", "invasion", "lure", "nest", "gym"];
+    // fort and maxbattle were missing, so "delete all alarms" left those two types behind and a deleted
+    // account kept them. Every tracking type PoracleWeb can create belongs here. See #510.
+    private static readonly string[] AlarmTypes =
+        ["pokemon", "raid", "egg", "quest", "invasion", "lure", "nest", "gym", "fort", "maxbattle"];
 
     // TODO: Migrate once PoracleNG adds a "get all humans" endpoint.
     // See: docs/poracleng-enhancement-requests.md

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserPurgeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserPurgeService.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.Logging;
+using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Core.Services;
+
+/// <inheritdoc cref="IUserPurgeService"/>
+public partial class UserPurgeService(
+    IHumanRepository humanRepository,
+    IUserGeofenceRepository geofenceRepository,
+    IUserGeofenceService geofenceService,
+    IWebhookDelegateRepository webhookDelegateRepository,
+    IQuickPickDefinitionRepository quickPickRepository,
+    IQuickPickAppliedStateRepository appliedStateRepository,
+    IHumanService humanService,
+    ILogger<UserPurgeService> logger) : IUserPurgeService
+{
+    private readonly IHumanRepository _humanRepository = humanRepository;
+    private readonly IUserGeofenceRepository _geofenceRepository = geofenceRepository;
+    private readonly IUserGeofenceService _geofenceService = geofenceService;
+    private readonly IWebhookDelegateRepository _webhookDelegateRepository = webhookDelegateRepository;
+    private readonly IQuickPickDefinitionRepository _quickPickRepository = quickPickRepository;
+    private readonly IQuickPickAppliedStateRepository _appliedStateRepository = appliedStateRepository;
+    private readonly IHumanService _humanService = humanService;
+    private readonly ILogger<UserPurgeService> _logger = logger;
+
+    public async Task<bool> PurgeAsync(string userId)
+    {
+        if (!await this._humanRepository.ExistsAsync(userId))
+        {
+            return false;
+        }
+
+        // Order matters only at the end: the humans row goes last, so a failure part-way through leaves an
+        // account that is still visible and still deletable rather than a half-erased ghost. Each step is
+        // logged and swallowed for the same reason -- one unreachable dependency must not strand the rest.
+        await this.TryAsync("alarms", () => this._humanService.DeleteAllAlarmsByUserAsync(userId));
+        await this.TryAsync("geofences", () => this.PurgeGeofencesAsync(userId));
+        await this.TryAsync("webhook delegates", () => this._webhookDelegateRepository.RemoveAllForIdAsync(userId));
+        await this.TryAsync("quick picks", () => this.PurgeQuickPicksAsync(userId));
+
+        return await this._humanRepository.DeleteUserAsync(userId);
+    }
+
+    /// <summary>
+    /// Goes through the geofence service rather than the repository so a promoted fence is also removed from
+    /// the shared Koji project, and so Poracle re-reads the feed. Otherwise a deleted user's polygons keep
+    /// being served to PoracleJS. See #511.
+    /// </summary>
+    private async Task PurgeGeofencesAsync(string userId)
+    {
+        foreach (var geofence in await this._geofenceRepository.GetByHumanIdAsync(userId))
+        {
+            await this._geofenceService.AdminDeleteAsync(userId, geofence.Id);
+        }
+    }
+
+    private async Task PurgeQuickPicksAsync(string userId)
+    {
+        // Applied state first: it is keyed on the definition, and a global pick the user applied leaves a row
+        // that no definition delete would reach.
+        await this._appliedStateRepository.DeleteByUserAsync(userId);
+
+        foreach (var definition in await this._quickPickRepository.GetByOwnerAsync(userId))
+        {
+            await this._quickPickRepository.DeleteByIdAndOwnerAsync(definition.Id, userId);
+        }
+    }
+
+    private async Task TryAsync(string step, Func<Task> work)
+    {
+        try
+        {
+            await work();
+        }
+        catch (Exception ex)
+        {
+            LogPurgeStepFailed(this._logger, ex, step);
+        }
+    }
+
+    // Its own try/catch rather than delegating to the overload above: an async lambda wrapping a Func<Task<T>>
+    // binds back to this method, which recurses until the stack goes.
+    private async Task TryAsync<T>(string step, Func<Task<T>> work)
+    {
+        try
+        {
+            await work();
+        }
+        catch (Exception ex)
+        {
+            LogPurgeStepFailed(this._logger, ex, step);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Could not remove {Step} while deleting a user; the account was still deleted and the leftovers need clearing by hand.")]
+    private static partial void LogPurgeStepFailed(ILogger logger, Exception exception, string step);
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -12,6 +12,7 @@ namespace Pgan.PoracleWebNet.Tests.Controllers;
 public class AdminControllerTests : ControllerTestBase
 {
     private readonly Mock<IHumanService> _humanService = new();
+    private readonly Mock<IUserPurgeService> _userPurgeService = new();
     private readonly Mock<IPoracleApiProxy> _proxy = new();
     private readonly Mock<IPoracleHumanProxy> _humanProxy = new();
     private readonly Mock<IWebhookDelegateService> _webhookDelegateService = new();
@@ -26,12 +27,21 @@ public class AdminControllerTests : ControllerTestBase
             .Returns("test-impersonation-jwt");
         this._sut = new AdminController(
             this._humanService.Object,
+            this._userPurgeService.Object,
             this._webhookDelegateService.Object,
             this._proxy.Object,
             this._humanProxy.Object,
             poracleSettings,
             this._jwtService.Object,
             this._logger.Object);
+    }
+
+    /// <summary>Both ids must name real accounts before a grant is meaningful. See #514.</summary>
+    private void GivenWebhookAndUserExist(string webhookId = "wh1", string userId = "u2")
+    {
+        this._humanService.Setup(s => s.GetByIdAsync(webhookId))
+            .ReturnsAsync(new Human { Id = webhookId, Type = "webhook" });
+        this._humanService.Setup(s => s.ExistsAsync(userId)).ReturnsAsync(true);
     }
 
     // --- GetUserAvatars (#395) ---
@@ -290,7 +300,9 @@ public class AdminControllerTests : ControllerTestBase
     public async Task DeleteUserReturnsNotFoundWhenMissing()
     {
         SetupUser(this._sut, isAdmin: true);
-        this._humanService.Setup(s => s.DeleteUserAsync("u1")).ReturnsAsync(false);
+        // The delete goes through the purge service now, so everything the account owns goes with it.
+        // See #510, #511, #512.
+        this._userPurgeService.Setup(s => s.PurgeAsync("u1")).ReturnsAsync(false);
         Assert.IsType<NotFoundResult>(await this._sut.DeleteUser("u1"));
     }
 
@@ -298,8 +310,11 @@ public class AdminControllerTests : ControllerTestBase
     public async Task DeleteUserReturnsNoContentWhenDeleted()
     {
         SetupUser(this._sut, isAdmin: true);
-        this._humanService.Setup(s => s.DeleteUserAsync("u1")).ReturnsAsync(true);
+        this._userPurgeService.Setup(s => s.PurgeAsync("u1")).ReturnsAsync(true);
+
         Assert.IsType<NoContentResult>(await this._sut.DeleteUser("u1"));
+
+        this._userPurgeService.Verify(s => s.PurgeAsync("u1"), Times.Once);
     }
 
     // --- ImpersonateUser ---
@@ -417,6 +432,7 @@ public class AdminControllerTests : ControllerTestBase
     {
         SetupUser(this._sut, isAdmin: true);
         var userId = new string('9', 100);
+        this.GivenWebhookAndUserExist(userId: userId);
         this._webhookDelegateService.Setup(s => s.AddDelegateAsync("wh1", userId))
             .ReturnsAsync([userId]);
 
@@ -425,9 +441,51 @@ public class AdminControllerTests : ControllerTestBase
         Assert.IsType<OkObjectResult>(result);
     }
     [Fact]
+    public async Task AddWebhookDelegateRejectsAWebhookThatDoesNotExist()
+    {
+        SetupUser(this._sut, isAdmin: true);
+        this._humanService.Setup(s => s.GetByIdAsync("wh-ghost")).ReturnsAsync((Human?)null);
+
+        var result = await this._sut.AddWebhookDelegate(new AdminController.WebhookDelegateRequest("wh-ghost", "u2"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        this._webhookDelegateService.Verify(
+            s => s.AddDelegateAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>A grant may only name a webhook, not an ordinary user account.</summary>
+    [Fact]
+    public async Task AddWebhookDelegateRejectsAnIdThatIsNotAWebhook()
+    {
+        SetupUser(this._sut, isAdmin: true);
+        this._humanService.Setup(s => s.GetByIdAsync("someone"))
+            .ReturnsAsync(new Human { Id = "someone", Type = "discord:user" });
+
+        var result = await this._sut.AddWebhookDelegate(new AdminController.WebhookDelegateRequest("someone", "u2"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AddWebhookDelegateRejectsAUserThatDoesNotExist()
+    {
+        SetupUser(this._sut, isAdmin: true);
+        this._humanService.Setup(s => s.GetByIdAsync("wh1"))
+            .ReturnsAsync(new Human { Id = "wh1", Type = "webhook" });
+        this._humanService.Setup(s => s.ExistsAsync("ghost")).ReturnsAsync(false);
+
+        var result = await this._sut.AddWebhookDelegate(new AdminController.WebhookDelegateRequest("wh1", "ghost"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        this._webhookDelegateService.Verify(
+            s => s.AddDelegateAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public async Task AddWebhookDelegateAddsNewDelegate()
     {
         SetupUser(this._sut, isAdmin: true);
+        this.GivenWebhookAndUserExist();
         this._webhookDelegateService.Setup(s => s.AddDelegateAsync("wh1", "u2"))
             .ReturnsAsync(["u1", "u2"]);
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserPurgeServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserPurgeServiceTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// Deleting a user removed the humans row alone. Alarms, geofences, delegate grants and quick picks all
+/// stayed — unreachable, so it looked deleted, until the same id was created again and adopted the lot.
+/// See #510, #511, #512.
+/// </summary>
+public class UserPurgeServiceTests
+{
+    private readonly Mock<IHumanRepository> _humans = new();
+    private readonly Mock<IUserGeofenceRepository> _geofences = new();
+    private readonly Mock<IUserGeofenceService> _geofenceService = new();
+    private readonly Mock<IWebhookDelegateRepository> _delegates = new();
+    private readonly Mock<IQuickPickDefinitionRepository> _quickPicks = new();
+    private readonly Mock<IQuickPickAppliedStateRepository> _appliedStates = new();
+    private readonly Mock<IHumanService> _humanService = new();
+    private readonly UserPurgeService _sut;
+
+    public UserPurgeServiceTests()
+    {
+        this._humans.Setup(r => r.ExistsAsync("u1")).ReturnsAsync(true);
+        this._humans.Setup(r => r.DeleteUserAsync("u1")).ReturnsAsync(true);
+        this._geofences.Setup(r => r.GetByHumanIdAsync("u1")).ReturnsAsync([]);
+        this._quickPicks.Setup(r => r.GetByOwnerAsync("u1")).ReturnsAsync([]);
+
+        this._sut = new UserPurgeService(
+            this._humans.Object,
+            this._geofences.Object,
+            this._geofenceService.Object,
+            this._delegates.Object,
+            this._quickPicks.Object,
+            this._appliedStates.Object,
+            this._humanService.Object,
+            NullLogger<UserPurgeService>.Instance);
+    }
+
+    [Fact]
+    public async Task PurgeRemovesEverythingTheAccountOwns()
+    {
+        this._geofences.Setup(r => r.GetByHumanIdAsync("u1"))
+            .ReturnsAsync([new UserGeofence { Id = 7, HumanId = "u1", KojiName = "zz" }]);
+        this._quickPicks.Setup(r => r.GetByOwnerAsync("u1"))
+            .ReturnsAsync([new QuickPickDefinition { Id = "p1", Name = "P", AlarmType = "monster", OwnerUserId = "u1" }]);
+
+        Assert.True(await this._sut.PurgeAsync("u1"));
+
+        this._humanService.Verify(s => s.DeleteAllAlarmsByUserAsync("u1"), Times.Once);
+        // Through the service, not the repository: a promoted fence must also leave the shared Koji project,
+        // and Poracle has to re-read the feed. See #511.
+        this._geofenceService.Verify(s => s.AdminDeleteAsync("u1", 7), Times.Once);
+        this._delegates.Verify(r => r.RemoveAllForIdAsync("u1"), Times.Once);
+        this._appliedStates.Verify(r => r.DeleteByUserAsync("u1"), Times.Once);
+        this._quickPicks.Verify(r => r.DeleteByIdAndOwnerAsync("p1", "u1"), Times.Once);
+        this._humans.Verify(r => r.DeleteUserAsync("u1"), Times.Once);
+    }
+
+    /// <summary>
+    /// Grants naming the id as the delegate go too, not only those naming it as the webhook — otherwise a
+    /// deleted user keeps rights over webhooks that still exist.
+    /// </summary>
+    [Fact]
+    public async Task PurgeClearsGrantsInBothDirections()
+    {
+        await this._sut.PurgeAsync("u1");
+
+        this._delegates.Verify(r => r.RemoveAllForIdAsync("u1"), Times.Once);
+        this._delegates.Verify(r => r.RemoveAllForWebhookAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnUnknownUserIsReportedRatherThanPartiallyPurged()
+    {
+        this._humans.Setup(r => r.ExistsAsync("ghost")).ReturnsAsync(false);
+
+        Assert.False(await this._sut.PurgeAsync("ghost"));
+
+        this._humanService.Verify(s => s.DeleteAllAlarmsByUserAsync(It.IsAny<string>()), Times.Never);
+        this._delegates.Verify(r => r.RemoveAllForIdAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// One unreachable dependency must not strand the rest, and must not leave an account that cannot be
+    /// deleted. The failure is logged for the admin to clear by hand.
+    /// </summary>
+    [Fact]
+    public async Task OneFailedStepDoesNotStopTheOthers()
+    {
+        this._humanService.Setup(s => s.DeleteAllAlarmsByUserAsync("u1"))
+            .ThrowsAsync(new HttpRequestException("PoracleNG is down"));
+
+        Assert.True(await this._sut.PurgeAsync("u1"));
+
+        this._delegates.Verify(r => r.RemoveAllForIdAsync("u1"), Times.Once);
+        this._humans.Verify(r => r.DeleteUserAsync("u1"), Times.Once);
+    }
+
+    /// <summary>The humans row goes last, so a part-way failure leaves an account still visible.</summary>
+    [Fact]
+    public async Task TheAccountItselfIsRemovedLast()
+    {
+        var order = new List<string>();
+        this._humanService.Setup(s => s.DeleteAllAlarmsByUserAsync("u1"))
+            .Callback(() => order.Add("alarms")).ReturnsAsync(0);
+        this._delegates.Setup(r => r.RemoveAllForIdAsync("u1"))
+            .Callback(() => order.Add("delegates")).ReturnsAsync(0);
+        this._humans.Setup(r => r.DeleteUserAsync("u1"))
+            .Callback(() => order.Add("human")).ReturnsAsync(true);
+
+        await this._sut.PurgeAsync("u1");
+
+        Assert.Equal("human", order[^1]);
+    }
+}


### PR DESCRIPTION
Closes #510, #511, #512, #514.

Deleting a user removed the `humans` row (and, since #481, the `profiles` rows) and nothing else. Alarms stayed in the Poracle DB; geofences, webhook delegate grants, quick picks and their applied state stayed in `poracle_web`. None of it was reachable through any API surface, so the account looked erased — until the same id was created again, which adopted all of it.

Two consequences worth naming separately:

- **#512 is a privilege issue.** Delegate grants survived the delete, so re-creating a webhook URL silently restored impersonation rights over it to whoever held them before.
- **#511 is externally visible.** A deleted user's polygons kept being published in the unauthenticated feed PoracleJS reads, so their areas kept matching alerts.

### The cascade
`UserPurgeService` owns it. The `humans` row goes **last**, so a failure part-way through leaves an account that is still visible and still deletable rather than a half-erased ghost; each step is logged and swallowed so one unreachable dependency cannot strand the rest. Geofences go through `UserGeofenceService` rather than the repository, so a promoted fence also leaves the shared Koji project and Poracle re-reads the feed.

`AlarmTypes` was missing `fort` and `maxbattle`, so **every** path that clears a user's alarms — including the admin "delete alarms" endpoint — left those two types behind. Fixed in the same change.

### #514
Neither delegate id was checked against anything, so a typo created a grant over a webhook that does not exist, for a user who does not exist, and the admin delegates view listed it as real. Both must now name existing accounts, and the webhook id must name a webhook rather than an ordinary user.

### Verified against a live API
```
account given: an alarm, a geofence, a delegate grant, an applied quick pick
DELETE /api/admin/users            -> 204
  delegate grants naming it        -> 0
  its geofences in the public feed -> 0
  admin geofence rows              -> 0
re-create the same id
  alarms inherited                 -> 0
  its own quick pick inherited     -> false
  applied badges                   -> 0
  geofences inherited              -> 0

#514  bogus webhook id  -> 400 "webhookId does not name an existing webhook."
      bogus user id     -> 400 "userId does not name an existing user."
      a user as webhook -> 400
      both real         -> 200
```

Suite green: 1777 passed, with a new `UserPurgeServiceTests` covering the full cascade, grants in both directions, an unknown user, a failing step not stranding the others, and the account being removed last.

One defect in the fix itself was caught by the suite before it went anywhere: the generic `TryAsync<T>` overload bound its own async lambda back to itself and recursed until the stack went, aborting the test run.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX