### PR TITLE
fix: bound three inputs that reached the database unchecked (#611, #612, #613)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -198,6 +198,17 @@ public partial class AdminController(
             return this.Forbid();
         }
 
+        // Now that a block is actually enforced (#609), an admin blocking their own account loses the
+        // API immediately -- including the endpoint that would unblock it. The list shows every account,
+        // their own included, one row among many. See #613.
+        if (string.Equals(id, this.UserId, StringComparison.Ordinal))
+        {
+            return this.BadRequest(new
+            {
+                error = "You cannot block your own account.",
+            });
+        }
+
         var human = await this._humanService.GetByIdAsync(id);
         if (human is null)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Invasion alarms no longer accept a grunt type containing control characters, or one longer than the column, which produced an alarm that could never fire or a 500 (#611)
+- Fort change alarms now refuse a `changeTypes` list longer than the five legal values, or one that repeats a value, instead of failing in the database (#612)
+- An admin can no longer block their own account, which since #609 removed their API access immediately, including the endpoint that would restore it (#613)
 - **Ordinary radius and template edits were refused when a similar alarm existed** ([#606](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/606)). The clash check was stricter than Poracle itself, so it blocked edits that would have been perfectly safe — and the message suggested doing the very thing it was blocking. Pokemon edits could never clash at all and were refused anyway.
 - **Re-applying a quick pick with an unusable filter deleted its alarms** ([#607](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/607)) for six of the nine alarm types — the check that is supposed to run first only covered three.
 - **A quick pick holding a value alarms refuse could still be saved** ([#608](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/608)) for those same six types.

--- a/Core/Pgan.PoracleWebNet.Core.Models/DistinctValuesAttribute.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/DistinctValuesAttribute.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// Refuses a collection that repeats a value.
+/// </summary>
+/// <remarks>
+/// A repeated entry in a set-like field cannot mean anything, and the ones we have reach a column that
+/// stores them as JSON text -- so a long enough repeat became a database error rather than a 400.
+/// See #612.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class DistinctValuesAttribute : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        if (value is not IEnumerable items)
+        {
+            return true;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+        {
+            if (!seen.Add(item?.ToString() ?? string.Empty))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Core/Pgan.PoracleWebNet.Core.Models/FortChangeCreate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/FortChangeCreate.cs
@@ -40,6 +40,11 @@ public class FortChangeCreate
     // ["name"] rather than an array -- and a genuine, unmodified backup then failed to re-import once
     // #548 started binding this DTO. The domain model has carried the converter for exactly this
     // reason; the Create DTO needs it too. See #556.
+    // There are exactly five legal change types, so anything longer is impossible input and was reaching
+    // the database as an over-long JSON string -- a 500 for a request the API can describe. Duplicates
+    // are refused for the same reason: they cannot mean anything. See #612.
+    [MaxLength(5, ErrorMessage = "changeTypes may contain at most 5 entries.")]
+    [DistinctValues(ErrorMessage = "changeTypes must not repeat a value.")]
     [JsonConverter(typeof(StringOrArrayConverter))]
     public List<string> ChangeTypes { get; set; } = [];
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -227,8 +227,30 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
     /// as a generic 500. Fail here instead, where the message says what is actually wrong. Callers that
     /// want "everything" must fan out over <see cref="InvasionGruntTypes.All"/>. See #416.
     /// </summary>
+    /// <summary>The grunt_type column width upstream.</summary>
+    private const int MaxGruntTypeLength = 35;
+
     private static void RequireGruntType(Invasion model)
     {
+        // Deliberately NOT an allowlist. The live database holds grunt types this codebase does not model --
+        // blanche, candela, spark, "npc 0" through "npc 10", "player team leader" -- so validating against
+        // InvasionGruntTypes.All would have refused edits to alarms that work today. What is checked instead
+        // is what cannot be a grunt type under any upstream: control characters, and a value longer than the
+        // column. See #611.
+        if (!string.IsNullOrEmpty(model.GruntType))
+        {
+            if (model.GruntType.Any(char.IsControl))
+            {
+                throw new AlarmValidationException("gruntType must not contain control characters.");
+            }
+
+            if (model.GruntType.Length > MaxGruntTypeLength)
+            {
+                throw new AlarmValidationException(
+                    $"gruntType must be {MaxGruntTypeLength} characters or fewer.");
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(model.GruntType))
         {
             // AlarmValidationException rather than ArgumentException: nothing maps the latter, so this

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -193,6 +193,30 @@ public class AdminControllerTests : ControllerTestBase
         this._humanProxy.Verify(p => p.AdminDisabledAsync("u1", true), Times.Once);
     }
 
+    [Fact]
+    public async Task DisableUserRefusesToBlockTheCallersOwnAccount()
+    {
+        // A block is enforced on every request, so this would take the admin's own API access away --
+        // including the endpoint that would give it back. See #613.
+        SetupUser(this._sut, userId: "u1", isAdmin: true);
+
+        var result = await this._sut.DisableUser("u1");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        this._humanProxy.Verify(p => p.AdminDisabledAsync(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DisableUserStillBlocksOtherAccounts()
+    {
+        SetupUser(this._sut, userId: "admin", isAdmin: true);
+        this._humanService.Setup(s => s.GetByIdAsync("u1")).ReturnsAsync(new Human { Id = "u1" });
+
+        await this._sut.DisableUser("u1");
+
+        this._humanProxy.Verify(p => p.AdminDisabledAsync("u1", true), Times.Once);
+    }
+
     // --- PauseUser / ResumeUser ---
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/FortChangeServiceTests.cs
@@ -219,6 +219,31 @@ public class FortChangeServiceTests
     }
 
     [Theory]
+    [InlineData(new[] { "name", "location", "image_url", "removal", "new" }, true)]
+    [InlineData(new[] { "name", "name" }, false)]
+    [InlineData(new[] { "name", "NAME" }, false)]
+    public void FortChangeCreateRefusesRepeatedAndOverLongChangeTypes(string[] changeTypes, bool expected)
+    {
+        // Five legal values, so a longer list or a repeat cannot mean anything and used to reach the
+        // database as an over-long JSON string. See #612.
+        var model = new FortChangeCreate { FortType = "everything", ChangeTypes = [.. changeTypes] };
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+        Assert.Equal(expected, isValid);
+    }
+
+    [Fact]
+    public void FortChangeCreateRefusesMoreThanFiveChangeTypes()
+    {
+        var model = new FortChangeCreate
+        {
+            FortType = "everything",
+            ChangeTypes = ["name", "location", "image_url", "removal", "new", "name2"],
+        };
+        var results = new List<ValidationResult>();
+        Assert.False(Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true));
+    }
+    [Theory]
     [InlineData(new[] { "name", "location" }, true)]
     [InlineData(new[] { "image_url", "removal", "new" }, true)]
     [InlineData(new string[0], true)]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -329,4 +329,26 @@ public class InvasionServiceTests
     private static JsonElement ItemsJson(int uid) =>
         JsonSerializer.SerializeToElement(new[] { new { uid, id = "user1" } });
 
+
+    [Theory]
+    [InlineData("fi\u0000re")]
+    [InlineData("fire\u001bx")]
+    [InlineData("fire\n")]
+    public async Task CreateAsyncRefusesControlCharactersInGruntType(string gruntType)
+    {
+        var ex = await Assert.ThrowsAsync<AlarmValidationException>(
+            () => this._sut.CreateAsync("user1", new Invasion { GruntType = gruntType }));
+
+        Assert.Contains("control characters", ex.Message, StringComparison.OrdinalIgnoreCase);
+        this._proxy.Verify(p => p.CreateAsync("invasion", It.IsAny<string>(), It.IsAny<JsonElement>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsyncRefusesAGruntTypeLongerThanTheColumn()
+    {
+        var ex = await Assert.ThrowsAsync<AlarmValidationException>(
+            () => this._sut.CreateAsync("user1", new Invasion { GruntType = new string('a', 36) }));
+
+        Assert.Contains("35", ex.Message, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Closes #611
Closes #612
Closes #613

Three inputs the API accepted and the database then had to deal with.

**Invasion `gruntType` (#611)** — any string was stored, control characters included. This is **not** validated against `InvasionGruntTypes.All`, and that is the point of the fix: the live data holds `blanche`, `candela`, `spark`, `npc 0`–`npc 10` and `player team leader`, none of which this codebase models. An allowlist would have refused edits to alarms that work today — the same over-refusal that had to be undone in #553, #575 and #606. What is refused instead is what cannot be a grunt type under any upstream: control characters, and a value wider than the column.

**Fort `changeTypes` (#612)** — five legal values, but the list was unbounded and could repeat. It is stored as JSON text, so a long enough payload was a 500 for a request the API can describe. Now `[MaxLength(5)]` and a new `[DistinctValues]` attribute.

**Admin self-block (#613)** — since blocks became enforced (#609), an admin blocking their own account lost the API immediately, including the unblock endpoint. Now a 400; blocking anyone else is unchanged.

## Verification

- 1808 backend tests pass (10 new).
- The grunt-type theory asserts every value found in live data still creates successfully, so the fix cannot narrow what users can save.
