### PR TITLE
fix: quick picks lost track of their alarms, and accepted fields they cannot store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Applying a quick pick twice made it forget the alarms it had created** ([#542](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/542)). The second apply adds nothing, and the pick recorded that as owning nothing — so Remove reported success while deleting nothing and the alarms were left with no way to identify them.
+- **Changing an applied quick pick's alarm type orphaned its alarms** ([#541](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/541)). The pick went looking for its Pokemon alarms among the raids, concluded they had all been deleted, and dropped its record of them — alarms left behind with no Remove button and nothing saying where they came from.
+- **Quick picks accepted names and other fields longer than they can store** ([#549](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/549)), returning a server error instead of saying so. Neither dialog limits the length, so a preset named with a sentence was enough.
+### Fixed
 - **Importing a profile accepted values every other path refuses** ([#548](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/548)). A hand-edited backup could store a negative radius, an IV window of -999 to 500, or a cleaning value outside its range, and the alarm then matched nothing. Imports are now checked the same way the add form is, and a file that fails is refused whole rather than half-applied.
 - **The area list showed other people's private geofence names** ([#544](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/544)). Any signed-in user could read the names everyone else had given their own geofences — "home", "work area" and so on. The page hid them, but the data was being sent. Your own geofences are still listed.
 - **A deleted account stayed signed in to an app where nothing worked** ([#545](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/545)). The session kept reporting itself healthy while every page failed with a generic error, for up to a day, with no way out but clearing browser storage. It now signs out.

--- a/Core/Pgan.PoracleWebNet.Core.Models/QuickPickDefinition.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/QuickPickDefinition.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 namespace Pgan.PoracleWebNet.Core.Models;
 
 /// <summary>
@@ -5,11 +6,20 @@ namespace Pgan.PoracleWebNet.Core.Models;
 /// </summary>
 public class QuickPickDefinition
 {
+    // Every one of these is bounded in the database (QuickPickDefinitionConfiguration) and was bounded
+    // nowhere else, so an over-long value reached MySQL and came back as an opaque 500. Neither quick-
+    // pick dialog sets a maxlength, so naming a preset with a sentence was enough. See #549.
+    [StringLength(50, ErrorMessage = "id must be 50 characters or fewer.")]
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    [Required(AllowEmptyStrings = false, ErrorMessage = "A name is required.")]
+    [StringLength(200, ErrorMessage = "name must be 200 characters or fewer.")]
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    [StringLength(50, ErrorMessage = "icon must be 50 characters or fewer.")]
     public string Icon { get; set; } = "bolt";
+    [StringLength(50, ErrorMessage = "category must be 50 characters or fewer.")]
     public string Category { get; set; } = "Common";
+    [StringLength(20, ErrorMessage = "alarmType must be 20 characters or fewer.")]
     public string AlarmType { get; set; } = "monster"; // monster, raid, egg, quest, invasion, lure, nest, gym, maxbattle
     public int SortOrder
     {

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -85,7 +85,17 @@ public partial class QuickPickService(
             // Verify tracked alarms still exist — if all deleted manually, clear applied state
             if (appliedState?.TrackedUids is { Count: > 0 })
             {
-                var remaining = await this.CountRemainingUidsAsync(userId, definition.AlarmType, appliedState.TrackedUids);
+                // Against the type the alarms were CREATED as, not the definition's current one. Editing
+                // an applied pick's alarm type -- a plain dropdown in the edit dialog -- made this look
+                // the monster uids up among the raids, find none, conclude the user had deleted them all
+                // and drop the applied state. The alarms stayed behind with nothing owning them and no
+                // Remove button, because the card then read as never applied. RemoveAsync already keys
+                // off the stored type for exactly this reason. See #541.
+                var trackedType = string.IsNullOrEmpty(appliedState.AlarmType)
+                    ? definition.AlarmType
+                    : appliedState.AlarmType;
+
+                var remaining = await this.CountRemainingUidsAsync(userId, trackedType, appliedState.TrackedUids);
                 if (remaining == 0)
                 {
                     // All alarms were deleted manually — clean up stale applied state
@@ -95,7 +105,7 @@ public partial class QuickPickService(
                 else if (remaining < appliedState.TrackedUids.Count)
                 {
                     // Some alarms were deleted — update the tracked UIDs to only valid ones
-                    appliedState.TrackedUids = await this.GetValidUidsAsync(userId, definition.AlarmType, appliedState.TrackedUids);
+                    appliedState.TrackedUids = await this.GetValidUidsAsync(userId, trackedType, appliedState.TrackedUids);
                     await this._appliedStateRepository.CreateOrUpdateAsync(appliedState);
                 }
             }
@@ -298,6 +308,14 @@ public partial class QuickPickService(
 
         LogQuickPickTracking(this._logger, quickPickId, reportedUids.Count, trackedUids.Count);
 
+        // Applying an already-applied pick adds nothing, because PoracleNG dedups -- so the diff is
+        // empty and writing it verbatim handed the pick an empty tracked list while its alarms were
+        // still there. Remove then answered 204 and deleted nothing, and the alarms were left with no
+        // way to attribute them. Keep what the pick already owned and add whatever this run created.
+        // See #542.
+        var previouslyTracked = await this._appliedStateRepository.GetAsync(userId, profileNo, quickPickId);
+        var stillOwned = previouslyTracked?.TrackedUids?.Where(afterUids.Contains) ?? [];
+
         var appliedState = new QuickPickAppliedState
         {
             UserId = userId,
@@ -306,7 +324,7 @@ public partial class QuickPickService(
             AlarmType = definition.AlarmType,
             AppliedAt = DateTime.UtcNow,
             ExcludePokemonIds = request.ExcludePokemonIds,
-            TrackedUids = trackedUids
+            TrackedUids = [.. stillOwned.Union(trackedUids)],
         };
 
         await this._appliedStateRepository.CreateOrUpdateAsync(appliedState);


### PR DESCRIPTION
Closes #541, #542, #549.

### #542 — a second apply made the pick forget its alarms
`ApplyAsync` overwrote the applied state with this run's before/after diff. Applying an already-applied pick adds nothing (PoracleNG dedups), so the diff was empty and the pick recorded itself as owning nothing while its alarms were still there. `Remove` then answered 204, deleted nothing, and the alarms were left with no way to attribute or bulk-remove them. It now keeps whatever the pick already owned that still exists, and adds what this run created.

### #541 — changing the alarm type orphaned the alarms
`GetAllAsync` reconciled tracked uids against the definition's **current** alarm type. Editing an applied pick's type — a plain dropdown in the edit dialog — made it look the monster uids up among the raids, find none, conclude the user had deleted them all, and drop the applied state. The alarms stayed behind with no Remove button and nothing saying where they came from. It now uses the type stored on the applied state, which is what `RemoveAsync` has always keyed off.

### #549 — fields longer than their columns
`QuickPickDefinition` carried no annotations, so an over-long id, name, icon, category or alarm type reached MySQL and returned an opaque 500. Neither quick-pick dialog sets a `maxlength`.

### Verified against a live API
```
#542  apply -> [40712];  apply again -> [40712]  (was [])
      remove -> 204, alarm actually deleted
#541  apply as monster, switch the definition to raid
      applied state survives -> true;  remove -> 204, alarm deleted
#549  260-character name -> 400
```

Suite green: 1791.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX