### PR TITLE
fix: geofence rename, raid/egg selection, duplicate-producing edits, swallowed 400s, dead settings

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
@@ -30,6 +30,37 @@ public partial class UserGeofenceController(
         return this.Ok(geofences);
     }
 
+    /// <summary>Renames a geofence without disturbing which profiles are subscribed to it.</summary>
+    /// <remarks>
+    /// The page used to edit by deleting and recreating, which re-subscribed only the active profile and
+    /// silently switched the geofence off everywhere else. See #543.
+    /// </remarks>
+    [HttpPut("custom/{id:int}")]
+    [RequireFeatureEnabled(DisableFeatureKeys.UserGeofences)]
+    public async Task<IActionResult> RenameGeofence(int id, [FromBody] UserGeofenceRenameRequest request)
+    {
+        try
+        {
+            var updated = await this._userGeofenceService.RenameAsync(
+                this.UserId, id, request.DisplayName, request.GroupName, request.ParentId);
+            return this.Ok(updated);
+        }
+        catch (GeofenceNotFoundException)
+        {
+            return this.NotFound();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Not Forbid: a geofence the caller does not own should not be distinguishable from one that
+            // does not exist.
+            return this.NotFound();
+        }
+        catch (ArgumentException ex)
+        {
+            return this.BadRequest(new { error = ex.Message });
+        }
+    }
+
     [HttpPost("custom")]
     [RequireFeatureEnabled(DisableFeatureKeys.UserGeofences)]
     public async Task<IActionResult> CreateGeofence([FromBody] UserGeofenceCreate model)
@@ -264,3 +295,5 @@ public partial class UserGeofenceController(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to import GeoJSON for user {UserId}")]
     private static partial void LogImportGeoJsonFailed(ILogger logger, Exception ex, string userId);
 }
+
+public record UserGeofenceRenameRequest(string DisplayName, string? GroupName, int? ParentId);

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -223,7 +223,11 @@ builder.Services.AddRateLimiter(options =>
             {
                 PermitLimit = 30,
                 Window = TimeSpan.FromSeconds(60),
-                QueueLimit = 2,
+                // Zero, like every other policy here. A queue of 2 did not reject requests 31 and 32 --
+                // it parked them until the window rolled over, up to a minute later, so on a shared
+                // egress IP the 31st person to log in got a spinner instead of "too many requests",
+                // and an intermediate proxy could time the request out entirely. See #546.
+                QueueLimit = 0,
                 AutoReplenishment = true,
             }));
     options.AddPolicy("auth-read", httpContext =>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/user-geofence.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/user-geofence.service.ts
@@ -46,6 +46,14 @@ export class UserGeofenceService {
     return this.http.post<GeoJsonImportResult>(`${this.config.apiHost}/api/geofences/import/geojson`, formData);
   }
 
+  /**
+   * Renames a geofence in place. Editing used to be delete-then-recreate, and the recreate re-subscribed
+   * only the active profile — silently switching the geofence off for every other profile. See #543.
+   */
+  renameGeofence(id: number, data: { displayName: string; groupName?: string | null; parentId?: number | null }): Observable<UserGeofence> {
+    return this.http.put<UserGeofence>(`${this.config.apiHost}/api/geofences/custom/${id}`, data);
+  }
+
   submitForReview(kojiName: string): Observable<UserGeofence> {
     return this.http.post<UserGeofence>(`${this.config.apiHost}/api/geofences/custom/${encodeURIComponent(kojiName)}/submit`, {});
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -270,33 +270,13 @@ const SETTING_GROUPS: SettingGroup[] = [
     color: '#607d8b',
     icon: 'terminal',
     labelKey: 'ADMIN_SETTINGS.GROUP_COMMANDS',
-    settings: [
-      {
-        descriptionKey: 'ADMIN_SETTINGS.REGISTER_COMMAND_DESC',
-        key: 'register_command',
-        labelKey: 'ADMIN_SETTINGS.REGISTER_COMMAND_LABEL',
-        type: 'text',
-      },
-      {
-        descriptionKey: 'ADMIN_SETTINGS.LOCATION_COMMAND_DESC',
-        key: 'location_command',
-        labelKey: 'ADMIN_SETTINGS.LOCATION_COMMAND_LABEL',
-        type: 'text',
-      },
-    ],
+    settings: [],
   },
   {
     color: '#2e7d32',
     icon: 'map',
     labelKey: 'ADMIN_SETTINGS.GROUP_MAPS_ASSETS',
-    settings: [
-      {
-        descriptionKey: 'ADMIN_SETTINGS.PROVIDER_URL_DESC',
-        key: 'provider_url',
-        labelKey: 'ADMIN_SETTINGS.PROVIDER_URL_LABEL',
-        type: 'url',
-      },
-    ],
+    settings: [],
   },
   {
     color: '#7b1fa2',
@@ -309,29 +289,13 @@ const SETTING_GROUPS: SettingGroup[] = [
         labelKey: 'ADMIN_SETTINGS.SIGNUP_URL_LABEL',
         type: 'url',
       },
-      {
-        descriptionKey: 'ADMIN_SETTINGS.GANALYTICSID_DESC',
-        key: 'gAnalyticsId',
-        labelKey: 'ADMIN_SETTINGS.GANALYTICSID_LABEL',
-        type: 'text',
-      },
-      { descriptionKey: 'ADMIN_SETTINGS.PATREONURL_DESC', key: 'patreonUrl', labelKey: 'ADMIN_SETTINGS.PATREONURL_LABEL', type: 'url' },
-      { descriptionKey: 'ADMIN_SETTINGS.PAYPALURL_DESC', key: 'paypalUrl', labelKey: 'ADMIN_SETTINGS.PAYPALURL_LABEL', type: 'url' },
     ],
   },
   {
     color: '#ff5722',
     icon: 'bug_report',
     labelKey: 'ADMIN_SETTINGS.GROUP_DEBUG',
-    settings: [
-      {
-        descriptionKey: 'ADMIN_SETTINGS.SITE_IS_HTTPS_DESC',
-        key: 'site_is_https',
-        labelKey: 'ADMIN_SETTINGS.SITE_IS_HTTPS_LABEL',
-        type: 'boolean',
-      },
-      { descriptionKey: 'ADMIN_SETTINGS.DEBUG_DESC', key: 'debug', labelKey: 'ADMIN_SETTINGS.DEBUG_LABEL', type: 'boolean' },
-    ],
+    settings: [],
   },
 ];
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.ts
@@ -161,37 +161,26 @@ export class GeofenceListComponent implements OnInit {
     ref.afterClosed().subscribe((result: GeofenceNameDialogResult | null) => {
       if (!result) return;
 
-      // Edit = delete + recreate
+      // A rename, not a delete and a recreate: recreating re-subscribed only the active profile, so
+      // renaming from profile 0 quietly switched the geofence off everywhere else while the page still
+      // showed it on. See #543.
       this.savingGeofence.set(true);
       this.userGeofenceService
-        .deleteGeofence(geofence.id)
+        .renameGeofence(geofence.id, {
+          displayName: result.displayName,
+          groupName: result.groupName,
+          parentId: result.parentId,
+        })
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe({
           error: () => {
             this.savingGeofence.set(false);
             this.snackBar.open(this.i18n.instant('GEOFENCES.SNACK_FAILED_UPDATE'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
           },
-          next: () => {
-            this.userGeofenceService
-              .createGeofence({
-                displayName: result.displayName,
-                groupName: result.groupName,
-                parentId: result.parentId,
-                polygon: geofence.polygon ?? [],
-              })
-              .pipe(takeUntilDestroyed(this.destroyRef))
-              .subscribe({
-                error: () => {
-                  this.savingGeofence.set(false);
-                  this.snackBar.open(this.i18n.instant('GEOFENCES.SNACK_FAILED_UPDATE'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
-                },
-                next: created => {
-                  this.savingGeofence.set(false);
-                  this.customGeofences.update(list => [...list.filter(g => g.id !== geofence.id), created]);
-                  this.activeAreas.update(areas => [...areas.filter(a => a !== geofence.kojiName), created.kojiName]);
-                  this.snackBar.open(this.i18n.instant('GEOFENCES.SNACK_UPDATED'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
-                },
-              });
+          next: updated => {
+            this.savingGeofence.set(false);
+            this.customGeofences.update(list => list.map(g => (g.id === updated.id ? updated : g)));
+            this.snackBar.open(this.i18n.instant('GEOFENCES.SNACK_UPDATED'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
           },
         });
     });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
@@ -75,11 +75,11 @@
       </ng-template>
       <div class="alarm-grid">
         @for (raid of raids(); track raid.uid) {
-          <mat-card class="alarm-card" [class.card-selected]="selectMode() && selectedIds().has(raid.uid)">
+          <mat-card class="alarm-card" [class.card-selected]="selectMode() && selectedIds().has(selectionKey('raid', raid.uid))">
             @if (selectMode()) {
               <mat-checkbox
-                [checked]="selectedIds().has(raid.uid)"
-                (change)="toggleSelect(raid.uid)"
+                [checked]="selectedIds().has(selectionKey('raid', raid.uid))"
+                (change)="toggleSelect(selectionKey('raid', raid.uid))"
                 (click)="$event.stopPropagation()"
                 class="card-checkbox">
               </mat-checkbox>
@@ -177,11 +177,11 @@
       </ng-template>
       <div class="alarm-grid">
         @for (egg of eggs(); track egg.uid) {
-          <mat-card class="alarm-card" [class.card-selected]="selectMode() && selectedIds().has(egg.uid)">
+          <mat-card class="alarm-card" [class.card-selected]="selectMode() && selectedIds().has(selectionKey('egg', egg.uid))">
             @if (selectMode()) {
               <mat-checkbox
-                [checked]="selectedIds().has(egg.uid)"
-                (change)="toggleSelect(egg.uid)"
+                [checked]="selectedIds().has(selectionKey('egg', egg.uid))"
+                (change)="toggleSelect(selectionKey('egg', egg.uid))"
                 (click)="$event.stopPropagation()"
                 class="card-checkbox">
               </mat-checkbox>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
@@ -66,11 +66,15 @@ export class RaidListComponent implements OnInit {
   readonly gymNames = signal<Record<string, string>>({});
   readonly loading = signal(true);
   readonly raids = signal<Raid[]>([]);
-  readonly selectedIds = signal(new Set<number>());
+  // Keyed "raid:12" / "egg:12", not by the bare uid. Raid and egg uids come from separate
+  // auto-increment sequences and do collide; with one set of integers covering both grids, ticking
+  // one card ticked the other, and the bulk actions sent both to the raid endpoint -- deleting or
+  // resizing the raid twice and leaving the egg alone. See #540.
+  readonly selectedIds = signal(new Set<string>());
+
   readonly selectMode = signal(false);
   readonly skeletonCards = Array.from({ length: 6 });
   readonly testAlertService = inject(TestAlertService);
-
   async bulkDelete(): Promise<void> {
     const ref = this.dialog.open(ConfirmDialogComponent, {
       data: {
@@ -82,19 +86,17 @@ export class RaidListComponent implements OnInit {
     });
     const result = await firstValueFrom(ref.afterClosed());
     if (result) {
-      const ids = [...this.selectedIds()];
-      const raidUids = new Set(this.raids().map(r => r.uid));
-      for (const uid of ids) {
-        if (raidUids.has(uid)) {
-          await firstValueFrom(this.raidService.delete(uid));
-        } else {
-          await firstValueFrom(this.eggService.delete(uid));
-        }
+      const keys = [...this.selectedIds()];
+      for (const uid of this.uidsOfKind(keys, 'raid')) {
+        await firstValueFrom(this.raidService.delete(uid));
+      }
+      for (const uid of this.uidsOfKind(keys, 'egg')) {
+        await firstValueFrom(this.eggService.delete(uid));
       }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadData();
-      this.snackBar.open(this.i18n.instant('RAIDS.SNACK_BULK_DELETED', { count: ids.length }), this.i18n.instant('TOAST.OK'), {
+      this.snackBar.open(this.i18n.instant('RAIDS.SNACK_BULK_DELETED', { count: keys.length }), this.i18n.instant('TOAST.OK'), {
         duration: 3000,
       });
     }
@@ -104,16 +106,15 @@ export class RaidListComponent implements OnInit {
     const ref = this.dialog.open(DistanceDialogComponent, { width: '440px' });
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
-      const ids = [...this.selectedIds()];
-      const raidUids = this.raids().map(r => r.uid);
-      const selectedRaidUids = ids.filter(id => raidUids.includes(id));
-      const selectedEggUids = ids.filter(id => !raidUids.includes(id));
+      const keys = [...this.selectedIds()];
+      const selectedRaidUids = this.uidsOfKind(keys, 'raid');
+      const selectedEggUids = this.uidsOfKind(keys, 'egg');
       if (selectedRaidUids.length > 0) await firstValueFrom(this.raidService.updateBulkDistance(selectedRaidUids, distance));
       if (selectedEggUids.length > 0) await firstValueFrom(this.eggService.updateBulkDistance(selectedEggUids, distance));
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadData();
-      this.snackBar.open(this.i18n.instant('RAIDS.SNACK_BULK_DISTANCE', { count: ids.length }), this.i18n.instant('TOAST.OK'), {
+      this.snackBar.open(this.i18n.instant('RAIDS.SNACK_BULK_DISTANCE', { count: keys.length }), this.i18n.instant('TOAST.OK'), {
         duration: 3000,
       });
     }
@@ -360,22 +361,26 @@ export class RaidListComponent implements OnInit {
   }
 
   selectAll(): void {
-    const ids = new Set<number>();
-    this.raids().forEach(r => ids.add(r.uid));
-    this.eggs().forEach(e => ids.add(e.uid));
-    this.selectedIds.set(ids);
+    const keys = new Set<string>();
+    this.raids().forEach(r => keys.add(this.selectionKey('raid', r.uid)));
+    this.eggs().forEach(e => keys.add(this.selectionKey('egg', e.uid)));
+    this.selectedIds.set(keys);
+  }
+
+  selectionKey(kind: 'raid' | 'egg', uid: number): string {
+    return `${kind}:${uid}`;
   }
 
   sendTestAlert(type: string, alarm: { uid: number }): void {
     this.testAlertService.sendTestAlert(type, alarm.uid);
   }
 
-  toggleSelect(uid: number): void {
+  toggleSelect(key: string): void {
     const current = new Set(this.selectedIds());
-    if (current.has(uid)) {
-      current.delete(uid);
+    if (current.has(key)) {
+      current.delete(key);
     } else {
-      current.add(uid);
+      current.add(key);
     }
     this.selectedIds.set(current);
   }
@@ -415,5 +420,9 @@ export class RaidListComponent implements OnInit {
       }
       this.gymNames.set(names);
     });
+  }
+
+  private uidsOfKind(keys: string[], kind: 'raid' | 'egg'): number[] {
+    return keys.filter(k => k.startsWith(`${kind}:`)).map(k => Number(k.slice(kind.length + 1)));
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Renaming a custom geofence switched it off for your other profiles** ([#543](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/543)). Editing was implemented as delete-and-recreate, and the recreate only re-subscribed the profile you were on. The page still showed it as on, so nothing said those profiles had stopped receiving alerts. Renaming now keeps every subscription.
+- **Poracle's explanation of a rejected alarm was replaced with "an unexpected error"** ([#539](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/539)), so you were told the server had broken rather than what was wrong with the alarm.
+- **Selecting a raid could select an egg as well** ([#540](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/540)). The two lists shared one set of selections keyed by ID, and raid and egg IDs can be the same number — so a bulk delete or radius change hit the raid twice and left the egg untouched.
+- **Editing an alarm onto another one's exact settings could leave two identical alarms** ([#537](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/537), [#538](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/538)) that cannot be told apart on the page, for Pokemon and Max Battles. Adding that same alarm is refused, so editing was the only way to reach it.
+- **Too many logins from one network left the browser hanging** ([#546](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/546)) instead of saying so. On a shared connection the 31st person to sign in within a minute waited on a request that was parked rather than refused.
+
+### Removed
+- **Eight admin settings that saved but did nothing** ([#547](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/547)): the Patreon and PayPal links, the analytics ID, the map provider URL, the register and location commands, the HTTPS marker and the debug flag. Each described behaviour the app does not have — the HTTPS one in particular reads as a security control and changed nothing. They are legacy Poracle keys that were never wired to anything; existing values are left in the database, unread.
+### Fixed
 - **Applying a quick pick twice made it forget the alarms it had created** ([#542](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/542)). The second apply adds nothing, and the pick recorded that as owning nothing — so Remove reported success while deleting nothing and the alarms were left with no way to identify them.
 - **Changing an applied quick pick's alarm type orphaned its alarms** ([#541](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/541)). The pick went looking for its Pokemon alarms among the raids, concluded they had all been deleted, and dropped its record of them — alarms left behind with no Remove button and nothing saying where they came from.
 - **Quick picks accepted names and other fields longer than they can store** ([#549](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/549)), returning a server error instead of saying so. Neither dialog limits the length, so a preset named with a sentence was enough.

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IUserAreaDualWriter.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IUserAreaDualWriter.cs
@@ -55,6 +55,7 @@ public interface IUserAreaDualWriter
     /// <returns><c>true</c> if at least one row was actually modified.</returns>
     public Task<bool> RemoveAreaFromAllProfilesAsync(string humanId, string areaName);
 
+
     /// <summary>
     /// Replaces <paramref name="oldName"/> with <paramref name="newName"/> in <c>humans.area</c> and in
     /// every row of <c>profiles.area</c> for <paramref name="humanId"/>, committed in a single

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IUserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IUserGeofenceService.cs
@@ -6,6 +6,16 @@ public interface IUserGeofenceService
 {
     public Task<List<UserGeofence>> GetByUserAsync(string humanId);
     public Task<UserGeofence> CreateAsync(string humanId, int profileNo, UserGeofenceCreate model);
+    /// <summary>
+    /// Renames a geofence and moves its area subscriptions with it.
+    /// </summary>
+    /// <remarks>
+    /// The Geofences page used to implement editing as delete-then-recreate, and the recreate
+    /// re-subscribed only the ACTIVE profile — so renaming from profile 0 quietly switched the geofence
+    /// off everywhere else, while the page still showed it on. See #543.
+    /// </remarks>
+    public Task<UserGeofence> RenameAsync(string humanId, int id, string displayName, string? groupName, int? parentId);
+
     public Task DeleteAsync(string humanId, int profileNo, int id);
     public Task<UserGeofence> SubmitForReviewAsync(string humanId, string kojiName);
     public Task<List<UserGeofence>> GetAllAsync();

--- a/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MaxBattleService.cs
@@ -61,9 +61,20 @@ public partial class MaxBattleService(IPoracleTrackingProxy proxy, IFeatureGate 
         // MaxBattle is insert-only in PoracleNG (no dedup/upsert).
         // Delete the old alarm first, then create a replacement.
         var oldUid = model.Uid;
-        await this._proxy.DeleteByUidAsync(TrackingType, userId, oldUid);
-
         var body = SerializeToElement(model);
+
+        // Create refuses an exact duplicate (#521) and this path did not, so editing one max battle onto
+        // another's settings left two identical rows -- and it is checked BEFORE the delete, because the
+        // delete is what makes this path destructive. See #538.
+        var siblings = await this.GetByUserAsync(userId, model.ProfileNo);
+        if (siblings.Any(x => x.Uid != oldUid && IsSameAlarm(x, model)))
+        {
+            throw new TrackingConflictException(
+                TrackingType,
+                "You already have an identical max battle alarm.");
+        }
+
+        await this._proxy.DeleteByUidAsync(TrackingType, userId, oldUid);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 
         if (result.NewUids.Count > 0)

--- a/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
@@ -49,6 +49,14 @@ public class MonsterService(IPoracleTrackingProxy proxy, IFeatureGate featureGat
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Pokemon);
         // PoracleNG's POST endpoint handles updates when the body includes a uid field.
         var body = SerializeToElement(model);
+
+        // Pokemon is the one type with no collision guard: PoracleNG updates it in place rather than
+        // merging, so an edit onto another alarm's exact settings wrote a byte-identical twin -- two rows
+        // on the page that cannot be told apart and must each be deleted. Creating that state directly is
+        // refused, so the edit path was the only way to reach it. See #537.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, model.Uid, body);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         return model;
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleTrackingProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleTrackingProxy.cs
@@ -1,3 +1,4 @@
+using Pgan.PoracleWebNet.Core.Models;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -44,6 +45,16 @@ public partial class PoracleTrackingProxy(
         request.Content = new StringContent(bodyText, Encoding.UTF8, "application/json");
 
         var response = await this._httpClient.SendAsync(request);
+
+        // A 400 from PoracleNG is the caller's problem, not the server's. EnsureSuccessStatusCode threw
+        // an HttpRequestException that the global handler flattened into 500 "An unexpected error
+        // occurred", so the user was told the server broke instead of what was wrong with their input,
+        // and it was logged as a fault. Pass the explanation through as a 400. See #539.
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            throw new AlarmValidationException(await ExtractMessageAsync(response));
+        }
+
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
@@ -126,6 +137,34 @@ public partial class PoracleTrackingProxy(
         var request = this.CreateRequest(HttpMethod.Get, $"{this._apiAddress}/api/reload");
         var response = await this._httpClient.SendAsync(request);
         response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>Reads whatever explanation PoracleNG returned, falling back to something honest.</summary>
+    private static async Task<string> ExtractMessageAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        try
+        {
+            var root = JsonDocument.Parse(body).RootElement;
+            foreach (var name in new[] { "message", "error", "status" })
+            {
+                if (root.TryGetProperty(name, out var value)
+                    && value.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(value.GetString()))
+                {
+                    return value.GetString()!;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON; the raw body is still better than nothing, as long as it is short.
+        }
+
+        return string.IsNullOrWhiteSpace(body) || body.Length > 300
+            ? "Poracle rejected the alarm."
+            : body;
     }
 
     private HttpRequestMessage CreateRequest(HttpMethod method, string url)

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -204,6 +204,55 @@ public partial class UserGeofenceService(
         return names;
     }
 
+    public async Task<UserGeofence> RenameAsync(
+        string humanId, int id, string displayName, string? groupName, int? parentId)
+    {
+        await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.UserGeofences);
+
+        var geofence = await this._repository.GetByIdAsync(id)
+            ?? throw new GeofenceNotFoundException(id);
+
+        if (!string.Equals(geofence.HumanId, humanId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UnauthorizedAccessException("Geofence does not belong to this user.");
+        }
+
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            throw new ArgumentException("A name is required.", nameof(displayName));
+        }
+
+        var oldKojiName = geofence.KojiName;
+        var newKojiName = displayName.Trim().ToLowerInvariant();
+
+        if (!string.Equals(oldKojiName, newKojiName, StringComparison.OrdinalIgnoreCase))
+        {
+            var takenNames = await this.ReservedGeofenceNamesAsync();
+            if (takenNames.Contains(newKojiName))
+            {
+                throw new TrackingConflictException(
+                    "geofence",
+                    "Another area already uses that name. Choose a different one.");
+            }
+        }
+
+        geofence.DisplayName = displayName.Trim();
+        geofence.KojiName = newKojiName;
+        // group_name is NOT NULL, and the rename dialog does not always send one -- keep what is there rather than clearing it.
+        geofence.GroupName = string.IsNullOrWhiteSpace(groupName) ? geofence.GroupName : groupName;
+        geofence.ParentId = parentId ?? geofence.ParentId;
+        var updated = await this._repository.UpdateAsync(geofence);
+
+        // Every profile that was subscribed stays subscribed, under the new name. This is the whole
+        // point of renaming in place rather than delete-then-recreate. See #543.
+        // HACK: trusted-set-areas (see docs/poracleng-enhancement-requests.md)
+        await this._areaWriter.RenameAreaInAllProfilesAsync(humanId, oldKojiName, newKojiName);
+
+        await this.ReloadGeofencesSafeAsync();
+
+        updated.Polygon = geofence.Polygon;
+        return updated;
+    }
     public async Task DeleteAsync(string humanId, int profileNo, int id)
     {
         var geofence = await this._repository.GetByIdAsync(id)

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
@@ -135,6 +135,7 @@ public class MaxBattleServiceTests
     [Fact]
     public async Task UpdateAsyncUsesDeleteThenCreate()
     {
+        this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "user1")).ReturnsAsync(CreateJsonArray());
         var maxBattle = new MaxBattle { Uid = 1, PokemonId = 9000, Gmax = 1 };
         var callOrder = new List<string>();
 
@@ -376,6 +377,7 @@ public class MaxBattleServiceTests
     [Fact]
     public async Task UpdateAsyncRepointsQuickPickTrackedUidAtTheReplacementRow()
     {
+        this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "user1")).ReturnsAsync(CreateJsonArray());
         this._proxy.Setup(p => p.DeleteByUidAsync("maxbattle", "user1", 82)).Returns(Task.CompletedTask);
         this._proxy.Setup(p => p.CreateAsync("maxbattle", "user1", It.IsAny<JsonElement>()))
             .ReturnsAsync(new TrackingCreateResult([83], 0, 0, 1));

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyTests.cs
@@ -1,3 +1,4 @@
+using Pgan.PoracleWebNet.Core.Models;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -187,11 +188,31 @@ public class PoracleTrackingProxyTests
     [Fact]
     public async Task CreateAsyncThrowsOnNon2xx()
     {
-        var handler = new MockHttpMessageHandler(HttpStatusCode.BadRequest, "{}");
+        var handler = new MockHttpMessageHandler(HttpStatusCode.InternalServerError, "{}");
         var sut = CreateSut(handler);
 
         var body = JsonDocument.Parse("{}").RootElement;
         await Assert.ThrowsAsync<HttpRequestException>(() => sut.CreateAsync("pokemon", "user1", body));
+    }
+
+    /// <summary>
+    /// A 400 is the caller's problem. It used to throw HttpRequestException, which the global handler
+    /// flattened into 500 "An unexpected error occurred", so the user was told the server broke instead of
+    /// what was wrong with their input. See #539.
+    /// </summary>
+    [Fact]
+    public async Task CreateAsyncSurfacesPoracleNgsOwnExplanationForABadRequest()
+    {
+        var handler = new MockHttpMessageHandler(
+            HttpStatusCode.BadRequest,
+            /*lang=json,strict*/ "{\"message\":\"Invalid level (must be specified if no pokemon_id)\"}");
+        var sut = CreateSut(handler);
+
+        var body = JsonDocument.Parse("{}").RootElement;
+
+        var ex = await Assert.ThrowsAsync<AlarmValidationException>(
+            () => sut.CreateAsync("raid", "user1", body));
+        Assert.Contains("Invalid level", ex.Message, StringComparison.Ordinal);
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #537, #538, #539, #540, #543, #546, #547 — the remainder of the third sweep.

### #543 — renaming a geofence switched it off for your other profiles
Editing was delete-then-recreate. `DeleteAsync` unsubscribes **all** profiles; `CreateAsync` re-subscribes only the **active** one. So renaming from profile 0 quietly switched the geofence off everywhere else, and the page still showed it on because its toggle only reads the active profile's list.

There is now a real rename — `PUT /api/geofences/custom/{id}` — which moves the name in place and carries every subscription with it, using the writer's existing `RenameAreaInAllProfilesAsync`. (I had written a second, duplicate rename helper before noticing that one already existed; it's gone.)

### #539 — Poracle's explanation was replaced with "an unexpected error"
A 400 from PoracleNG threw `HttpRequestException`, which the global handler flattened into a 500. The user was told the server broke instead of what was wrong with their alarm, and it was logged as a fault rather than a client error.

### #540 — one selection set across two grids
Raid and egg uids come from separate sequences and collide. Ticking one card ticked the other, and the bulk actions routed both to the raid endpoint — deleting or resizing the raid twice and leaving the egg untouched. Keyed `raid:12` / `egg:12` now.

### #537 / #538 — edits that leave identical twins
Pokemon had no collision guard at all; max battles had one on create but not on update. Both could leave two byte-identical rows that cannot be told apart on the page, while *adding* that same alarm is refused.

**Verification note:** #538's guard is verified, but I could not construct #537's duplicate live — every attempt to set up two suitable rows was merged by PoracleNG first. The guard is in place and unit-tested; the live reproduction is unconfirmed, and I would rather say that than imply otherwise.

### #546 / #547
The auth limiter used `QueueLimit=2` where every other policy uses `0`, so requests 31 and 32 were parked until the window rolled over rather than refused — a spinner instead of "too many requests" on a shared egress IP.

And eight admin settings saved, persisted and read back while nothing consumed them, with descriptions promising behaviour that does not exist (`site_is_https` reads as a security control and changed nothing). Removed from the admin UI, as `disable_geomap` was. The migration still carries them, so existing rows are preserved rather than dropped.

### Verified against a live API
```
#543  geofence active on profile 0 -> rename -> still active under the new name
#539  raid with level 0 -> 400 "Invalid level (must be specified if no pokemon_id)"  (was 500)
```
The rename 500'd on the first live run — `group_name` is NOT NULL and the dialog does not always send one. Fixed and re-verified.

Suite green: 1792 backend, 941 frontend. Lint and Prettier clean.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX