### PR TITLE
fix: import bypassed every model rule, areas leaked private names, a deleted account stayed signed in

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AreaController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AreaController.cs
@@ -53,7 +53,13 @@ public partial class AreaController(
             var areasJson = await this._poracleApiProxy.GetAreasWithGroupsAsync(this.UserId);
             if (areasJson != null)
             {
-                return this.Content(areasJson, "application/json");
+                // PoracleNG returns its whole fence set regardless of userSelectable, and PoracleWeb feeds
+                // every user-drawn geofence into that set (userSelectable:false, to keep them off the bot's
+                // area picker). Streaming the response through therefore handed any signed-in user the names
+                // of every private geofence anyone had drawn -- "home", "work area", and worse. The Areas
+                // page filtered them out client-side, so nothing looked wrong. Filter server-side, where it
+                // counts, and keep the user's OWN fences: those are theirs to see. See #544.
+                return this.Content(await this.RemoveOtherUsersPrivateAreasAsync(areasJson), "application/json");
             }
         }
         catch (Exception ex)
@@ -64,6 +70,54 @@ public partial class AreaController(
         return this.Ok(Array.Empty<object>());
     }
 
+
+    /// <summary>
+    /// Drops areas marked <c>userSelectable:false</c> unless the caller owns them.
+    /// </summary>
+    /// <remarks>
+    /// A malformed payload is passed through untouched rather than emptied: the page is more useful with
+    /// an unfiltered list than with none, and the names are not a secret worth failing closed over -- but
+    /// anything we can parse, we filter. See #544.
+    /// </remarks>
+    private async Task<string> RemoveOtherUsersPrivateAreasAsync(string areasJson)
+    {
+        JsonElement parsed;
+        try
+        {
+            parsed = JsonDocument.Parse(areasJson).RootElement;
+        }
+        catch (JsonException)
+        {
+            return areasJson;
+        }
+
+        if (parsed.ValueKind != JsonValueKind.Array)
+        {
+            return areasJson;
+        }
+
+        var ownNames = (await this._userGeofenceService.GetByUserAsync(this.UserId) ?? [])
+            .SelectMany(g => new[] { g.KojiName, g.PromotedName })
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var kept = parsed.EnumerateArray()
+            .Where(area => IsSelectable(area) || OwnedByCaller(area, ownNames))
+            .ToList();
+
+        return JsonSerializer.Serialize(kept);
+    }
+
+    private static bool IsSelectable(JsonElement area) =>
+        area.ValueKind != JsonValueKind.Object
+        || !area.TryGetProperty("userSelectable", out var selectable)
+        || selectable.ValueKind != JsonValueKind.False;
+
+    private static bool OwnedByCaller(JsonElement area, HashSet<string> ownNames) =>
+        area.ValueKind == JsonValueKind.Object
+        && area.TryGetProperty("name", out var name)
+        && name.ValueKind == JsonValueKind.String
+        && ownNames.Contains(name.GetString() ?? string.Empty);
     [HttpPut]
     [RequireFeatureEnabled(DisableFeatureKeys.Areas)]
     public async Task<IActionResult> UpdateAreas([FromBody] UpdateAreasRequest request)

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -745,9 +745,20 @@ public partial class AuthController(
     {
         // Read enabled status from DB (not JWT) so it reflects real-time changes
         var human = await this._humanService.GetByIdAsync(this.UserId);
-        var adminDisable = human != null && human.AdminDisable == 1;
-        var enabled = human == null || (human.Enabled == 1 && human.AdminDisable == 0);
-        var dbProfileNo = human?.CurrentProfileNo ?? this.ProfileNo;
+
+        // A missing row used to read as healthy, so a deleted account kept answering 200 with
+        // enabled:true while every other endpoint threw. The SPA only signs out on 401, so the user sat
+        // in a fully rendered app where nothing worked, for up to the token lifetime, with no way out but
+        // clearing storage by hand. The account is gone; say so, and let the interceptor sign them out.
+        // See #545.
+        if (human is null)
+        {
+            return this.Unauthorized(new { error = "This account no longer exists." });
+        }
+
+        var adminDisable = human.AdminDisable == 1;
+        var enabled = human.Enabled == 1 && human.AdminDisable == 0;
+        var dbProfileNo = human.CurrentProfileNo;
 
         var userInfo = new UserInfo
         {
@@ -767,7 +778,7 @@ public partial class AuthController(
         // out-of-band via the active_hours scheduler or bot !profile commands.
         // When mismatched, issue a refreshed JWT so subsequent API calls use the
         // correct profile and alarms don't land on the wrong profile.
-        if (human != null && dbProfileNo != this.ProfileNo)
+        if (dbProfileNo != this.ProfileNo)
         {
             LogProfileResync(this._logger, this.UserId, this.ProfileNo, dbProfileNo);
             // GenerateToken builds from UserInfo, which has no impersonatedBy field, so an admin

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
@@ -179,6 +179,14 @@ public partial class ProfileOverviewController(
             await this._humanProxy.DeleteProfileAsync(this.UserId, newProfileNo);
             throw;
         }
+        catch (AlarmValidationException)
+        {
+            // Roll back the shell profile, then let it reach the global filter: the message names the
+            // alarm and the field, which is a great deal more use than "check that the file is valid".
+            // See #548.
+            await this._humanProxy.DeleteProfileAsync(this.UserId, newProfileNo);
+            throw;
+        }
         catch (Exception ex)
         {
             await this._humanProxy.DeleteProfileAsync(this.UserId, newProfileNo);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Importing a profile accepted values every other path refuses** ([#548](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/548)). A hand-edited backup could store a negative radius, an IV window of -999 to 500, or a cleaning value outside its range, and the alarm then matched nothing. Imports are now checked the same way the add form is, and a file that fails is refused whole rather than half-applied.
+- **The area list showed other people's private geofence names** ([#544](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/544)). Any signed-in user could read the names everyone else had given their own geofences — "home", "work area" and so on. The page hid them, but the data was being sent. Your own geofences are still listed.
+- **A deleted account stayed signed in to an app where nothing worked** ([#545](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/545)). The session kept reporting itself healthy while every page failed with a generic error, for up to a day, with no way out but clearing browser storage. It now signs out.
+### Fixed
 - **Editing an alarm could silently delete a different one** ([#531](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/531)). Changing a raid's team, an egg's level, a gym's slot or battle toggles, or a fort-change's change types onto settings another alarm already had merged the two: one alarm vanished, the survivor took the edited alarm's radius, and the app reported a successful update. The clash is now refused and both alarms are left alone.
 - **Re-applying a quick pick could destroy its alarms** ([#532](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/532)). Re-apply deleted the existing alarms first and only then checked whether the pick could be applied, so a pick that had been disabled or edited into an impossible filter lost its alarms and reported only that it had been refused. Everything that can refuse a re-apply is now checked before anything is deleted.
 ### Fixed

--- a/Core/Pgan.PoracleWebNet.Core.Services/ProfileOverviewService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/ProfileOverviewService.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
@@ -84,6 +86,12 @@ public class ProfileOverviewService(
         var humanJson = await this._humanProxy.GetHumanAsync(userId);
         var originalProfileNo = humanJson?.GetIntProp("current_profile_no") ?? 1;
 
+        // Checked before anything is written, and before the profile switch: this is the one write path
+        // that never ran the alarm models' own rules, so a hand-edited backup could persist a distance of
+        // -77, an IV window of -999 to 500 or a clean value of 99 -- every one of which the matching POST
+        // refuses with a 400. A partial import is worse than a refused one. See #548.
+        EnsureAlarmsAreValid(alarms);
+
         await this._humanProxy.SwitchProfileAsync(userId, targetProfileNo);
 
         var totalCreated = 0;
@@ -125,6 +133,100 @@ public class ProfileOverviewService(
         return totalCreated;
     }
 
+
+    /// <summary>
+    /// Runs each imported alarm through the same model rules a direct POST would.
+    /// </summary>
+    /// <remarks>
+    /// Deserializing into the *Create model applies its [Range] and [StringLength] attributes; the monster
+    /// pair check catches windows nothing can satisfy. A file that fails is refused whole, so the caller
+    /// never ends up with half a profile. See #548.
+    /// </remarks>
+    private static void EnsureAlarmsAreValid(JsonElement alarms)
+    {
+        if (alarms.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        foreach (var type in AlarmTypes)
+        {
+            if (!alarms.TryGetProperty(type, out var alarmsArray)
+                || alarmsArray.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            var index = 0;
+            foreach (var alarm in alarmsArray.EnumerateArray())
+            {
+                index++;
+                ValidateAlarm(type, alarm, index);
+            }
+        }
+    }
+
+    private static void ValidateAlarm(string type, JsonElement alarm, int index)
+    {
+        object? model;
+        try
+        {
+            model = type switch
+            {
+                "pokemon" => Deserialize<MonsterCreate>(alarm),
+                "raid" => Deserialize<RaidCreate>(alarm),
+                "egg" => Deserialize<EggCreate>(alarm),
+                "quest" => Deserialize<QuestCreate>(alarm),
+                "invasion" => Deserialize<InvasionCreate>(alarm),
+                "lure" => Deserialize<LureCreate>(alarm),
+                "nest" => Deserialize<NestCreate>(alarm),
+                "gym" => Deserialize<GymCreate>(alarm),
+                "fort" => Deserialize<FortChangeCreate>(alarm),
+                "maxbattle" => Deserialize<MaxBattleCreate>(alarm),
+                _ => null,
+            };
+        }
+        catch (JsonException ex)
+        {
+            throw new AlarmValidationException(
+                $"{type} alarm {index} in this file could not be read: {ex.Message}");
+        }
+
+        if (model is null)
+        {
+            return;
+        }
+
+        var results = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true))
+        {
+            throw new AlarmValidationException(
+                $"{type} alarm {index} in this file is not valid: {results[0].ErrorMessage}");
+        }
+
+        // The [Range] and [StringLength] attributes live on the *Create DTOs -- the domain models carry
+        // none, so validating those found nothing and the import sailed through. The cross-field check
+        // wants the domain model, so the same JSON is read a second time; Core.Services does not
+        // reference Core.Mappings and one import is not worth a new project dependency. See #548.
+        if (model is MonsterCreate)
+        {
+            var monster = Deserialize<Monster>(alarm) ?? new Monster();
+            var inverted = MonsterRangeValidator.Validate(monster);
+            if (inverted is not null)
+            {
+                throw new AlarmValidationException($"{type} alarm {index} in this file is impossible: {inverted}");
+            }
+        }
+    }
+
+    private static T? Deserialize<T>(JsonElement alarm) =>
+        JsonSerializer.Deserialize<T>(alarm.GetRawText(), SnakeCaseOptions);
+
+    private static readonly JsonSerializerOptions SnakeCaseOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
     public async Task<JsonElement> GetAllProfilesOverviewAsync(string userId) => await this._trackingProxy.GetAllTrackingAllProfilesAsync(userId);
 
     /// <summary>

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AreaControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AreaControllerTests.cs
@@ -1,3 +1,4 @@
+using Pgan.PoracleWebNet.Core.Models;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -87,6 +88,40 @@ public class AreaControllerTests : ControllerTestBase
         this._proxy.Setup(p => p.GetAreasWithGroupsAsync("123456789")).ReturnsAsync(/*lang=json,strict*/ "[{\"name\":\"area1\"}]");
         var result = await this._sut.GetAvailableAreas();
         Assert.IsType<ContentResult>(result);
+    }
+
+    /// <summary>
+    /// PoracleNG returns its whole fence set regardless of userSelectable, and PoracleWeb feeds every
+    /// user-drawn geofence into it, so streaming the response through handed any signed-in user the names
+    /// of every private geofence anyone had drawn. See #544.
+    /// </summary>
+    [Fact]
+    public async Task GetAvailableAreasHidesOtherUsersPrivateGeofences()
+    {
+        this._proxy.Setup(p => p.GetAreasWithGroupsAsync("123456789")).ReturnsAsync(
+            /*lang=json,strict*/
+            "[{\"name\":\"downtown\",\"userSelectable\":true},{\"name\":\"someone elses home\",\"userSelectable\":false}]");
+
+        var result = Assert.IsType<ContentResult>(await this._sut.GetAvailableAreas());
+
+        Assert.Contains("downtown", result.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("someone elses home", result.Content, StringComparison.Ordinal);
+    }
+
+    /// <summary>The caller's own fences are theirs to see, even though they are not selectable.</summary>
+    [Fact]
+    public async Task GetAvailableAreasKeepsTheCallersOwnGeofences()
+    {
+        this._proxy.Setup(p => p.GetAreasWithGroupsAsync("123456789")).ReturnsAsync(
+            /*lang=json,strict*/
+            "[{\"name\":\"my garden\",\"userSelectable\":false},{\"name\":\"someone elses home\",\"userSelectable\":false}]");
+        this._userGeofenceService.Setup(s => s.GetByUserAsync("123456789"))
+            .ReturnsAsync([new UserGeofence { Id = 1, HumanId = "123456789", KojiName = "my garden" }]);
+
+        var result = Assert.IsType<ContentResult>(await this._sut.GetAvailableAreas());
+
+        Assert.Contains("my garden", result.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("someone elses home", result.Content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
@@ -129,8 +129,13 @@ public class AuthControllerMeTests : ControllerTestBase
         Assert.NotNull(userInfo.Token);
     }
 
+    /// <summary>
+    /// A missing row used to read as healthy, so a deleted account kept answering 200 with enabled:true
+    /// while every other endpoint threw -- and the SPA, which only signs out on 401, left the user in a
+    /// fully rendered app where nothing worked. See #545.
+    /// </summary>
     [Fact]
-    public async Task MeFallsBackToJwtProfileNoWhenHumanNotFound()
+    public async Task MeSignsOutAnAccountThatNoLongerExists()
     {
         SetupUser(this._sut, profileNo: 2);
         this._humanService.Setup(s => s.GetByIdAsync("123456789"))
@@ -138,10 +143,7 @@ public class AuthControllerMeTests : ControllerTestBase
 
         var result = await this._sut.Me();
 
-        var ok = Assert.IsType<OkObjectResult>(result);
-        var userInfo = Assert.IsType<UserInfo>(ok.Value);
-        Assert.Equal(2, userInfo.ProfileNo);
-        Assert.Null(userInfo.Token);
+        Assert.IsType<UnauthorizedObjectResult>(result);
         this._jwtService.Verify(
             j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>()), Times.Never);
     }


### PR DESCRIPTION
Closes #544, #545, #548.

### #548 — the import was the one write path with no rules
`ImportAlarmsAsync` handed each element of the uploaded file straight to PoracleNG, stripping only `uid`/`id`/`profile_no`. None of the `[Range]` or `[StringLength]` attributes ran, so a hand-edited backup could persist `distance: -77`, an IV window of -999 to 500, or `clean: 99` — each of which the matching POST refuses with a 400. The file is now validated **whole**, before the profile switch and before anything is written, so a bad file is refused rather than half-applied.

The attributes live on the `*Create` DTOs, not the domain models. My first version validated the domain models, passed its tests, and let the bad import straight through — caught only by re-running it live.

### #544 — private geofence names were readable by any signed-in user
PoracleNG returns its whole fence set regardless of `userSelectable`, and PoracleWeb feeds every user-drawn geofence into that set (with `userSelectable:false`, to keep them off the bot's picker). Streaming the response through therefore handed any authenticated user the names everyone else had given their own geofences. The Areas page filtered them client-side, so the leak was invisible in the UI. Filtered server-side now; the caller's own fences are kept.

### #545 — a deleted account kept a session that looked healthy
`Me()` treated a missing `humans` row as healthy, so the account answered 200 with `enabled:true` while every other endpoint threw a 500 — and the SPA only signs out on 401.

### Verified against a live API
```
#548  impossible values -> 400 "pokemon alarm 1 in this file is impossible: minIv (95) is greater than maxIv (5)…"
      valid import      -> 200, and no orphan profile left behind by either
#544  /api/areas/available -> 793 entries, the only non-selectable one left is the caller's own
#545  impersonate a throwaway account -> /api/auth/me 200
      delete it          -> /api/auth/me 401 {"error":"This account no longer exists."}
```

Suite green: 1791.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX