### PR TITLE
fix: bulk radius collapse, blank profiles page, reapply ordering, and per-user rate limits

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -396,10 +396,15 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors();
 
-app.UseRateLimiter();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+// After authentication, deliberately. Registered before it, the partition key could not see
+// User.Identity, so every "per-user" policy silently fell back to the IP -- one person behind a shared
+// egress could exhaust the allowance for everyone behind it, and the per-user policies were per-user in
+// name only. See #581.
+app.UseRateLimiter();
 
 app.MapControllers();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A bulk radius change could leave you with fewer alarms than you selected** ([#580](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/580)). Two alarms that differed only by radius became the same alarm once both were set to the same one, and Poracle merged them — while the app reported every alarm updated. It is now refused with an explanation.
+- **The Profiles page was blank for accounts that had never edited a profile** ([#582](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/582)). It reported no alarms across any profile while the alarms were there and firing.
+- **Re-applying a quick pick whose type had changed deleted its alarms before refusing** ([#579](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/579)), so the error read as "nothing happened" while the alarms were already gone.
+
+### Security
+- **Per-user rate limits were shared by everyone behind the same address** ([#581](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/581)). The limiter ran before sign-in was established, so it could not tell users apart — one person on a shared connection could use up the allowance for everyone on it.
+### Fixed
 - **Adding a Pokemon alarm at a tighter IV silently replaced the existing one** ([#574](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/574)). Same species, higher minimum IV — about the most ordinary thing you can do — reported a new alarm created and destroyed the old one.
 - **An "any gym" alarm was refused when a gym-specific one existed** ([#575](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/575)), and whether it worked depended on which of the two you added first. They are different alarms and both are allowed again.
 - **Duplicating a profile from the Profiles page put the Pokemon alarms on the wrong profile** ([#576](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/576)) — back onto the profile being copied, which quietly gained a duplicate each time, while the new profile came up with no Pokemon tracking at all.

--- a/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/EggService.cs
@@ -107,6 +107,11 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -133,6 +138,11 @@ public class EggService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/FortChangeService.cs
@@ -119,6 +119,11 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -145,6 +150,11 @@ public class FortChangeService(IPoracleTrackingProxy proxy, IFeatureGate feature
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/GymService.cs
@@ -105,6 +105,11 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -131,6 +136,11 @@ public class GymService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, I
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -133,6 +133,11 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -159,6 +164,11 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/LureService.cs
@@ -129,6 +129,11 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -155,6 +160,11 @@ public class LureService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/NestService.cs
@@ -105,6 +105,11 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -131,6 +136,11 @@ public class NestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/ProfileService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/ProfileService.cs
@@ -22,7 +22,55 @@ public class ProfileService(
     public async Task<IEnumerable<Profile>> GetByUserAsync(string userId)
     {
         var json = await this._humanProxy.GetProfilesAsync(userId);
-        return DeserializeProfiles(json);
+        var profiles = DeserializeProfiles(json);
+
+        return await this.WithActiveProfileAsync(userId, profiles);
+    }
+
+    /// <summary>
+    /// Guarantees the profile the user is actually on appears in the list.
+    /// </summary>
+    /// <remarks>
+    /// PoracleNG only materialises a <c>profiles</c> row when something writes one, so an account that has
+    /// never renamed or added a profile has none -- while <c>humans.current_profile_no</c> still points at
+    /// one and alarms hang off it. The Profiles and Profile Overview pages then rendered "no alarms across
+    /// any profiles" over a full set of alarms. Synthesised rather than written, so this stays a read.
+    /// See #582.
+    /// </remarks>
+    private async Task<IEnumerable<Profile>> WithActiveProfileAsync(string userId, List<Profile> profiles)
+    {
+        JsonElement? human;
+        try
+        {
+            human = await this._humanProxy.GetHumanAsync(userId);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            return profiles;
+        }
+
+        if (human is not { } record)
+        {
+            return profiles;
+        }
+
+        var activeProfileNo = record.GetIntProp("current_profile_no");
+        if (profiles.Exists(p => p.ProfileNo == activeProfileNo))
+        {
+            return profiles;
+        }
+
+        profiles.Add(new Profile
+        {
+            Id = userId,
+            ProfileNo = activeProfileNo,
+            Name = "Default",
+            Area = record.GetStringPropOrNull("area") ?? "[]",
+            Latitude = record.GetDoubleProp("latitude"),
+            Longitude = record.GetDoubleProp("longitude"),
+        });
+
+        return [.. profiles.OrderBy(p => p.ProfileNo)];
     }
 
     public async Task<Profile?> GetByUserAndProfileNoAsync(string userId, int profileNo)

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuestService.cs
@@ -105,6 +105,11 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -131,6 +136,11 @@ public class QuestService(IPoracleTrackingProxy proxy, IFeatureGate featureGate,
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -421,6 +421,19 @@ public partial class QuickPickService(
             await this._featureGate.EnsureEnabledAsync(disableKey);
         }
 
+        // The alarm-type guard runs here too, not just in ApplyAsync. Re-apply deletes before it applies,
+        // so a pick whose type changed since it was applied lost its alarms AND its applied state before
+        // the refusal ever fired -- the deletes are committed and the error reads as "nothing happened".
+        // See #579.
+        var applied = await this._appliedStateRepository.GetAsync(userId, profileNo, quickPickId);
+        if (applied is not null
+            && applied.TrackedUids.Count > 0
+            && !string.Equals(applied.AlarmType, definition.AlarmType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AlarmValidationException(
+                "This quick pick still owns alarms of a different type. Remove it first, then apply it again.");
+        }
+
         // Building throws for a filter the alarm model refuses. Nothing is sent anywhere.
         BuildSampleAlarm(definition, profileNo, request);
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/RaidService.cs
@@ -111,6 +111,11 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(itemList);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.
@@ -137,6 +142,11 @@ public class RaidService(IPoracleTrackingProxy proxy, IFeatureGate featureGate, 
         }
 
         var body = SerializeToElement(matching);
+        // Two selected rows that differed only by radius become the same alarm once both are set to
+        // the same one, and PoracleNG resolves that inside the batch -- fewer alarms than selected,
+        // one left at its old radius, and a response claiming all were updated. See #580.
+        TrackingUpdateReconciler.EnsureBatchDoesNotCollapse(body, TrackingType);
+
         await this._proxy.CreateAsync(TrackingType, userId, body);
         // PoracleNG rewrites every row, so the uids change. Follow any quick-pick that
         // tracks them, pairing on content because the batch response is reordered. See #443.

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -103,6 +103,49 @@ internal static partial class TrackingUpdateReconciler
     }
 
     /// <summary>
+    /// Refuses a bulk write in which two of the submitted rows would become the same alarm.
+    /// </summary>
+    /// <remarks>
+    /// The distance endpoints rewrite every selected row and POST them as one batch. Two rows that differed
+    /// only by radius become identical once both are set to the same radius, and PoracleNG resolves that
+    /// within the batch -- so the user ended up with FEWER alarms than they selected, at least one still at
+    /// its old radius, and a response claiming every one was updated. Refuse instead of silently losing a
+    /// row. See #580.
+    /// </remarks>
+    public static void EnsureBatchDoesNotCollapse(JsonElement body, string trackingType)
+    {
+        if (body.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in body.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!seen.Add(IdentityOf(row)))
+            {
+                throw new TrackingConflictException(
+                    trackingType,
+                    "Two of the selected alarms would end up identical at that radius. "
+                    + "Change them separately, or remove one first.");
+            }
+        }
+    }
+
+    /// <summary>Everything about a row that distinguishes it from another, in a stable order.</summary>
+    private static string IdentityOf(JsonElement row) =>
+        string.Join(
+            '|',
+            row.EnumerateObject()
+                .Where(p => !AssignedByPoracle.Contains(p.Name))
+                .OrderBy(p => p.Name, StringComparer.Ordinal)
+                .Select(p => $"{p.Name}={p.Value}"));
+    /// <summary>
     /// Refuses an edit that PoracleNG would satisfy by merging into a DIFFERENT alarm.
     /// </summary>
     /// <remarks>

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -288,6 +288,43 @@ public class CreateResultSemanticsTests
         Assert.Equal(191, result.Uid);
     }
 
+    /// <summary>
+    /// min_iv is diff:"update" on the monster struct only, so adding the same species at a tighter IV
+    /// floor is exactly one updatable difference -- PoracleNG updates the existing alarm rather than
+    /// inserting, and the user loses it. See #574.
+    /// </summary>
+    [Fact]
+    public async Task AddingTheSameSpeciesAtATighterIvIsRefused()
+    {
+        var sut = new MonsterService(this._proxy.Object, this._gate.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("pokemon", "u1")).ReturnsAsync(Rows(
+            new { uid = 1, id = "u1", pokemon_id = 140, min_iv = 90, distance = 4000 }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.CreateAsync("u1", new Monster { PokemonId = 140, MinIv = 95, Distance = 4000 }));
+    }
+
+    /// <summary>
+    /// gym_id is blank precisely when the user means "any gym", so it must count as a difference. Skipping
+    /// every blank field made an any-gym alarm read as identical to a gym-specific one. See #575.
+    /// </summary>
+    [Fact]
+    public async Task AnAnyGymAlarmDoesNotCollideWithAGymSpecificOne()
+    {
+        var sut = new RaidService(this._proxy.Object, this._gate.Object,
+            NullLogger<RaidService>.Instance, this._remapper.Object);
+        this._proxy.Setup(p => p.GetByUserAsync("raid", "u1")).ReturnsAsync(Rows(
+            new { uid = 1, id = "u1", level = 5, gym_id = "zzgym", distance = 1111 }));
+        this._proxy.Setup(p => p.CreateAsync("raid", "u1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([2], 0, 0, 1));
+        this._proxy.Setup(p => p.GetByUserAsync("raid", "u1")).ReturnsAsync(Rows(
+            new { uid = 1, id = "u1", level = 5, gym_id = "zzgym", distance = 1111 }));
+
+        var result = await sut.CreateAsync("u1", new Raid { Level = 5, GymId = "", Distance = 2222 });
+
+        Assert.Equal(2, result.Uid);
+    }
+
     // ── #462: a colliding natural-key edit must not destroy either alarm ─────
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/EggServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/EggServiceTests.cs
@@ -126,19 +126,22 @@ public class EggServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             },
             new
             {
                 uid = 3,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow3"
             });
         this._proxy.Setup(p => p.GetByUserAsync("egg", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("egg", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
@@ -179,13 +179,15 @@ public class FortChangeServiceTests
             {
                 uid = 1,
                 id = "u1",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u1",
-                distance = 0
+                distance = 0,
+                template = "ZZrow2"
             });
         this._proxy.Setup(p => p.GetByUserAsync("fort", "u1")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("fort", "u1", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/GymServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/GymServiceTests.cs
@@ -127,31 +127,36 @@ public class GymServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             },
             new
             {
                 uid = 3,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow3"
             },
             new
             {
                 uid = 4,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow4"
             },
             new
             {
                 uid = 5,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow5"
             });
         this._proxy.Setup(p => p.GetByUserAsync("gym", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("gym", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -142,25 +142,29 @@ public class InvasionServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             },
             new
             {
                 uid = 3,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow3"
             },
             new
             {
                 uid = 4,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow4"
             });
         this._proxy.Setup(p => p.GetByUserAsync("invasion", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("invasion", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/LureServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/LureServiceTests.cs
@@ -112,13 +112,15 @@ public class LureServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             });
         this._proxy.Setup(p => p.GetByUserAsync("lure", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("lure", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/MaxBattleServiceTests.cs
@@ -206,13 +206,15 @@ public class MaxBattleServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             });
         this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.BulkDeleteByUidsAsync("maxbattle", "u", It.IsAny<IEnumerable<int>>()))
@@ -231,19 +233,22 @@ public class MaxBattleServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             },
             new
             {
                 uid = 3,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow3"
             });
         this._proxy.Setup(p => p.GetByUserAsync("maxbattle", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.BulkDeleteByUidsAsync("maxbattle", "u", It.IsAny<IEnumerable<int>>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/NestServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/NestServiceTests.cs
@@ -117,19 +117,22 @@ public class NestServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             },
             new
             {
                 uid = 3,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow3"
             });
         this._proxy.Setup(p => p.GetByUserAsync("nest", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("nest", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuestServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuestServiceTests.cs
@@ -111,7 +111,8 @@ public class QuestServiceTests
         {
             uid = 1,
             id = "u",
-            distance = 0
+            distance = 0,
+            template = "ZZrow1"
         });
         this._proxy.Setup(p => p.GetByUserAsync("quest", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("quest", "u", It.IsAny<JsonElement>()))

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/RaidServiceTests.cs
@@ -169,6 +169,25 @@ public class RaidServiceTests
         Assert.Equal(3, await this._sut.DeleteAllByUserAsync("u", 1));
     }
 
+    /// <summary>
+    /// Two rows that differ only by radius become the same alarm once both are set to the same radius,
+    /// and PoracleNG resolves that inside the batch -- so the user ends up with fewer alarms than they
+    /// selected, one still at its old radius, and a response claiming every one was updated. See #580.
+    /// </summary>
+    [Fact]
+    public async Task UpdateDistanceRefusesWhenTwoSelectedAlarmsWouldBecomeIdentical()
+    {
+        this._proxy.Setup(p => p.GetByUserAsync("raid", "u1")).ReturnsAsync(CreateJsonArray(
+            new { uid = 1, id = "u1", level = 5, distance = 500, template = "1" },
+            new { uid = 2, id = "u1", level = 5, distance = 900, template = "1" }));
+
+        await Assert.ThrowsAsync<TrackingConflictException>(
+            () => this._sut.UpdateDistanceByUidsAsync([1, 2], "u1", 700));
+
+        this._proxy.Verify(
+            p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()), Times.Never);
+    }
+
     [Fact]
     public async Task UpdateDistanceByUserAsyncReturnsCount()
     {
@@ -177,13 +196,15 @@ public class RaidServiceTests
             {
                 uid = 1,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZrow1"
             },
             new
             {
                 uid = 2,
                 id = "u",
-                distance = 0
+                distance = 0,
+                template = "ZZsecond"
             });
         this._proxy.Setup(p => p.GetByUserAsync("raid", "u")).ReturnsAsync(json);
         this._proxy.Setup(p => p.CreateAsync("raid", "u", It.IsAny<JsonElement>()))


### PR DESCRIPTION
Closes #579, #580, #581, #582.

- **#580 (critical)** The distance endpoints POST every selected row as one batch. Two rows differing only by radius become the same alarm once both are set to the same radius, and PoracleNG resolves that inside the batch — fewer alarms than selected, one left at its old radius, and `{"updated":N}` claiming otherwise. Refused before the write. The create guard from #571 makes such a pair hard to produce going forward, but data created before it exists, so the check earns its place.
- **#582 (major)** PoracleNG only materialises a `profiles` row when something writes one. An account that never renamed or added a profile has none — while `current_profile_no` points at one and alarms hang off it — so both profile pages rendered "no alarms across any profiles" over a full set of alarms. The active profile is synthesised into the list; nothing is written.
- **#579 (major)** `ReapplyAsync` validates before deleting (#532), but its dry run lacked the alarm-type guard `ApplyAsync` grew in #557. A pick whose type had changed lost its alarms *and* its applied state before the refusal fired.
- **#581 (major, security)** `UseRateLimiter` ran before `UseAuthentication`, so a partition key reading `User.Identity` saw nothing and every "per-user" policy fell back to the IP. One person behind a shared egress could exhaust the allowance for everyone behind it.

### Verified against a live API
```
bulk radius over two distinct alarms -> {"updated":2}, exactly two rows, both at 777
profiles list for an ordinary account -> unchanged
```

Suite green: 1797, including a service-level test that a collapsing bulk write is refused before anything is sent.

Seven findings from this sweep remain and are next.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX