### PR TITLE
fix: an Add could take over an existing alarm, and the merge rule now follows prod's source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Adding an alarm could silently take over one you already had** ([#561](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/561), [#569](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/569)). Adding an alarm that matched an existing one except for its radius reported a new alarm created, and quietly moved the old one instead — leaving one alarm where there had been two. It is now refused, while adding a genuinely new alarm, or re-adding one you already have, behave as before.
+### Fixed
 - **A quick pick with a long name failed with a server error** ([#555](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/555)). The identifier generated from the name could be longer than the column that stores it.
 - **A profile backup containing a fort-change alarm would not import** ([#556](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/556)) — an unmodified export produced by this app, refused by the validation added in v2.12.2.
 - **A renamed geofence disappeared from the map and reported no points** ([#559](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/559), [#566](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/566)) until the page was reloaded, because the rename response left the shape out.

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -32,6 +32,11 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         // (eggs and raids share UI in the SPA). See DisableFeatureKeys.Raids comment.
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Raids);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -31,6 +31,11 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.FortChanges);
         model.Id = userId;
 
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
+
         // PoracleNG's dedup key for this type ignores distance, so a create matching an existing alarm's
         // fort type, include-empty flag and change types OVERWRITES that alarm's radius instead of adding a
         // second one -- while PoracleWeb answered 201 with a fresh uid, so the user believed they had two

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -30,6 +30,11 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Gyms);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
@@ -33,6 +33,11 @@ public class MonsterService(IPoracleTrackingProxy proxy, IFeatureGate featureGat
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Pokemon);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -30,6 +30,11 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Nests);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -30,6 +30,11 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Quests);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -30,6 +30,11 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Raids);
         model.Id = userId;
+
+        // An Add that PoracleNG resolves into an update of an existing alarm takes that alarm over:
+        // 201 Created, and the user quietly loses the one they had. See #561.
+        await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
+            this._proxy, TrackingType, userId, 0, SerializeToElement(model));
         var body = SerializeToElement(model);
         var result = await this._proxy.CreateAsync(TrackingType, userId, body);
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -128,11 +128,10 @@ internal static partial class TrackingUpdateReconciler
         int oldUid,
         JsonElement submitted)
     {
-        // Updates only. The create path has the same exposure (#561) but the same comparison does not
-        // work there: a create carries model defaults where the stored row carries PoracleNG's, so
-        // more than one updatable field reads as different and the collision is missed. Left open
-        // rather than shipped as a guard that quietly does nothing.
-        if (oldUid <= 0 || submitted.ValueKind != JsonValueKind.Object)
+        // Creates as well as edits. PoracleNG resolves an Add that differs from an existing alarm by one
+        // updatable field into an UPDATE of that alarm, so the user pressed Add, got a 201, and quietly
+        // lost the alarm they had. oldUid 0 means there is no row of ours to exclude. See #561, #569.
+        if (submitted.ValueKind != JsonValueKind.Object)
         {
             return;
         }
@@ -188,14 +187,16 @@ internal static partial class TrackingUpdateReconciler
         "distance", "template", "clean",
     };
 
-    // slot_changes and battle_changes were treated as updatable for gyms, on the strength of the tags in
-    // the PoracleNG checkout. The running binary keeps two gyms that differ only in those toggles as
-    // separate rows -- so they identify an alarm, and calling them updatable refused every edit on both.
-    // They are compared like any other field now. See #553.
+    /// <summary>Gyms tag these two diff:"update" as well.</summary>
+    private static readonly HashSet<string> GymUpdatableFields = new(StringComparer.Ordinal)
+    {
+        "slot_changes", "battle_changes",
+    };
 
     private static bool WouldMergeInto(
         JsonElement submitted, JsonElement existing, string trackingType, bool isCreate)
     {
+        var isGym = string.Equals(trackingType, "gym", StringComparison.Ordinal);
         var updatableDifferences = 0;
 
         foreach (var field in submitted.EnumerateObject())
@@ -211,12 +212,22 @@ internal static partial class TrackingUpdateReconciler
                 continue;
             }
 
+            // Nor can a field we are not supplying: PoracleNG fills it with its own default (template
+            // becomes the configured default name, "1" when unset), so a null here says nothing about
+            // what will be stored. Counting it as a difference is what made the create-path check miss
+            // every collision -- the model sends template null where the stored row holds "1", which
+            // read as a second difference and took the pair over the one-difference threshold. See #561.
+            if (IsBlank(field.Value))
+            {
+                continue;
+            }
+
             // Compare what PoracleNG will STORE, not what was sent: it rewrites some values on the way
             // in, and it diffs the rewritten row. Comparing the raw submission made every collision
             // look like a difference, which is exactly how the destructive merge got through.
             var same = SameValue(NormalizeForStorage(field, submitted, trackingType), storedValue);
 
-            if (IsUpdatable(field.Name))
+            if (IsUpdatable(field.Name, isGym))
             {
                 if (!same)
                 {
@@ -232,11 +243,15 @@ internal static partial class TrackingUpdateReconciler
             }
         }
 
-        // Counted, not ignored. The running PoracleNG merges two rows only when EXACTLY ONE updatable
-        // field differs; with two or more it inserts a separate row, so those alarms genuinely coexist.
-        // Ignoring the fields wholesale called every such pair a collision and refused every ordinary edit
-        // on both -- radius, template, auto-delete, clearing the gym -- leaving them uneditable. That is a
-        // worse defect than the merge this check exists to prevent. See #553.
+        // This mirrors DiffTracking in PoracleNG's processor/internal/db/diff.go, at the commit prod runs:
+        //
+        //     if totalDiffs == 0                            -> duplicate (nothing written)
+        //     if totalDiffs == 1 && nonUpdatableDiffs == 0  -> UPDATE of that existing row
+        //     otherwise                                     -> new insert
+        //
+        // Counted, not ignored. Ignoring the updatable fields wholesale called every pair that differs in
+        // two of them a collision, and refused every ordinary edit on both -- radius, template,
+        // auto-delete, clearing the gym -- leaving them uneditable (#553).
         //
         // Zero differences on an EDIT means the submission matches another row outright, which is a
         // collision worth refusing. On a CREATE it means an exact duplicate, and PoracleNG already
@@ -245,7 +260,8 @@ internal static partial class TrackingUpdateReconciler
         return isCreate ? updatableDifferences == 1 : updatableDifferences <= 1;
     }
 
-    private static bool IsUpdatable(string fieldName) => UpdatableFields.Contains(fieldName);
+    private static bool IsUpdatable(string fieldName, bool isGym) =>
+        UpdatableFields.Contains(fieldName) || (isGym && GymUpdatableFields.Contains(fieldName));
     /// <summary>
     /// True when the row being edited already holds every value the update submitted, so PoracleNG's
     /// "already present" was the row colliding with itself rather than with a different alarm.


### PR DESCRIPTION
Closes #561, #569 — and fixes the root cause behind three wrong fixes today.

### The root cause
The local PoracleNG checkout was at `5343134` (2026-04-01). Prod runs `6a50070` (2026-05-24) — four months of drift. Its `DiffTracking` merged whenever no non-updatable field differed. The version prod runs is:

```go
if totalDiffs == 0                           { duplicate }        // nothing written
if totalDiffs == 1 && nonUpdatableDiffs == 0 { update of that row }  // EXACTLY one
                                               new insert
```

That `totalDiffs == 1` clause does not exist in the stale copy. Reading it produced the max-battle level mistake (#521), the merge guard that compared the wrong thing (#531), and the over-refusal that made alarms uneditable (#553).

Checkout is now pinned to the commit prod runs (local edits stashed, not discarded), and the rule in `TrackingUpdateReconciler` quotes it directly.

### #561 / #569 — Add could take over an existing alarm
The create path had the same exposure as the edit path. Adding an alarm that matched an existing one except for its radius made PoracleNG **update** that alarm: 201 Created, and one alarm where there had been two.

My earlier attempt at this guard passed its tests and did nothing live, because a create sends the model's defaults where the stored row holds PoracleNG's — `template: null` against a stored `"1"` read as a second difference and pushed the pair past the one-difference threshold. A field we are not supplying is one PoracleNG will fill in, so it cannot be compared and is now skipped.

### Gym toggles restored to updatable
#553 made `slot_changes` / `battle_changes` identity fields on the strength of a sweep observation. The source prod runs tags them `diff:"update"`, and a direct POST to PoracleNG settles it: two gyms differing **only** in `slot_changes` merge (`insert:0`), while differing in `slot_changes` **and** distance inserts both rows. The sweep's claim that such gyms coexist was wrong; the uneditability it reported was real and came from ignoring the fields wholesale.

### Verified against a live API
```
Add at a different radius        -> 409, the original alarm intact
exact duplicate                  -> 200, uid 0   (multi-select add relies on this)
a different Pokemon              -> created
two updatable differences        -> created, both rows coexist
#553 pair (radius + template)    -> still editable; moving one onto the other -> 409, both intact
gym differing only in slot only  -> merges, as the source says
```

Suite green: 1794.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX
