### PR TITLE
fix: the collision guard refused legitimate edits, leaving alarms uneditable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Some alarms became impossible to edit** ([#553](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/553)). The check added to stop an edit overwriting a different alarm was too broad: two alarms that differ in both radius and template are genuinely separate, but every edit on either was refused — radius, template, auto-delete and clearing the gym — with a message about an alarm that was not in the way. Gyms differing only in their slot and battle toggles had the same problem. Both are editable again, and an edit that really would overwrite another alarm is still refused.
+### Fixed
 - **Renaming a custom geofence switched it off for your other profiles** ([#543](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/543)). Editing was implemented as delete-and-recreate, and the recreate only re-subscribed the profile you were on. The page still showed it as on, so nothing said those profiles had stopped receiving alerts. Renaming now keeps every subscription.
 - **Poracle's explanation of a rejected alarm was replaced with "an unexpected error"** ([#539](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/539)), so you were told the server had broken rather than what was wrong with the alarm.
 - **Selecting a raid could select an egg as well** ([#540](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/540)). The two lists shared one set of selections keyed by ID, and raid and egg IDs can be the same number — so a bulk delete or radius change hit the raid twice and left the egg untouched.

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -169,31 +169,33 @@ internal static partial class TrackingUpdateReconciler
         }
     }
 
-    /// <summary>Fields whose value never distinguishes two alarms.</summary>
-    private static readonly HashSet<string> NotPartOfIdentity = new(StringComparer.Ordinal)
+    /// <summary>Fields the comparison ignores entirely: PoracleNG owns them.</summary>
+    private static readonly HashSet<string> AssignedByPoracle = new(StringComparer.Ordinal)
     {
         // Assigned by PoracleNG, or rendered by it from the rest.
         "uid", "id", "profile_no", "description",
         // Never persisted (see #494).
         "ping",
-        // diff:"update" upstream -- differing here is what makes PoracleNG merge rather than insert.
+    };
+
+    /// <summary>diff:"update" upstream: a difference here can make PoracleNG merge rather than insert.</summary>
+    private static readonly HashSet<string> UpdatableFields = new(StringComparer.Ordinal)
+    {
         "distance", "template", "clean",
     };
 
-    /// <summary>Gyms additionally treat these two as updatable.</summary>
-    private static readonly HashSet<string> GymUpdatableFields = new(StringComparer.Ordinal)
-    {
-        "slot_changes", "battle_changes",
-    };
+    // slot_changes and battle_changes were treated as updatable for gyms, on the strength of the tags in
+    // the PoracleNG checkout. The running binary keeps two gyms that differ only in those toggles as
+    // separate rows -- so they identify an alarm, and calling them updatable refused every edit on both.
+    // They are compared like any other field now. See #553.
 
     private static bool WouldMergeInto(JsonElement submitted, JsonElement existing, string trackingType)
     {
-        var isGym = string.Equals(trackingType, "gym", StringComparison.Ordinal);
+        var updatableDifferences = 0;
 
         foreach (var field in submitted.EnumerateObject())
         {
-            if (NotPartOfIdentity.Contains(field.Name)
-                || (isGym && GymUpdatableFields.Contains(field.Name)))
+            if (AssignedByPoracle.Contains(field.Name))
             {
                 continue;
             }
@@ -207,14 +209,36 @@ internal static partial class TrackingUpdateReconciler
             // Compare what PoracleNG will STORE, not what was sent: it rewrites some values on the way
             // in, and it diffs the rewritten row. Comparing the raw submission made every collision
             // look like a difference, which is exactly how the destructive merge got through.
-            if (!SameValue(NormalizeForStorage(field, submitted, trackingType), storedValue))
+            var same = SameValue(NormalizeForStorage(field, submitted, trackingType), storedValue);
+
+            if (IsUpdatable(field.Name))
+            {
+                if (!same)
+                {
+                    updatableDifferences++;
+                }
+
+                continue;
+            }
+
+            if (!same)
             {
                 return false;
             }
         }
 
-        return true;
+        // Counted, not ignored. The running PoracleNG merges two rows only when EXACTLY ONE updatable
+        // field differs; with two or more it inserts a separate row, so those alarms genuinely coexist.
+        // Ignoring the fields wholesale called every such pair a collision and refused every ordinary edit
+        // on both -- radius, template, auto-delete, clearing the gym -- leaving them uneditable. That is a
+        // worse defect than the merge this check exists to prevent. See #553.
+        //
+        // Zero differences is the row colliding with itself, which IsNoOpEditAsync handles; only the
+        // one-difference case is a genuine merge into someone else.
+        return updatableDifferences <= 1;
     }
+
+    private static bool IsUpdatable(string fieldName) => UpdatableFields.Contains(fieldName);
     /// <summary>
     /// True when the row being edited already holds every value the update submitted, so PoracleNG's
     /// "already present" was the row colliding with itself rather than with a different alarm.

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -213,6 +213,64 @@ public class CreateResultSemanticsTests
             }));
     }
 
+    /// <summary>
+    /// Two alarms that differ in more than one updatable field genuinely coexist -- PoracleNG inserts
+    /// rather than merges -- so every ordinary edit on them must keep working. Ignoring those fields
+    /// wholesale called such a pair a collision and refused radius, template and auto-delete edits on both,
+    /// leaving them uneditable. See #553.
+    /// </summary>
+    [Fact]
+    public async Task AnEditIsAllowedWhenTwoUpdatableFieldsSeparateTheAlarms()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 1, id = "u1", team = 4, distance = 1000, template = "1" },
+            new { uid = 2, id = "u1", team = 4, distance = 6000, template = "ZZalt" }));
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([3], 0, 1, 0));
+
+        // Changing uid 2's radius still leaves it separated from uid 1 by BOTH radius and template.
+        var result = await sut.UpdateAsync("u1", new Gym
+        {
+            Id = "u1",
+            Uid = 2,
+            Team = 4,
+            Distance = 6500,
+            Template = "ZZalt",
+        });
+
+        Assert.Equal(3, result.Uid);
+    }
+
+    /// <summary>
+    /// Gyms that differ only in their slot/battle toggles are kept apart by PoracleNG, so those fields
+    /// identify an alarm and both must stay editable. See #553.
+    /// </summary>
+    [Fact]
+    public async Task AGymSeparatedOnlyByItsTogglesIsStillEditable()
+    {
+        var sut = new GymService(this._proxy.Object, this._gate.Object,
+            NullLogger<GymService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("gym", "u1")).ReturnsAsync(Rows(
+            new { uid = 1, id = "u1", team = 4, slot_changes = 1, battle_changes = 0, distance = 1000 },
+            new { uid = 2, id = "u1", team = 4, slot_changes = 0, battle_changes = 1, distance = 1000 }));
+        this._proxy.Setup(p => p.CreateAsync("gym", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([3], 0, 1, 0));
+
+        var result = await sut.UpdateAsync("u1", new Gym
+        {
+            Id = "u1",
+            Uid = 2,
+            Team = 4,
+            SlotChanges = 0,
+            BattleChanges = 1,
+            Distance = 1500,
+        });
+
+        Assert.Equal(3, result.Uid);
+    }
+
     /// <summary>An edit that collides with nothing must still go through untouched.</summary>
     [Fact]
     public async Task AnEditThatCollidesWithNothingIsUnaffected()


### PR DESCRIPTION
Closes #553. Regression from #533, found by the fourth sweep — and precisely the failure mode I asked that sweep to hunt for, which is the only reason it surfaced before release.

The guard treated `distance`, `template` and `clean` as never-identifying. The running PoracleNG merges two rows only when **exactly one** of them differs; with two or more it inserts. So two alarms that legitimately coexist — same level and team, different radius *and* template — read as a collision, and every ordinary edit on either was refused with a message naming an alarm that was not in the way. Reachable from the shipped Add dialog, and unrecoverable from the UI.

Gyms had a second form: `slot_changes` / `battle_changes` were treated as updatable per the checkout's tags, but the running binary keeps such gyms apart, so both became uneditable.

Updatable differences are now **counted**: a collision needs every identity field to match and at most one updatable field to differ. Gym toggles are compared like any other field.

**Source/binary mismatch, for the record:** `diffTracking` in the PoracleNG checkout returns `isUpdate` whenever no non-updatable field differs, regardless of how many updatable ones do. The deployed binary requires exactly one. This follows the deployed binary, since that is what users hit — and it is the second time this session that trusting the checkout over the running instance produced a wrong fix.

### Verified against a live API
```
two eggs, level 5 / team 4, differing in radius AND template
  edit the radius of one   -> 200, both rows survive  (was 409)
  edit its template        -> 200
  move one onto the other's exact settings -> 409, both intact  (still guarded)
```

Suite green: 1794, with two new cases pinning the coexistence behaviour.

The other 16 findings from the fourth sweep are not in this PR — this one is shipped first because it makes alarms unusable.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX