### PR TITLE
fix: the collision guard now mirrors PoracleNG's ordering, and blocking is enforced

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Pgan.PoracleWebNet.Api.Configuration;
@@ -9,6 +10,7 @@ namespace Pgan.PoracleWebNet.Api.Controllers;
 [Route("api/admin")]
 public partial class AdminController(
     IHumanService humanService,
+    IMemoryCache cache,
     IUserPurgeService userPurgeService,
     IWebhookDelegateService webhookDelegateService,
     IPoracleApiProxy poracleApiProxy,
@@ -18,6 +20,7 @@ public partial class AdminController(
     ILogger<AdminController> logger) : BaseApiController
 {
     private readonly IHumanService _humanService = humanService;
+    private readonly IMemoryCache _cache = cache;
     private readonly IUserPurgeService _userPurgeService = userPurgeService;
     private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
     private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
@@ -177,6 +180,11 @@ public partial class AdminController(
 
         await this._humanProxy.AdminDisabledAsync(id, false);
 
+        // Evict the block cache so this takes effect on the next request rather than up to a
+        // minute later. Without it the filter kept serving the value it had already cached, which
+        // is how the first live check of this fix appeared to fail. See #609.
+        this._cache.Remove($"blocked:{id}");
+
         // Re-fetch to return the updated state
         var updated = await this._humanService.GetByIdAsync(id) ?? human;
         return this.Ok(updated);
@@ -197,6 +205,11 @@ public partial class AdminController(
         }
 
         await this._humanProxy.AdminDisabledAsync(id, true);
+
+        // Evict the block cache so this takes effect on the next request rather than up to a
+        // minute later. Without it the filter kept serving the value it had already cached, which
+        // is how the first live check of this fix appeared to fail. See #609.
+        this._cache.Remove($"blocked:{id}");
 
         // Re-fetch to return the updated state
         var updated = await this._humanService.GetByIdAsync(id) ?? human;

--- a/Applications/Pgan.PoracleWebNet.Api/Filters/BlockedAccountFilter.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Filters/BlockedAccountFilter.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Api.Filters;
+
+/// <summary>
+/// Rejects requests from an account an admin has blocked.
+/// </summary>
+/// <remarks>
+/// #597 made <c>/api/auth/me</c> answer 401 so the SPA signs a blocked user out. That is a client-side
+/// courtesy, not enforcement: the API kept serving every other endpoint until the SPA happened to poll, and
+/// anything not going through the SPA was unaffected entirely. Blocking has to mean the API refuses.
+/// <para>
+/// The lookup is cached for a minute per user, so this costs one PoracleNG call per user per minute rather
+/// than one per request. A minute of stale access after a block is the trade; without the cache this would
+/// add a round trip to every single request. Auth endpoints are exempt so signing out and reading
+/// <c>/api/auth/me</c> still work — that is how the SPA learns it has been blocked.
+/// </para>
+/// See #609.
+/// </remarks>
+public sealed class BlockedAccountFilter(IHumanService humanService, IMemoryCache cache) : IAsyncActionFilter
+{
+    private static readonly TimeSpan CacheFor = TimeSpan.FromMinutes(1);
+
+    private readonly IHumanService _humanService = humanService;
+    private readonly IMemoryCache _cache = cache;
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var userId = context.HttpContext.User.FindFirst("userId")?.Value;
+        var path = context.HttpContext.Request.Path.Value ?? string.Empty;
+
+        if (string.IsNullOrEmpty(userId)
+            || path.StartsWith("/api/auth", StringComparison.OrdinalIgnoreCase))
+        {
+            await next();
+            return;
+        }
+
+        if (await this.IsBlockedAsync(userId))
+        {
+            context.Result = new ObjectResult(new
+            {
+                error = "This account has been blocked by an administrator.",
+            })
+            {
+                StatusCode = StatusCodes.Status403Forbidden,
+            };
+
+            return;
+        }
+
+        await next();
+    }
+
+    private async Task<bool> IsBlockedAsync(string userId)
+    {
+        var key = $"blocked:{userId}";
+        if (this._cache.TryGetValue(key, out bool blocked))
+        {
+            return blocked;
+        }
+
+        try
+        {
+            var human = await this._humanService.GetByIdAsync(userId);
+            blocked = human?.AdminDisable == 1;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // Never lock everyone out because PoracleNG blinked. A deleted account is handled elsewhere.
+            return false;
+        }
+
+        this._cache.Set(key, blocked, CacheFor);
+        return blocked;
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -187,6 +187,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.TrackingConflictExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AlarmValidationExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AccountGoneExceptionFilter>();
+    options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.BlockedAccountFilter>();
 });
 
 // Add Poracle services (DbContext, repositories, services, settings)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Blocking a user was not enforced by the API** ([#609](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/609)). The earlier fix only signed the browser out; the API kept serving a blocked account, and anything not using the web app was unaffected entirely. Blocking now refuses immediately, and unblocking restores access at once.
 - **Blocking a user did not block them** ([#597](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/597)). Blocking stopped notifications being delivered and left the web session untouched, so a blocked account kept full access for up to a day, and signing in again issued a fresh token.
 - **Rate limits could be bypassed by forging a header** ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)). `X-Forwarded-For` was believed from any caller, so a client could name a different address on each request and hand itself a fresh allowance — including on the sign-in endpoints the limit exists to protect. It is now honoured only from proxies the deployment declares, via `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS`.
 - **Per-user rate limits were shared by everyone behind the same address** ([#581](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/581)). The limiter ran before sign-in was established, so it could not tell users apart — one person on a shared connection could use up the allowance for everyone on it.
@@ -16,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ordinary radius and template edits were refused when a similar alarm existed** ([#606](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/606)). The clash check was stricter than Poracle itself, so it blocked edits that would have been perfectly safe — and the message suggested doing the very thing it was blocking. Pokemon edits could never clash at all and were refused anyway.
+- **Re-applying a quick pick with an unusable filter deleted its alarms** ([#607](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/607)) for six of the nine alarm types — the check that is supposed to run first only covered three.
+- **A quick pick holding a value alarms refuse could still be saved** ([#608](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/608)) for those same six types.
 - **Revoking a webhook delegate did not take effect until they signed in again** ([#600](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/600)) — up to a day of continued access, including the ability to act as that webhook.
 - **Bulk delete stopped at the first alarm that had already gone** ([#603](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/603)), reporting nothing and leaving the list unrefreshed even though some alarms had been deleted.
 - **An admin could save a quick pick holding a value alarms refuse** ([#604](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/604)), so every user who applied it got the error instead. It is now caught when the pick is saved.

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -464,6 +464,15 @@ public partial class QuickPickService(
     }
 
     /// <summary>Builds one alarm of the definition's type purely to run its validation.</summary>
+    /// <summary>Deserializes a definition's filters onto its model and validates them, writing nothing.</summary>
+    private static void BuildFromFilters<T>(Dictionary<string, object?> filters)
+        where T : new()
+    {
+        var json = JsonSerializer.Serialize(filters, JsonOptions);
+        var alarm = JsonSerializer.Deserialize<T>(json, JsonOptions) ?? new T();
+        EnsureValidAlarm(alarm!);
+    }
+
     private static void BuildSampleAlarm(
         QuickPickDefinition definition, int profileNo, QuickPickApplyRequest request)
     {
@@ -478,9 +487,31 @@ public partial class QuickPickService(
             case "maxbattle":
                 BuildMaxBattle(definition.Filters, profileNo, request);
                 break;
+            // The rest deserialize their filters straight onto the model. That IS validated on the way
+            // through -- but only after RemoveAsync has already deleted the alarms, so a re-apply of a pick
+            // with a bad filter destroyed them and created nothing. And a definition holding such a filter
+            // could still be SAVED, because the save check runs the same dry run. Six of the nine types
+            // fell through here. See #607, #608.
+            case "egg":
+                BuildFromFilters<Egg>(definition.Filters);
+                break;
+            case "quest":
+                BuildFromFilters<Quest>(definition.Filters);
+                break;
+            case "invasion":
+                BuildFromFilters<Invasion>(definition.Filters);
+                break;
+            case "lure":
+                BuildFromFilters<Lure>(definition.Filters);
+                break;
+            case "nest":
+                BuildFromFilters<Nest>(definition.Filters);
+                break;
+            case "gym":
+                BuildFromFilters<Gym>(definition.Filters);
+                break;
             default:
-                // The remaining types deserialize their filters straight onto the model, which the
-                // apply path validates on the way through; there is nothing extra to check here.
+                // An alarm type this build does not know. Apply will fail on it anyway.
                 break;
         }
     }

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingUpdateReconciler.cs
@@ -150,23 +150,18 @@ internal static partial class TrackingUpdateReconciler
 
         foreach (var candidate in body.EnumerateArray())
         {
-            foreach (var row in existing.EnumerateArray())
+            // Ordering matters here too: PoracleNG resolves each candidate against the FIRST row that
+            // classifies, so a later sibling is never touched. Checking every row refused bulk changes that
+            // would have been harmless -- and told the user to make the single change that was also
+            // refused. See #606.
+            var decisive = FirstClassifyingRow(existing, candidate, trackingType);
+            if (decisive is { Classification: RowMatch.Update } match
+                && !submittedUids.Contains(match.Uid))
             {
-                if (row.ValueKind != JsonValueKind.Object
-                    || !row.TryGetProperty("uid", out var rowUid)
-                    || rowUid.ValueKind != JsonValueKind.Number
-                    || submittedUids.Contains(rowUid.GetInt32()))
-                {
-                    continue;
-                }
-
-                if (WouldMergeInto(candidate, row, trackingType, isCreate: false))
-                {
-                    throw new TrackingConflictException(
-                        trackingType,
-                        "That radius would overwrite another alarm you did not select. "
-                        + "Change these alarms one at a time.");
-                }
+                throw new TrackingConflictException(
+                    trackingType,
+                    "That radius would overwrite another alarm you did not select. "
+                    + "Remove or edit that alarm first.");
             }
         }
     }
@@ -240,10 +235,16 @@ internal static partial class TrackingUpdateReconciler
         int oldUid,
         JsonElement submitted)
     {
-        // Creates as well as edits. PoracleNG resolves an Add that differs from an existing alarm by one
-        // updatable field into an UPDATE of that alarm, so the user pressed Add, got a 201, and quietly
-        // lost the alarm they had. oldUid 0 means there is no row of ours to exclude. See #561, #569.
         if (submitted.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        // Pokemon edits cannot merge at all: trackingMonster.go splits rows on req.UID.isSet() and sends
+        // uid-bearing ones straight to UpdateMonsterByUID, never reaching the diff. Every refusal this
+        // guard produced for a monster edit was therefore false. It is the only type that does this.
+        // See #606.
+        if (oldUid > 0 && string.Equals(trackingType, "pokemon", StringComparison.Ordinal))
         {
             return;
         }
@@ -255,8 +256,6 @@ internal static partial class TrackingUpdateReconciler
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            // Cannot see the siblings, so cannot rule a collision in or out. Let the edit through rather
-            // than refuse a legitimate one on a transport error; the pre-existing behaviour applies.
             return;
         }
 
@@ -265,25 +264,72 @@ internal static partial class TrackingUpdateReconciler
             return;
         }
 
+        // In list order, and stopping at the first row that classifies. DiffAndClassify walks the
+        // existing rows and BREAKS on the first duplicate-or-update match, so only that row is ever
+        // taken over -- a later sibling is irrelevant. Refusing on any match anywhere blocked ordinary
+        // radius and template edits whenever a similar alarm existed further down the list, and the
+        // error told the user to do the very thing that was blocked. See #606.
+        var decisive = FirstClassifyingRow(rows, submitted, trackingType);
+        if (decisive is not { Classification: RowMatch.Update } match)
+        {
+            return;
+        }
+
+        if (match.Uid == oldUid)
+        {
+            // PoracleNG would update the row being edited, which is exactly what was asked for.
+            return;
+        }
+
+        throw new TrackingConflictException(
+            trackingType,
+            "Another alarm of this type already uses those settings. Edit or remove that one instead.");
+    }
+
+    private enum RowMatch
+    {
+        Duplicate,
+        Update,
+    }
+
+    private readonly record struct ClassifiedRow(int Uid, RowMatch Classification);
+
+    /// <summary>
+    /// The first existing row PoracleNG would resolve the submission against, mirroring the break in
+    /// DiffAndClassify. Rows it would treat as unrelated, or as a separate insert, are skipped.
+    /// </summary>
+    private static ClassifiedRow? FirstClassifyingRow(
+        JsonElement rows, JsonElement submitted, string trackingType)
+    {
         foreach (var row in rows.EnumerateArray())
         {
             if (row.ValueKind != JsonValueKind.Object
                 || !row.TryGetProperty("uid", out var uid)
-                || uid.ValueKind != JsonValueKind.Number
-                || uid.GetInt32() == oldUid)
+                || uid.ValueKind != JsonValueKind.Number)
             {
                 continue;
             }
 
-            if (WouldMergeInto(submitted, row, trackingType, isCreate: oldUid <= 0))
+            var differences = CountUpdatableDifferences(submitted, row, trackingType);
+            if (differences is null)
             {
-                throw new TrackingConflictException(
-                    trackingType,
-                    "Another alarm of this type already uses those settings. Edit or remove that one instead.");
+                // An identity field differs: unrelated, or a separate insert. Keep looking.
+                continue;
+            }
+
+            if (differences == 0)
+            {
+                return new ClassifiedRow(uid.GetInt32(), RowMatch.Duplicate);
+            }
+
+            if (differences == 1)
+            {
+                return new ClassifiedRow(uid.GetInt32(), RowMatch.Update);
             }
         }
-    }
 
+        return null;
+    }
     /// <summary>Fields the comparison ignores entirely: PoracleNG owns them.</summary>
     private static readonly HashSet<string> AssignedByPoracle = new(StringComparer.Ordinal)
     {
@@ -329,8 +375,11 @@ internal static partial class TrackingUpdateReconciler
 
 
 
-    private static bool WouldMergeInto(
-        JsonElement submitted, JsonElement existing, string trackingType, bool isCreate)
+    /// <summary>
+    /// Counts differing updatable fields, or null when an identity field differs (no relation).
+    /// </summary>
+    private static int? CountUpdatableDifferences(
+        JsonElement submitted, JsonElement existing, string trackingType)
     {
         var updatableDifferences = 0;
 
@@ -379,11 +428,11 @@ internal static partial class TrackingUpdateReconciler
 
             if (!same)
             {
-                return false;
+                return null;
             }
         }
 
-        // This mirrors DiffTracking in PoracleNG's processor/internal/db/diff.go, at the commit prod runs:
+        // Mirrors DiffTracking in processor/internal/db/diff.go at the commit prod runs:
         //
         //     if totalDiffs == 0                            -> duplicate (nothing written)
         //     if totalDiffs == 1 && nonUpdatableDiffs == 0  -> UPDATE of that existing row
@@ -393,11 +442,7 @@ internal static partial class TrackingUpdateReconciler
         // two of them a collision, and refused every ordinary edit on both -- radius, template,
         // auto-delete, clearing the gym -- leaving them uneditable (#553).
         //
-        // Zero differences on an EDIT means the submission matches another row outright, which is a
-        // collision worth refusing. On a CREATE it means an exact duplicate, and PoracleNG already
-        // reports that as "already present" -- answered with 200 and no new uid since #459, which is
-        // what multi-select add relies on. Only the one-difference case takes an existing alarm over.
-        return isCreate ? updatableDifferences == 1 : updatableDifferences <= 1;
+        return updatableDifferences;
     }
 
     private static bool IsUpdatable(string fieldName, string trackingType) =>

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,6 +28,7 @@ public class AdminControllerTests : ControllerTestBase
             .Returns("test-impersonation-jwt");
         this._sut = new AdminController(
             this._humanService.Object,
+            new MemoryCache(new MemoryCacheOptions()),
             this._userPurgeService.Object,
             this._webhookDelegateService.Object,
             this._proxy.Object,


### PR DESCRIPTION
Closes #606, #607, #608, #609.

### #606 — the guard was stricter than PoracleNG
`DiffAndClassify` (`processor/internal/store/tracking.go:49-68`) walks the existing rows and **breaks on the first** duplicate-or-update match, so only that row is ever taken over. My guard refused if *any* row anywhere was within one updatable difference.

The result: an ordinary radius or template edit was refused whenever a similar alarm sat further down the list. Two things made it worse — the bulk path succeeded at the exact end state the single edit refused, and the error told the user to "change these alarms one at a time", which is the operation that was blocked.

Worse still for Pokemon: `trackingMonster.go:257,274` routes uid-bearing rows straight to `UpdateMonsterByUID`, bypassing the diff entirely. **Every** refusal on a monster edit was false.

The guard now finds the first row PoracleNG would classify and refuses only when that row is not the one being edited. Monster edits are exempt. The bulk sibling check got the same treatment.

This is the fourth revision of this guard, and the pattern is worth naming: each earlier version was correct about the danger and wrong about the boundary. The boundary is now taken from upstream's control flow rather than inferred from behaviour.

### #607 / #608 — the dry run covered three types of nine
`BuildSampleAlarm` makes re-apply validate before deleting (#532) and makes a bad definition fail at save (#604). It only handled monster, raid and maxbattle; egg, quest, invasion, lure, nest and gym fell through to a no-op — so **their filters were validated only after `RemoveAsync` had already deleted the alarms**.

### #609 — blocking was not enforced
#597 made `/api/auth/me` answer 401 so the SPA signs a blocked user out. That is a client-side courtesy: the API kept serving every other endpoint until the SPA polled, and a non-SPA caller was unaffected entirely. A global filter refuses now — cached per user for a minute, and evicted when an admin blocks or unblocks so the change lands on the next request. Auth endpoints stay open, which is how the SPA learns it has been blocked.

My first live check of this appeared to fail; the cause was my own cache holding the `false` recorded moments earlier. The eviction is why it now takes effect immediately.

### Verified against a live API
```
#606  monster 500m/IV90 + 1000m/IV95 -> edit the first to 1000m -> 200, BOTH survive   (was 409)
      raid ZZA@500 + ZZB@1000        -> edit ZZA to 1000m      -> 200, both survive    (was 409)
      edit that WOULD take over a preceding row                -> 409, both intact
      Add that would take over                                  -> 409
#609  block   -> /api/monsters 403, /api/dashboard 403, /api/areas 403, /api/auth/me 401
      unblock -> 200
      an ordinary admin session throughout -> 200
```

Suite green: 1798.

Eleven findings from this sweep remain and are next.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX
