### PR TITLE
fix: forgeable rate-limit partition, deleted-session 500s, and four smaller gaps

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Filters/AccountGoneExceptionFilter.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Filters/AccountGoneExceptionFilter.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Api.Filters;
+
+/// <summary>
+/// Answers 401 when the authenticated account no longer exists.
+/// </summary>
+/// <remarks>
+/// Registered globally, beside the conflict and validation filters. A deleted user's token stayed valid, so
+/// every endpoint threw on PoracleNG's 404 and the global handler returned 500 -- and the SPA signs out only
+/// on 401, so the session sat there failing on every page. /api/auth/me alone got this right (#545); this
+/// makes the rest of the API agree with it. See #584.
+/// </remarks>
+public sealed class AccountGoneExceptionFilter : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Exception is not AccountGoneException ex)
+        {
+            return;
+        }
+
+        context.Result = new UnauthorizedObjectResult(new
+        {
+            error = ex.Message,
+        });
+        context.ExceptionHandled = true;
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -181,6 +181,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.SummaryBackendUnavailableExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.TrackingConflictExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AlarmValidationExceptionFilter>();
+    options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AccountGoneExceptionFilter>();
 });
 
 // Add Poracle services (DbContext, repositories, services, settings)
@@ -371,10 +372,35 @@ var forwardedHeadersOptions = new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 };
+// Clearing both lists tells ASP.NET to believe X-Forwarded-For from ANY peer, so a client could name its
+// own address and hand itself a fresh rate-limit bucket per request -- including on the login endpoints
+// the per-IP partitioning exists to protect. Trust only the proxies the deployment names.
+//
+// PROXY_KNOWN_PROXIES / PROXY_KNOWN_NETWORKS take comma-separated addresses and CIDR ranges. With
+// neither set the header is ignored entirely and the connection address is used, which is correct for a
+// direct-exposed instance and safe for one behind a proxy that has not been declared yet -- it means
+// everyone behind that proxy shares a bucket, rather than everyone being able to forge one. See #583.
+foreach (var proxy in SplitConfigList(builder.Configuration["Proxy:KnownProxies"]))
+{
+    if (System.Net.IPAddress.TryParse(proxy, out var address))
+    {
+        forwardedHeadersOptions.KnownProxies.Add(address);
+    }
+}
+
+foreach (var network in SplitConfigList(builder.Configuration["Proxy:KnownNetworks"]))
+{
+    var parts = network.Split('/', 2);
+    if (parts.Length == 2
+        && System.Net.IPAddress.TryParse(parts[0], out var prefix)
+        && int.TryParse(parts[1], out var length))
+    {
 #pragma warning disable ASPDEPR005
-forwardedHeadersOptions.KnownNetworks.Clear();
+        forwardedHeadersOptions.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(prefix, length));
 #pragma warning restore ASPDEPR005
-forwardedHeadersOptions.KnownProxies.Clear();
+    }
+}
+
 app.UseForwardedHeaders(forwardedHeadersOptions);
 
 // Security headers -- values live in SecurityHeaders so they can be unit-tested
@@ -434,6 +460,12 @@ static string UserOrIpPartitionKey(HttpContext ctx)
 }
 
 // Maps a short env var name to .NET's __ convention if the target is not already set.
+/// <summary>Splits a comma-separated config value, ignoring blanks.</summary>
+static string[] SplitConfigList(string? value) =>
+    string.IsNullOrWhiteSpace(value)
+        ? []
+        : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
 static void MapEnvVar(string shortName, string configName, string? defaultValue = null)
 {
     if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(configName)))

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -60,6 +60,11 @@ interface SettingGroup {
  * left in the database rather than deleted. See #547, #560.
  */
 const RETIRED_KEYS = [
+  // Legacy Poracle keys describing a map picker this app does not have. Removed from the settings UI and
+  // from SettingsMigrationService when they were retired, but rows persist in existing databases and were
+  // still rendering in the "Other" catch-all. See #589.
+  'disable_geomap',
+  'disable_geomap_select',
   'register_command',
   'location_command',
   'provider_url',

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles-overview/profile-overview.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles-overview/profile-overview.component.ts
@@ -620,9 +620,15 @@ export class ProfileOverviewComponent implements OnInit {
               .importProfile({ ...backup, profileName: name })
               .pipe(takeUntilDestroyed(this.destroyRef))
               .subscribe({
-                error: () => {
+                // The server names the alarm and the field a file got wrong; a fixed string threw that
+                // away and left the user to guess which of hundreds of alarms was the problem. See #588.
+                error: (err: { error?: { error?: string } }) => {
                   this.switching.set(false);
-                  this.snackBar.open(this.i18n.instant('PROFILES.SNACK_FAILED_IMPORT'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
+                  this.snackBar.open(
+                    err?.error?.error ?? this.i18n.instant('PROFILES.SNACK_FAILED_IMPORT'),
+                    this.i18n.instant('TOAST.OK'),
+                    { duration: 6000 },
+                  );
                 },
                 next: res => {
                   this.switching.set(false);

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-apply-dialog.component.ts
@@ -117,9 +117,11 @@ export class QuickPickApplyDialogComponent {
       : this.quickPickService.apply(this.data.definition.id, request);
 
     obs.subscribe({
-      error: () => {
-        this.snackBar.open(this.i18n.instant('QUICK_PICKS.SNACK_FAILED_APPLY'), this.i18n.instant('TOAST.OK'), {
-          duration: 3000,
+      // The server says what to do -- remove the pick first, or fix the filter it will not accept. A fixed
+      // string left the user with a dead end. See #587.
+      error: (err: { error?: { error?: string } }) => {
+        this.snackBar.open(err?.error?.error ?? this.i18n.instant('QUICK_PICKS.SNACK_FAILED_APPLY'), this.i18n.instant('TOAST.OK'), {
+          duration: 6000,
         });
         this.applying.set(false);
         this.applyStatus.set('');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Rate limits could be bypassed by forging a header** ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)). `X-Forwarded-For` was believed from any caller, so a client could name a different address on each request and hand itself a fresh allowance — including on the sign-in endpoints the limit exists to protect. It is now honoured only from proxies the deployment declares, via `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS`.
+
+### Fixed
+- **A deleted account kept getting server errors instead of being signed out** ([#584](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/584)). Only the session check answered correctly; every other page returned "an unexpected error occurred" until the app happened to re-check. All of them now agree and the session ends.
+- **Renaming a geofence skipped the name rules that creating one enforces** ([#585](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/585)), so a name the app refuses at creation could be applied by editing instead.
+- **The PVP league accepted values no league uses** ([#586](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/586)), storing a filter that can never match. It is now limited to the four the dropdown offers.
+- **Quick-pick apply and profile import discarded the server's explanation** ([#587](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/587), [#588](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/588)) — the instruction telling you what to do, and the message naming the bad alarm in a file.
+- **Two retired map-picker settings still appeared in the admin page** ([#589](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/589)).
 ### Fixed
 - **A bulk radius change could leave you with fewer alarms than you selected** ([#580](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/580)). Two alarms that differed only by radius became the same alarm once both were set to the same one, and Poracle merged them — while the app reported every alarm updated. It is now refused with an explanation.
 - **The Profiles page was blank for accounts that had never edited a profile** ([#582](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/582)). It reported no alarms across any profile while the alarms were there and firing.

--- a/Core/Pgan.PoracleWebNet.Core.Models/AccountGoneException.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/AccountGoneException.cs
@@ -1,0 +1,29 @@
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// The account the request is authenticated as no longer exists.
+/// </summary>
+/// <remarks>
+/// A JWT outlives the account it names. After an admin deletes a user, PoracleNG answers 404 "User not
+/// found" for every lookup, and <c>EnsureSuccessStatusCode</c> turned that into an unhandled 500 — so the
+/// deleted user sat in a fully rendered app throwing "an unexpected error occurred" on every page, because
+/// the SPA only signs out on 401. <c>/api/auth/me</c> alone got this right (#545). Raised here and mapped to
+/// 401 so every endpoint answers the same way and the session ends. See #584.
+/// </remarks>
+public sealed class AccountGoneException : Exception
+{
+    public AccountGoneException()
+        : base("This account no longer exists.")
+    {
+    }
+
+    public AccountGoneException(string message)
+        : base(message)
+    {
+    }
+
+    public AccountGoneException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Core/Pgan.PoracleWebNet.Core.Models/MonsterCreate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/MonsterCreate.cs
@@ -100,7 +100,11 @@ public class MonsterCreate
         get; set;
     }
 
-    [Range(0, int.MaxValue)]
+    // The league is a CP cap, and the dropdown offers exactly four: none, Little (500), Great (1500),
+    // Ultra (2500). [Range(0, int.MaxValue)] accepted any positive integer, so a value no league uses
+    // stored a PVP filter that can never match -- the one unbounded field among Best/Worst/Cap.
+    // See #586.
+    [AllowedValues(0, 500, 1500, 2500)]
     public int PvpRankingLeague
     {
         get; set;

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleHumanProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleHumanProxy.cs
@@ -1,3 +1,5 @@
+using Pgan.PoracleWebNet.Core.Models;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
@@ -15,6 +17,22 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
     /// URL-encodes a userId for safe path construction. Webhook IDs are full URLs
     /// containing slashes that would break routing without encoding.
     /// </summary>
+    /// <summary>
+    /// Turns PoracleNG's "user not found" into something the API can answer 401 to.
+    /// </summary>
+    /// <remarks>
+    /// A JWT outlives the account it names. Without this, every lookup for a deleted user threw an
+    /// HttpRequestException that the global handler flattened into a 500, so the SPA -- which signs out
+    /// only on 401 -- left the user in an app where every page failed. See #584.
+    /// </remarks>
+    private static void EnsureAccountStillExists(HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new AccountGoneException();
+        }
+    }
+
     private static string Encode(string userId) => Uri.EscapeDataString(userId);
 
     public async Task<JsonElement?> GetHumanAsync(string userId)
@@ -40,18 +58,21 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
     public async Task CreateHumanAsync(JsonElement body)
     {
         var response = await this.SendAsync(HttpMethod.Post, "/api/humans", body.GetRawText());
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task StartAsync(string userId)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/start");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task StopAsync(string userId)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/stop");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
@@ -65,12 +86,14 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
             state = disabled
         });
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/adminDisabled", body);
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task SetLocationAsync(string userId, double lat, double lon)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/setLocation/{lat}/{lon}");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
@@ -78,6 +101,7 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
     {
         var body = JsonSerializer.Serialize(areas);
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/setAreas", body);
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
@@ -89,12 +113,14 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
     public async Task SwitchProfileAsync(string userId, int profileNo)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/humans/{Encode(userId)}/switchProfile/{profileNo}");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task<JsonElement> GetProfilesAsync(string userId)
     {
         var response = await this.SendAsync(HttpMethod.Get, $"/api/profiles/{Encode(userId)}");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
@@ -105,24 +131,28 @@ public class PoracleHumanProxy(HttpClient httpClient, IConfiguration configurati
     public async Task AddProfileAsync(string userId, JsonElement body)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/profiles/{Encode(userId)}/add", body.GetRawText());
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task UpdateProfileAsync(string userId, JsonElement body)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/profiles/{Encode(userId)}/update", body.GetRawText());
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task DeleteProfileAsync(string userId, int profileNo)
     {
         var response = await this.SendAsync(HttpMethod.Delete, $"/api/profiles/{Encode(userId)}/byProfileNo/{profileNo}");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task CopyProfileAsync(string userId, int fromProfileNo, int toProfileNo)
     {
         var response = await this.SendAsync(HttpMethod.Post, $"/api/profiles/{Encode(userId)}/copy/{fromProfileNo}/{toProfileNo}");
+        EnsureAccountStillExists(response);
         response.EnsureSuccessStatusCode();
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -217,13 +217,23 @@ public partial class UserGeofenceService(
             throw new UnauthorizedAccessException("Geofence does not belong to this user.");
         }
 
-        if (string.IsNullOrWhiteSpace(displayName))
+        // The same rules create enforces. Rename checked only for emptiness, so a name creation refuses --
+        // over 50 characters, or carrying characters outside the allowlist -- could be applied by editing
+        // an existing geofence instead. The polygon-side validation on this feature is thorough, which
+        // made the gap look like an oversight rather than a decision. See #585.
+        var trimmedName = displayName?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(trimmedName) || trimmedName.Length > 50)
         {
-            throw new ArgumentException("A name is required.", nameof(displayName));
+            throw new ArgumentException("Display name must be between 1 and 50 characters.", nameof(displayName));
+        }
+
+        if (!MyRegex().IsMatch(trimmedName))
+        {
+            throw new ArgumentException("Display name contains invalid characters.", nameof(displayName));
         }
 
         var oldKojiName = geofence.KojiName;
-        var newKojiName = displayName.Trim().ToLowerInvariant();
+        var newKojiName = trimmedName.ToLowerInvariant();
 
         if (!string.Equals(oldKojiName, newKojiName, StringComparison.OrdinalIgnoreCase))
         {
@@ -236,7 +246,7 @@ public partial class UserGeofenceService(
             }
         }
 
-        geofence.DisplayName = displayName.Trim();
+        geofence.DisplayName = trimmedName;
         geofence.KojiName = newKojiName;
         // group_name is NOT NULL, and the rename dialog does not always send one -- keep what is there rather than clearing it.
         geofence.GroupName = string.IsNullOrWhiteSpace(groupName) ? geofence.GroupName : groupName;


### PR DESCRIPTION
Closes #583–#589 — the last of the fifth sweep.

### #583 (security) — the rate limit could be bypassed by forging a header
`KnownProxies` and `KnownNetworks` were both cleared, which tells ASP.NET to believe `X-Forwarded-For` from **any** peer. A client could name a different address on each request and hand itself a fresh bucket every time — including on the sign-in endpoints the per-IP partitioning exists to protect.

Now honoured only from proxies the deployment declares (`PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS`). With neither set the header is ignored and the connection address is used: correct for a direct-exposed instance, and safe behind an undeclared proxy — everyone behind it shares a bucket, rather than everyone being able to forge one.

**Verified empirically**, since a status code alone proves nothing here: 130 requests to a 120/60s endpoint, each with a different forged `X-Forwarded-For`, gave 120 × 200 then 429. Before the fix each forged address would have had its own allowance.

### #584 — a deleted account kept getting 500s instead of being signed out
A JWT outlives the account it names. PoracleNG answers 404 after a delete and `EnsureSuccessStatusCode` turned that into an unhandled 500, so the user sat in a rendered app failing on every page — the SPA signs out only on 401. `/api/auth/me` alone got this right (#545); `AccountGoneException` plus a global filter makes the rest of the API agree with it.

### #585, #586, #587, #588, #589
Rename skipped the name rules creation enforces. `pvpRankingLeague` was the one unbounded PVP field despite being a four-value dropdown. The apply dialog and import handler discarded the server's message. Two long-retired map-picker settings still rendered from rows that persist in existing databases.

### Verified against a live API
```
#583  130 requests w/ unique forged XFF -> 120 × 200 then 429
#585  60-char rename -> 400;  invalid characters -> 400;  valid rename -> 200
#586  league 1234 -> 400;  league 1500 -> created
```

Suite green: 1797 backend, 941 frontend. Lint and Prettier clean.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX