### PR TITLE
fix: an edit could delete a different alarm, and re-apply could destroy a pick's alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Editing an alarm could silently delete a different one** ([#531](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/531)). Changing a raid's team, an egg's level, a gym's slot or battle toggles, or a fort-change's change types onto settings another alarm already had merged the two: one alarm vanished, the survivor took the edited alarm's radius, and the app reported a successful update. The clash is now refused and both alarms are left alone.
+- **Re-applying a quick pick could destroy its alarms** ([#532](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/532)). Re-apply deleted the existing alarms first and only then checked whether the pick could be applied, so a pick that had been disabled or edited into an impossible filter lost its alarms and reported only that it had been refused. Everything that can refuse a re-apply is now checked before anything is deleted.
+### Fixed
 - **Changing the notification language marked your account as never seen** ([#517](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/517)). The write blanked the last-seen timestamp Poracle and the admin user list use to judge whether an account is still alive, and reported success without a hint that anything else had changed.
 - **A quick pick could create an alarm that can never match anything** ([#507](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/507)). Filter values the alarm form rejects were saved through a pick and notified nothing, silently. Quick picks are now held to the same rules as the form.
 - **Disabling a quick pick stranded the alarms it had created** ([#508](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/508)). The pick vanished from the list along with its Remove button, leaving alarms with no way to un-apply them and nothing to say where they came from — and an admin disabling a shared pick did that to everyone who had applied it.

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -48,6 +48,12 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Raids);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -60,6 +60,12 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.FortChanges);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -46,6 +46,12 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Gyms);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -46,6 +46,12 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Nests);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -46,6 +46,12 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Quests);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -20,9 +20,11 @@ public partial class QuickPickService(
     IGymService gymService,
     IMaxBattleService maxBattleService,
     IMasterDataService masterDataService,
+    IFeatureGate featureGate,
     ILogger<QuickPickService> logger) : IQuickPickService
 {
     private readonly IQuickPickDefinitionRepository _definitionRepository = definitionRepository;
+    private readonly IFeatureGate _featureGate = featureGate;
     private readonly IQuickPickAppliedStateRepository _appliedStateRepository = appliedStateRepository;
     private readonly IMonsterService _monsterService = monsterService;
     private readonly IRaidService _raidService = raidService;
@@ -335,8 +337,69 @@ public partial class QuickPickService(
     public async Task<QuickPickAppliedState> ReapplyAsync(
         string userId, int profileNo, string quickPickId, QuickPickApplyRequest request)
     {
+        // Remove used to run first unconditionally. Once apply grew guards -- a disabled pick, a filter
+        // the alarm model refuses, an alarm type an admin has switched off -- a refused re-apply
+        // destroyed the alarms and created nothing in their place, while the error read as "nothing
+        // happened". The pick also dropped off the list, taking the Remove button with it. Everything
+        // that can refuse this is checked BEFORE anything is deleted. See #531.
+        await this.EnsureApplicableAsync(userId, profileNo, quickPickId, request);
+
         await this.RemoveAsync(userId, profileNo, quickPickId);
         return await this.ApplyAsync(userId, profileNo, quickPickId, request);
+    }
+
+    /// <summary>
+    /// Runs everything that can refuse an apply, without writing anything.
+    /// </summary>
+    /// <remarks>
+    /// Builds the alarms the apply would build and validates them, which is where an impossible filter
+    /// surfaces. Building is side-effect free, so this is a genuine dry run rather than a partial apply.
+    /// </remarks>
+    private async Task EnsureApplicableAsync(
+        string userId, int profileNo, string quickPickId, QuickPickApplyRequest request)
+    {
+        var definition = await this.LoadDefinitionAsync(userId, quickPickId)
+            ?? throw new InvalidOperationException($"Quick pick '{quickPickId}' not found.");
+
+        if (!definition.Enabled)
+        {
+            throw new AlarmValidationException("That quick pick is disabled and cannot be applied.");
+        }
+
+        // The same gate the alarm services apply, so a type an admin has switched off refuses here
+        // rather than half-way through, after the deletes.
+        var disableKey = DisableFeatureKeys.ByTrackingType.TryGetValue(definition.AlarmType, out var key)
+            ? key
+            : null;
+        if (disableKey is not null)
+        {
+            await this._featureGate.EnsureEnabledAsync(disableKey);
+        }
+
+        // Building throws for a filter the alarm model refuses. Nothing is sent anywhere.
+        BuildSampleAlarm(definition, profileNo, request);
+    }
+
+    /// <summary>Builds one alarm of the definition's type purely to run its validation.</summary>
+    private static void BuildSampleAlarm(
+        QuickPickDefinition definition, int profileNo, QuickPickApplyRequest request)
+    {
+        switch (definition.AlarmType)
+        {
+            case "monster":
+                BuildMonster(definition.Filters, 1, profileNo, request);
+                break;
+            case "raid":
+                BuildRaid(definition.Filters, profileNo, request);
+                break;
+            case "maxbattle":
+                BuildMaxBattle(definition.Filters, profileNo, request);
+                break;
+            default:
+                // The remaining types deserialize their filters straight onto the model, which the
+                // apply path validates on the way through; there is nothing extra to check here.
+                break;
+        }
     }
 
     public async Task<bool> RemoveAsync(string userId, int profileNo, string quickPickId)

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -52,6 +52,12 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Raids);
         var oldUid = model.Uid;
         var body = SerializeToElement(model);
+
+        // Refuse before writing: PoracleNG would satisfy this by merging into the other alarm and
+        // the reconciler would then delete this one, losing a row the user never touched. See #531.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, oldUid, body);
+
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         // PoracleNG inserts instead of upserting when the edit changes a dedup-key field,

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -103,6 +103,119 @@ internal static partial class TrackingUpdateReconciler
     }
 
     /// <summary>
+    /// Refuses an edit that PoracleNG would satisfy by merging into a DIFFERENT alarm.
+    /// </summary>
+    /// <remarks>
+    /// PoracleNG decides what to do with a submitted row by diffing it against the existing ones
+    /// (diffTracking in processor/internal/api/tracking.go). When the only differences are in fields it
+    /// tags <c>diff:"update"</c>, it updates that existing row in place and re-keys it -- answering
+    /// {insert:0, updates:1, newUids:[new]}. If the row it picked is not the one being edited, the edit
+    /// has just overwritten somebody else's alarm, and the reconciler below then deleted the original as
+    /// "superseded": two alarms became one, the victim's radius replaced by the editor's, reported as a
+    /// clean 200. Reachable from the ordinary edit dialogs -- changing a raid's team, a gym's slot or
+    /// battle toggles, an egg's level, a fort-change's change types. Lures and invasions were never
+    /// exposed because they carry their own pre-flight checks from #462.
+    /// <para>
+    /// The updatable set is uniform upstream -- template, distance and clean, plus slot_changes and
+    /// battle_changes on gyms -- so the collision test is the same for every type: equal on everything
+    /// else means PoracleNG will merge them.
+    /// </para>
+    /// </remarks>
+    public static async Task EnsureNoMergeIntoAnotherAlarmAsync(
+        IPoracleTrackingProxy proxy,
+        string trackingType,
+        string userId,
+        int oldUid,
+        JsonElement submitted)
+    {
+        if (oldUid <= 0 || submitted.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        JsonElement rows;
+        try
+        {
+            rows = await proxy.GetByUserAsync(trackingType, userId);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // Cannot see the siblings, so cannot rule a collision in or out. Let the edit through rather
+            // than refuse a legitimate one on a transport error; the pre-existing behaviour applies.
+            return;
+        }
+
+        if (rows.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (var row in rows.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object
+                || !row.TryGetProperty("uid", out var uid)
+                || uid.ValueKind != JsonValueKind.Number
+                || uid.GetInt32() == oldUid)
+            {
+                continue;
+            }
+
+            if (WouldMergeInto(submitted, row, trackingType))
+            {
+                throw new TrackingConflictException(
+                    trackingType,
+                    "Another alarm of this type already uses those settings. Edit or remove that one instead.");
+            }
+        }
+    }
+
+    /// <summary>Fields whose value never distinguishes two alarms.</summary>
+    private static readonly HashSet<string> NotPartOfIdentity = new(StringComparer.Ordinal)
+    {
+        // Assigned by PoracleNG, or rendered by it from the rest.
+        "uid", "id", "profile_no", "description",
+        // Never persisted (see #494).
+        "ping",
+        // diff:"update" upstream -- differing here is what makes PoracleNG merge rather than insert.
+        "distance", "template", "clean",
+    };
+
+    /// <summary>Gyms additionally treat these two as updatable.</summary>
+    private static readonly HashSet<string> GymUpdatableFields = new(StringComparer.Ordinal)
+    {
+        "slot_changes", "battle_changes",
+    };
+
+    private static bool WouldMergeInto(JsonElement submitted, JsonElement existing, string trackingType)
+    {
+        var isGym = string.Equals(trackingType, "gym", StringComparison.Ordinal);
+
+        foreach (var field in submitted.EnumerateObject())
+        {
+            if (NotPartOfIdentity.Contains(field.Name)
+                || (isGym && GymUpdatableFields.Contains(field.Name)))
+            {
+                continue;
+            }
+
+            // A field the stored row does not carry cannot tell the two apart.
+            if (!existing.TryGetProperty(field.Name, out var storedValue))
+            {
+                continue;
+            }
+
+            // Compare what PoracleNG will STORE, not what was sent: it rewrites some values on the way
+            // in, and it diffs the rewritten row. Comparing the raw submission made every collision
+            // look like a difference, which is exactly how the destructive merge got through.
+            if (!SameValue(NormalizeForStorage(field, submitted, trackingType), storedValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    /// <summary>
     /// True when the row being edited already holds every value the update submitted, so PoracleNG's
     /// "already present" was the row colliding with itself rather than with a different alarm.
     /// </summary>
@@ -198,9 +311,40 @@ internal static partial class TrackingUpdateReconciler
     /// back as the string <c>["name"]</c> -- which is why the models carry StringOrArrayConverter. A byte
     /// comparison would call that unchanged list a change.
     /// </remarks>
+    /// <summary>
+    /// Applies the rewrites PoracleNG performs before it stores a submitted field.
+    /// </summary>
+    /// <remarks>
+    /// Raids and max battles force <c>level</c> to 9000 unless the alarm tracks any boss
+    /// (trackingRaid.go:217-219, trackingMaxbattle.go:137-139). Nothing else in the identity set is
+    /// rewritten -- the updatable fields are excluded from the comparison already.
+    /// </remarks>
+    private static JsonElement NormalizeForStorage(JsonProperty field, JsonElement submitted, string trackingType)
+    {
+        var levelIsForced = string.Equals(field.Name, "level", StringComparison.Ordinal)
+            && (string.Equals(trackingType, "raid", StringComparison.Ordinal)
+                || string.Equals(trackingType, "maxbattle", StringComparison.Ordinal))
+            && submitted.TryGetProperty("pokemon_id", out var pokemonId)
+            && pokemonId.ValueKind == JsonValueKind.Number
+            && pokemonId.GetInt32() != AnyPokemonId;
+
+        return levelIsForced ? AnyLevelElement : field.Value;
+    }
+
+    private const int AnyPokemonId = 9000;
+
+    private static readonly JsonElement AnyLevelElement =
+        JsonDocument.Parse("9000").RootElement.Clone();
+
     private static bool SameValue(JsonElement submitted, JsonElement stored)
     {
         if (JsonElement.DeepEquals(submitted, stored))
+        {
+            return true;
+        }
+
+        // null and "" are the same absence: the models use null for "any gym", PoracleNG stores "".
+        if (IsBlank(submitted) && IsBlank(stored))
         {
             return true;
         }
@@ -212,6 +356,10 @@ internal static partial class TrackingUpdateReconciler
 
         return false;
     }
+
+    private static bool IsBlank(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Null
+        || (value.ValueKind == JsonValueKind.String && string.IsNullOrEmpty(value.GetString()));
 
     private static bool TryParse(string? text, out JsonElement parsed)
     {

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -161,6 +161,75 @@ public class CreateResultSemanticsTests
         await Assert.ThrowsAsync<TrackingConflictException>(
             () => sut.UpdateAsync("u1", new Gym { Id = "u1", Uid = 134, Team = 4, Distance = 500 }));
     }
+    // ── #531: an edit must never be satisfied by merging into a DIFFERENT alarm ────
+
+    /// <summary>
+    /// PoracleNG updates an existing row in place when the submission differs from it only in fields it
+    /// tags updatable -- distance, template, clean, and slot/battle changes on gyms. If that row is not the
+    /// one being edited, the edit overwrites somebody else's alarm and the reconciler then deletes the
+    /// original as superseded: two alarms become one, reported as a clean 200.
+    /// </summary>
+    [Fact]
+    public async Task AnEditThatWouldMergeIntoAnotherAlarmIsRefusedBeforeAnythingIsWritten()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 189, id = "u1", team = 4, gym_id = "", distance = 1500 },
+            new { uid = 190, id = "u1", team = 2, gym_id = "", distance = 8001 }));
+
+        // Moving 189 onto team 2 leaves only distance differing from 190, so PoracleNG would merge them.
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Gym { Id = "u1", Uid = 189, Team = 2, Distance = 1500 }));
+
+        this._proxy.Verify(
+            p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()), Times.Never);
+        this._proxy.Verify(
+            p => p.DeleteByUidAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    /// <summary>
+    /// slot_changes and battle_changes are updatable for gyms, so two alarms differing only there would
+    /// merge as well -- the case the sweep reproduced from the gym edit dialog.
+    /// </summary>
+    [Fact]
+    public async Task AGymEditDifferingOnlyInItsToggleFieldsIsAlsoRefused()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 189, id = "u1", team = 4, slot_changes = 1, battle_changes = 0, distance = 1500 },
+            new { uid = 190, id = "u1", team = 4, slot_changes = 0, battle_changes = 1, distance = 8001 }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateAsync("u1", new Gym
+            {
+                Id = "u1",
+                Uid = 189,
+                Team = 4,
+                SlotChanges = 0,
+                BattleChanges = 1,
+                Distance = 1500,
+            }));
+    }
+
+    /// <summary>An edit that collides with nothing must still go through untouched.</summary>
+    [Fact]
+    public async Task AnEditThatCollidesWithNothingIsUnaffected()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 189, id = "u1", team = 4, distance = 1500 },
+            new { uid = 190, id = "u1", team = 2, distance = 8001 }));
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([191], 0, 1, 0));
+
+        var result = await sut.UpdateAsync("u1", new Gym { Id = "u1", Uid = 189, Team = 3, Distance = 1500 });
+
+        Assert.Equal(191, result.Uid);
+    }
+
     // ── #462: a colliding natural-key edit must not destroy either alarm ─────
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickDefaultsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickDefaultsTests.cs
@@ -36,7 +36,17 @@ public class QuickPickDefaultsTests
             new Mock<IGymService>().Object,
             new Mock<IMaxBattleService>().Object,
             new Mock<IMasterDataService>().Object,
+            FeatureGateAlwaysOn(),
             new Mock<ILogger<QuickPickService>>().Object);
+
+    /// <summary>A gate with every feature on, so these tests exercise the pick logic itself.</summary>
+    private static IFeatureGate FeatureGateAlwaysOn()
+    {
+        var gate = new Mock<IFeatureGate>();
+        gate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+        gate.Setup(g => g.IsEnabledAsync(It.IsAny<string>())).ReturnsAsync(true);
+        return gate.Object;
+    }
 
     [Fact]
     public async Task DefaultInvasionPicksUseValidGruntTypes()

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
@@ -21,10 +21,15 @@ public class QuickPickServiceSecurityTests
     private readonly Mock<IGymService> _gymService = new();
     private readonly Mock<IMaxBattleService> _maxBattleService = new();
     private readonly Mock<IMasterDataService> _masterDataService = new();
+    private readonly Mock<IFeatureGate> _featureGate = new();
     private readonly Mock<ILogger<QuickPickService>> _logger = new();
     private readonly QuickPickService _sut;
 
-    public QuickPickServiceSecurityTests() => this._sut = new QuickPickService(
+    public QuickPickServiceSecurityTests()
+    {
+        this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+        this._featureGate.Setup(g => g.IsEnabledAsync(It.IsAny<string>())).ReturnsAsync(true);
+        this._sut = new QuickPickService(
             this._definitionRepository.Object,
             this._appliedStateRepository.Object,
             this._monsterService.Object,
@@ -37,7 +42,9 @@ public class QuickPickServiceSecurityTests
             this._gymService.Object,
             this._maxBattleService.Object,
             this._masterDataService.Object,
+            this._featureGate.Object,
             this._logger.Object);
+    }
 
     // --- Ownership on the write path ---
     // CreateOrUpdateAsync upserts on Id alone and the Id comes from the request body, so without an


### PR DESCRIPTION
Closes #531, #532. Both are data loss, and both were found by the third regression sweep rather than by any of the per-fix verification I did earlier today.

### #531 — editing one alarm could delete another
PoracleNG diffs a submitted row against the existing ones (`diffTracking`, `tracking.go:278`). When the only differences are in fields tagged `diff:"update"`, it updates **that** row in place and re-keys it: `{insert:0, updates:1, newUids:[new]}`. When the row it picked was not the one being edited, the edit overwrote a different alarm — and the reconciler then deleted the original as "superseded". Two alarms became one, the victim's radius replaced by the editor's, reported as a clean 200 with "updated".

The conflict guard from #463/#524 only catches `updates:0`, so this fell straight through. Reachable from the shipped dialogs: two raids differing by team, two eggs by level, two gyms by their slot/battle toggles, two fort-changes by change types. Lures and invasions were safe because they carry their own pre-flight checks from #462 — this extends the same protection to the reconciled types.

The updatable set is uniform upstream (`template`, `distance`, `clean`, plus `slot_changes`/`battle_changes` on gyms), so the collision test is the same for every type: equal on everything else means PoracleNG will merge them.

**The first version of this fix passed its unit tests and did nothing live.** It compared the raw submission, but PoracleNG normalizes before it diffs — raids and max battles force `level` to 9000 unless the alarm tracks any boss — so every collision looked like a difference. Exactly the mistake made with the max-battle level in #521, made again a week's worth of work later. The comparison now normalizes first.

### #532 — a refused re-apply destroyed the alarms
`ReapplyAsync` was `RemoveAsync` then `ApplyAsync`. The guards I added in #507 and #508 turned that ordering into a data-loss path: a pick that had been disabled, or edited into an impossible filter, lost its alarms and reported only that it had been refused — and the pick then dropped off the list, taking the Remove button with it. Everything that can refuse an apply is now checked first, by building the alarms and validating them without writing anything.

### Verified against a live API
```
#531  two raids (team 1 / team 2)  -> edit onto team 2   -> 409, BOTH rows intact
      edit onto team 3 (unused)                          -> 200, applied
      gyms  (slot/battle toggles)  -> 409, both intact
      eggs  (level 4 / level 5)    -> 409, both intact
      forts ([name] / [removal])   -> 409, both intact

#532  applied pick, then made impossible -> re-apply 400, alarms intact, pick still listed
      applied pick, then disabled        -> re-apply 400, alarms intact
      remove afterwards                  -> 204
```

Suite green: 1789.

The remaining 16 findings from the sweep (2 more regressions, 12 new majors, 2 minors) are not in this PR — these two were shipped first because they destroy user data.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX