### PR TITLE
fix: six defects across raids, auth, geofence review and settings (#615-#620)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminGeofenceController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminGeofenceController.cs
@@ -33,6 +33,17 @@ public partial class AdminGeofenceController(IUserGeofenceService userGeofenceSe
         return this.Ok(geofences);
     }
 
+    /// <summary>Adds the cached Discord avatars the admin list renders. See #618.</summary>
+    private static void AddAvatars(UserGeofence geofence)
+    {
+        geofence.OwnerAvatarUrl = Services.AvatarCacheService.GetAvatarOrDefault(geofence.HumanId);
+
+        if (!string.IsNullOrEmpty(geofence.ReviewedBy))
+        {
+            geofence.ReviewedByAvatarUrl = Services.AvatarCacheService.GetAvatarOrDefault(geofence.ReviewedBy);
+        }
+    }
+
     [HttpGet("submissions")]
     public async Task<IActionResult> GetSubmissions()
     {
@@ -101,6 +112,9 @@ public partial class AdminGeofenceController(IUserGeofenceService userGeofenceSe
         {
             var result = await this._userGeofenceService.ApproveSubmissionAsync(
                 this.UserId, id, request?.PromotedName, request?.ParentId, request?.GroupName);
+            // The SPA swaps the list row for this response, so it needs the same avatars the list
+            // projection adds -- without them the card fell back to raw snowflakes. See #618.
+            AddAvatars(result);
             return this.Ok(result);
         }
         catch (KojiOperationException ex)
@@ -145,6 +159,9 @@ public partial class AdminGeofenceController(IUserGeofenceService userGeofenceSe
         try
         {
             var result = await this._userGeofenceService.RejectSubmissionAsync(this.UserId, id, request.ReviewNotes);
+            // The SPA swaps the list row for this response, so it needs the same avatars the list
+            // projection adds -- without them the card fell back to raw snowflakes. See #618.
+            AddAvatars(result);
             return this.Ok(result);
         }
         catch (KojiOperationException ex)

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -34,6 +34,7 @@ public partial class AuthController(
 {
     private const string EnableDiscordKey = "enable_discord";
     private const string EnableTelegramKey = "enable_telegram";
+    private const string TelegramBotUsernameKey = "telegram_bot";
     private const string EnableOidcKey = "enable_oidc";
     private const string EnableOidcSloKey = "enable_oidc_slo";
 
@@ -635,8 +636,29 @@ public partial class AuthController(
         return this.Ok(new
         {
             enabled = this._telegramSettings.Enabled && !disabledBySetting,
-            botUsername = this._telegramSettings.BotUsername
+            botUsername = await this.ResolveTelegramBotUsernameAsync(),
         });
+    }
+
+    /// <summary>
+    /// The Telegram bot username the login widget is built with.
+    /// </summary>
+    /// <remarks>
+    /// Configuration wins; the <c>telegram_bot</c> site setting is the fallback. The admin page has
+    /// always offered that field and nothing has ever read it, so an admin filling it in to fix a dead
+    /// Telegram button saw it save and change nothing. Precedence is this way round on purpose: a
+    /// deployment whose env var is set and working must not have its widget repointed at whatever was
+    /// typed into the UI back when the field was inert. See #620.
+    /// </remarks>
+    private async Task<string> ResolveTelegramBotUsernameAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(this._telegramSettings.BotUsername))
+        {
+            return this._telegramSettings.BotUsername;
+        }
+
+        var configured = await this._siteSettingService.GetValueAsync(TelegramBotUsernameKey);
+        return configured?.Trim().TrimStart('@') ?? string.Empty;
     }
 
     /// <summary>
@@ -702,7 +724,7 @@ public partial class AuthController(
             {
                 configured = telegramConfigured,
                 enabledByAdmin = !telegramDisabledByAdmin,
-                botUsername = telegramConfigured ? this._telegramSettings.BotUsername : string.Empty,
+                botUsername = telegramConfigured ? await this.ResolveTelegramBotUsernameAsync() : string.Empty,
             },
             oidc = new
             {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.spec.ts
@@ -49,6 +49,23 @@ describe('errorInterceptor', () => {
     expect(toast.error).toHaveBeenCalledWith('HTTP_ERROR.UNAUTHORIZED');
   });
 
+  it('clears the whole session on a 401, not just the access token', () => {
+    // The admin token is the higher-privilege credential an impersonating admin leaves behind, and
+    // stopImpersonating() would install it as the active token. See #616.
+    localStorage.setItem('poracle_token', 'expired-token');
+    localStorage.setItem('poracle_admin_token', 'admin-token');
+    localStorage.setItem('poracle_refresh_token', 'refresh-token');
+    localStorage.setItem('poracle_token_expires_at', '1');
+
+    http.get('/api/dashboard').subscribe({ error: () => {} });
+    httpMock.expectOne('/api/dashboard').flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(localStorage.getItem('poracle_token')).toBeNull();
+    expect(localStorage.getItem('poracle_admin_token')).toBeNull();
+    expect(localStorage.getItem('poracle_refresh_token')).toBeNull();
+    expect(localStorage.getItem('poracle_token_expires_at')).toBeNull();
+  });
+
   it('should show permission toast for 403 without disableKey', () => {
     http.get('/api/admin/users').subscribe({ error: () => {} });
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { catchError, throwError } from 'rxjs';
 
 import { ToastService } from '../services/toast.service';
+import { TokenStoreService } from '../services/token-store.service';
 
 /** Endpoints where errors should be silently swallowed (no user-facing toast). */
 const SILENT_URL_PATTERNS = [
@@ -29,6 +30,7 @@ function isAuthCallbackRoute(): boolean {
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const toast = inject(ToastService);
+  const tokenStore = inject(TokenStoreService);
   const router = inject(Router);
   const translate = inject(TranslateService);
 
@@ -38,7 +40,15 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
 
       // On 401, clear token and redirect — but NOT during OAuth callback flow or login page
       if (error.status === 401 && !isAuthCallbackRoute()) {
+        // The whole session, not just the access token. Three keys used to survive the app deciding the
+        // session was invalid: poracle_admin_token -- the higher-privilege credential an impersonating
+        // admin leaves behind, which stopImpersonating() would then install as the active token -- plus
+        // the refresh token and its expiry, so the next load tried to refresh a session the server had
+        // already rejected. Navigation is deliberately left alone: routing through AuthService.logout()
+        // would append loggedout=1 and suppress the OIDC auto-redirect. See #616.
         localStorage.removeItem('poracle_token');
+        localStorage.removeItem('poracle_admin_token');
+        tokenStore.clear();
         // Preserve any existing query params (e.g. ?error=missing_required_role)
         const params = new URLSearchParams(window.location.search);
         router.navigate(['/login'], { queryParams: Object.fromEntries(params) });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/scanner.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/scanner.service.spec.ts
@@ -2,6 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateService } from '@ngx-translate/core';
 
 import { ScannerService } from './scanner.service';
 
@@ -13,7 +14,12 @@ describe('ScannerService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting(), { provide: MatSnackBar, useValue: { open: jest.fn() } }],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MatSnackBar, useValue: { open: jest.fn() } },
+        { provide: TranslateService, useValue: { instant: jest.fn((key: string) => key) } },
+      ],
     });
     service = TestBed.inject(ScannerService);
     httpMock = TestBed.inject(HttpTestingController);
@@ -44,7 +50,8 @@ describe('ScannerService', () => {
     service.searchGyms('abc').subscribe(r => (result = r));
     const req = httpMock.expectOne(r => r.url === '/api/scanner/gyms');
     req.flush('rate limited', { status: 429, statusText: 'Too Many Requests' });
-    expect(snackBar.open).toHaveBeenCalledWith(expect.stringContaining('Too many scanner requests'), 'OK', { duration: 4000 });
+    // Translated now, not a raw English sentence. See #619.
+    expect(snackBar.open).toHaveBeenCalledWith('GYM_PICKER.RATE_LIMITED', 'TOAST.OK', { duration: 4000 });
     expect(result).toEqual([]);
   });
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/scanner.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/scanner.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -18,6 +19,7 @@ export interface GymSearchResult {
 export class ScannerService {
   private readonly http = inject(HttpClient);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly translate = inject(TranslateService);
 
   getGymById(id: string): Observable<GymSearchResult | null> {
     return this.http
@@ -40,7 +42,10 @@ export class ScannerService {
 
   private handleError<T>(err: HttpErrorResponse, fallback: T): Observable<T> {
     if (err.status === 429) {
-      this.snackBar.open('Too many scanner requests — please slow down.', 'OK', { duration: 4000 });
+      // Raw English in all eleven locales, in a service whose neighbours all translate. See #619.
+      this.snackBar.open(this.translate.instant('GYM_PICKER.RATE_LIMITED'), this.translate.instant('TOAST.OK'), {
+        duration: 4000,
+      });
     }
     return of(fallback);
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/dashboard/dashboard.component.ts
@@ -11,7 +11,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router, RouterModule } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { switchMap, forkJoin, EMPTY } from 'rxjs';
+import { switchMap, forkJoin, EMPTY, catchError } from 'rxjs';
 
 import { DashboardCounts, GeofenceData, Location, Profile, WeatherData } from '../../core/models';
 import { AreaService } from '../../core/services/area.service';
@@ -495,6 +495,9 @@ export class DashboardComponent implements OnInit {
           }
           return EMPTY;
         }),
+        // Same 403 as #617: without this the disabled-location case threw instead of leaving the
+        // location panel empty.
+        catchError(() => EMPTY),
       )
       .subscribe();
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
@@ -6,7 +6,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
-import { finalize } from 'rxjs';
+import { catchError, finalize, of } from 'rxjs';
 
 import { ActiveHourEntry, compressDayRange, formatTime12h, groupActiveHours } from '../../../core/models/active-hours.models';
 import { I18nService } from '../../../core/services/i18n.service';
@@ -78,10 +78,15 @@ export class SummaryScheduleDialogComponent {
       .pipe(finalize(() => this.loading.set(false)))
       .subscribe(schedule => this.schedule.set(schedule));
 
-    this.locationService.getLocation().subscribe(location => {
-      this.userLat.set(location?.latitude ?? 0);
-      this.userLon.set(location?.longitude ?? 0);
-    });
+    // 0,0 is already the default, and is what a disabled or unset location should leave in place --
+    // without an error arm the same 403 threw instead. See #617.
+    this.locationService
+      .getLocation()
+      .pipe(catchError(() => of(null)))
+      .subscribe(location => {
+        this.userLat.set(location?.latitude ?? 0);
+        this.userLon.set(location?.longitude ?? 0);
+      });
   }
 
   /** Remove the schedule entirely (clear all rules). */

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.html
@@ -55,9 +55,6 @@
               @if (selectedPokemonIds().length > 0) {
                 <p class="selection-count">{{ 'RAIDS.POKEMON_SELECTED' | translate: { count: selectedPokemonIds().length } }}</p>
               }
-
-              <h4>{{ 'RAIDS.RAID_LEVEL_LABEL' | translate }}</h4>
-              <app-level-selector pickerType="boss" [value]="bossLevelArray()" (valueChange)="onBossLevelChange($event)" />
             </div>
           </mat-tab>
         </mat-tab-group>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-add-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
@@ -64,11 +64,6 @@ export class RaidAddDialogComponent {
   private readonly raidService = inject(RaidService);
   private readonly snackBar = inject(MatSnackBar);
 
-  /** Single-select Boss-tab level; defaults to PoracleNG's "any" sentinel (9000). */
-  bossLevel = signal<number>(ANY_LEVEL_VALUE);
-  /** Stable array reference for the level selector input — prevents per-tick re-binding. */
-  bossLevelArray = computed(() => [this.bossLevel()]);
-
   commonForm = this.fb.group({
     clean: [false],
     distanceKm: [this.alertDefaults.defaultDistanceKm()],
@@ -97,9 +92,6 @@ export class RaidAddDialogComponent {
   }
 
   /** Boss tab is single-select; the selector emits an array of length 0 or 1. */
-  onBossLevelChange(values: number[]): void {
-    this.bossLevel.set(values[0] ?? ANY_LEVEL_VALUE);
-  }
 
   onDistanceModeChange(): void {
     if (this.commonForm.controls.distanceMode.value === 'areas') {
@@ -162,8 +154,9 @@ export class RaidAddDialogComponent {
         creates.push(this.eggService.create(egg));
       }
     } else {
-      // By Boss
-      const bossLevel = this.bossLevel();
+      // By Boss. The level is always the "any" sentinel, never a chosen one: trackingRaid.go rewrites
+      // level to 9000 for every alarm carrying a specific pokemon_id, so the tab used to show a level
+      // picker whose value could not survive the request. See #615.
       for (const pokemonId of this.selectedPokemonIds()) {
         const raid: RaidCreate = {
           clean,
@@ -172,7 +165,7 @@ export class RaidAddDialogComponent {
           exclusive: 0,
           form: 0,
           gymId: this.selectedGymId() ?? '',
-          level: bossLevel,
+          level: ANY_LEVEL_VALUE,
           move: 9000,
           pokemonId,
           rsvpChanges: common.rsvpChanges ?? 0,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+
+import { DeliveryPreviewComponent } from './delivery-preview.component';
+import { AreaService } from '../../../core/services/area.service';
+import { LocationService } from '../../../core/services/location.service';
+
+describe('DeliveryPreviewComponent', () => {
+  let areaService: { getSelected: jest.Mock };
+  let locationService: { getDistanceMapUrl: jest.Mock; getLocation: jest.Mock };
+
+  function create(): DeliveryPreviewComponent {
+    const fixture = TestBed.createComponent(DeliveryPreviewComponent);
+    return fixture.componentInstance;
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    areaService = { getSelected: jest.fn().mockReturnValue(of([])) };
+    locationService = {
+      getDistanceMapUrl: jest.fn().mockReturnValue(of({ url: 'map.png' })),
+      getLocation: jest.fn().mockReturnValue(of({ latitude: 1, longitude: 2 })),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService(),
+        { provide: AreaService, useValue: areaService },
+        { provide: LocationService, useValue: locationService },
+      ],
+      imports: [DeliveryPreviewComponent],
+    });
+  });
+
+  it('stops loading when the location request fails', () => {
+    // disable_location answers 403 here. A next-only subscriber left the spinner running in every add
+    // and edit alarm dialog the moment distance mode was picked. See #617.
+    locationService.getLocation.mockReturnValue(throwError(() => ({ status: 403 })));
+
+    const component = create();
+    component.mode = 'distance';
+    component.distanceKm = 5;
+    component.ngOnChanges({});
+
+    expect(component.loading()).toBe(false);
+    expect(component.mapUrl()).toBe('');
+  });
+
+  it('shows the map when the location resolves', () => {
+    const component = create();
+    component.mode = 'distance';
+    component.distanceKm = 5;
+    component.ngOnChanges({});
+
+    expect(component.loading()).toBe(false);
+    expect(component.mapUrl()).toBe('map.png');
+    expect(locationService.getDistanceMapUrl).toHaveBeenCalledWith(1, 2, 5000);
+  });
+
+  it('does not fetch a map when the user has no location set', () => {
+    locationService.getLocation.mockReturnValue(of({ latitude: 0, longitude: 0 }));
+
+    const component = create();
+    component.mode = 'distance';
+    component.distanceKm = 5;
+    component.ngOnChanges({});
+
+    expect(component.loading()).toBe(false);
+    expect(locationService.getDistanceMapUrl).not.toHaveBeenCalled();
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/delivery-preview/delivery-preview.component.ts
@@ -4,6 +4,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
+import { catchError, of } from 'rxjs';
 
 import { AreaService } from '../../../core/services/area.service';
 import { LocationService } from '../../../core/services/location.service';
@@ -43,17 +44,23 @@ export class DeliveryPreviewComponent implements OnChanges {
         this.mapUrl.set('');
         this.loading.set(true);
 
-        // Get user location first, then fetch distance map
-        this.locationService.getLocation().subscribe(loc => {
-          if (loc && (loc.latitude !== 0 || loc.longitude !== 0)) {
-            this.locationService.getDistanceMapUrl(loc.latitude, loc.longitude, distanceMeters).subscribe(result => {
+        // Get user location first, then fetch distance map. The error arm matters: with disable_location
+        // on, GET /api/location answers 403, and a next-only subscriber left `loading` set -- so the
+        // preview inside every add and edit alarm dialog span forever the moment distance mode was
+        // picked. No location means no map, which is what an empty mapUrl already renders. See #617.
+        this.locationService
+          .getLocation()
+          .pipe(catchError(() => of(null)))
+          .subscribe(loc => {
+            if (loc && (loc.latitude !== 0 || loc.longitude !== 0)) {
+              this.locationService.getDistanceMapUrl(loc.latitude, loc.longitude, distanceMeters).subscribe(result => {
+                this.loading.set(false);
+                if (result?.url) this.mapUrl.set(result.url);
+              });
+            } else {
               this.loading.set(false);
-              if (result?.url) this.mapUrl.set(result.url);
-            });
-          } else {
-            this.loading.set(false);
-          }
-        });
+            }
+          });
       }
     }
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Søg efter et gym (valgfrit)",
     "SEARCH_HINT": "Skriv gym-navn...",
-    "CLEAR_ARIA": "Ryd gym-valg"
+    "CLEAR_ARIA": "Ryd gym-valg",
+    "RATE_LIMITED": "For mange scanneranmodninger — sæt farten lidt ned."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Notifikationer sendes for disse områder:",
@@ -1563,7 +1564,7 @@
     "ENABLE_TELEGRAM_LABEL": "Aktiver Telegram-login",
     "ENABLE_TELEGRAM_DESC": "Tillad Telegram-login på dette site. Kræver TELEGRAM_ENABLED=true, bot-token og bot-brugernavn i .env (servergenstart kræves efter .env-ændringer).",
     "TELEGRAM_BOT_LABEL": "Bot-brugernavn",
-    "TELEGRAM_BOT_DESC": "Telegram-bot-brugernavn (uden @).",
+    "TELEGRAM_BOT_DESC": "Telegram-bot-brugernavn (uden @). Bruges, når TELEGRAM_BOT_USERNAME ikke er konfigureret.",
     "ENABLE_DISCORD_LABEL": "Aktiver Discord-login",
     "ENABLE_DISCORD_DESC": "Tillad Discord-login på dette site. Kræver Discord Client ID og Client Secret i .env (servergenstart kræves efter .env-ændringer). Påvirker ikke PoracleNG-bot-levering.",
     "PROVIDER_URL_LABEL": "Kortflise-URL",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Arena suchen (optional)",
     "SEARCH_HINT": "Arena-Name eingeben...",
-    "CLEAR_ARIA": "Arena-Auswahl löschen"
+    "CLEAR_ARIA": "Arena-Auswahl löschen",
+    "RATE_LIMITED": "Zu viele Scanner-Anfragen — bitte etwas langsamer."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Benachrichtigungen werden für diese Gebiete gesendet:",
@@ -1554,7 +1555,7 @@
     "ENABLE_TELEGRAM_LABEL": "Telegram-Anmeldung aktivieren",
     "ENABLE_TELEGRAM_DESC": "Telegram-Anmeldung auf dieser Website zulassen. Erfordert TELEGRAM_ENABLED=true, Bot-Token und Bot-Benutzernamen in .env (Server-Neustart nach .env-Änderungen erforderlich).",
     "TELEGRAM_BOT_LABEL": "Bot-Benutzername",
-    "TELEGRAM_BOT_DESC": "Telegram-Bot-Benutzername (ohne @).",
+    "TELEGRAM_BOT_DESC": "Telegram-Bot-Benutzername (ohne @). Wird verwendet, wenn TELEGRAM_BOT_USERNAME nicht konfiguriert ist.",
     "ENABLE_DISCORD_LABEL": "Discord-Anmeldung aktivieren",
     "ENABLE_DISCORD_DESC": "Discord-Anmeldung auf dieser Website zulassen. Erfordert Discord Client ID und Client Secret in .env (Server-Neustart nach .env-Änderungen erforderlich). Betrifft nicht die PoracleNG-Bot-Zustellung.",
     "ENABLE_OIDC_LABEL": "Externe SSO-Anmeldung aktivieren",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Search for a gym (optional)",
     "SEARCH_HINT": "Type gym name...",
-    "CLEAR_ARIA": "Clear gym selection"
+    "CLEAR_ARIA": "Clear gym selection",
+    "RATE_LIMITED": "Too many scanner requests — please slow down."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Notifications will be sent for these areas:",
@@ -1549,7 +1550,7 @@
     "ENABLE_TELEGRAM_LABEL": "Enable Telegram Login",
     "ENABLE_TELEGRAM_DESC": "Allow Telegram login on this site. Requires TELEGRAM_ENABLED=true, bot token, and bot username in .env (server restart required for .env changes).",
     "TELEGRAM_BOT_LABEL": "Bot Username",
-    "TELEGRAM_BOT_DESC": "Telegram bot username (without @).",
+    "TELEGRAM_BOT_DESC": "Telegram bot username (without @). Used when TELEGRAM_BOT_USERNAME is not configured.",
     "ENABLE_DISCORD_LABEL": "Enable Discord Login",
     "ENABLE_DISCORD_DESC": "Allow Discord login on this site. Requires Discord Client ID and Client Secret in .env (server restart required for .env changes). Does not affect PoracleNG bot delivery.",
     "ENABLE_OIDC_LABEL": "Enable External SSO Login",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Buscar un gimnasio (opcional)",
     "SEARCH_HINT": "Escribe nombre del gimnasio...",
-    "CLEAR_ARIA": "Borrar selección de gimnasio"
+    "CLEAR_ARIA": "Borrar selección de gimnasio",
+    "RATE_LIMITED": "Demasiadas solicitudes al escáner: reduce el ritmo."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Se enviarán notificaciones para estas zonas:",
@@ -1555,7 +1556,7 @@
     "ENABLE_TELEGRAM_LABEL": "Activar inicio de sesión con Telegram",
     "ENABLE_TELEGRAM_DESC": "Permite iniciar sesión con Telegram en este sitio. Requiere TELEGRAM_ENABLED=true, bot token y bot username en .env (reinicio necesario tras cambios en .env).",
     "TELEGRAM_BOT_LABEL": "Nombre de usuario del bot",
-    "TELEGRAM_BOT_DESC": "Nombre de usuario del bot de Telegram (sin @).",
+    "TELEGRAM_BOT_DESC": "Nombre de usuario del bot de Telegram (sin @). Se usa cuando TELEGRAM_BOT_USERNAME no está configurado.",
     "ENABLE_DISCORD_LABEL": "Activar inicio de sesión con Discord",
     "ENABLE_DISCORD_DESC": "Permite iniciar sesión con Discord en este sitio. Requiere Discord Client ID y Client Secret en .env (reinicio necesario tras cambios en .env). No afecta la entrega del bot PoracleNG.",
     "ENABLE_OIDC_LABEL": "Habilitar inicio de sesión SSO externo",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Rechercher une arène (optionnel)",
     "SEARCH_HINT": "Tape le nom de l'arène...",
-    "CLEAR_ARIA": "Effacer la sélection d'arène"
+    "CLEAR_ARIA": "Effacer la sélection d'arène",
+    "RATE_LIMITED": "Trop de requêtes au scanner — ralentissez un peu."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Les notifications seront envoyées pour ces zones :",
@@ -1555,7 +1556,7 @@
     "ENABLE_TELEGRAM_LABEL": "Activer la connexion Telegram",
     "ENABLE_TELEGRAM_DESC": "Autoriser la connexion Telegram sur ce site. Nécessite TELEGRAM_ENABLED=true, le bot token et le bot username dans .env (redémarrage du serveur requis pour les changements .env).",
     "TELEGRAM_BOT_LABEL": "Nom d'utilisateur du bot",
-    "TELEGRAM_BOT_DESC": "Nom d'utilisateur du bot Telegram (sans @).",
+    "TELEGRAM_BOT_DESC": "Nom d'utilisateur du bot Telegram (sans @). Utilisé lorsque TELEGRAM_BOT_USERNAME n’est pas configuré.",
     "ENABLE_DISCORD_LABEL": "Activer la connexion Discord",
     "ENABLE_DISCORD_DESC": "Autoriser la connexion Discord sur ce site. Nécessite le Discord Client ID et Client Secret dans .env (redémarrage du serveur requis pour les changements .env). N'affecte pas la livraison du bot PoracleNG.",
     "ENABLE_OIDC_LABEL": "Activer la connexion SSO externe",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Cerca una palestra (opzionale)",
     "SEARCH_HINT": "Scrivi nome palestra...",
-    "CLEAR_ARIA": "Cancella selezione palestra"
+    "CLEAR_ARIA": "Cancella selezione palestra",
+    "RATE_LIMITED": "Troppe richieste allo scanner: rallenta un po’."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Le notifiche verranno inviate per queste aree:",
@@ -1554,7 +1555,7 @@
     "ENABLE_TELEGRAM_LABEL": "Abilita accesso Telegram",
     "ENABLE_TELEGRAM_DESC": "Consenti l'accesso Telegram su questo sito. Richiede TELEGRAM_ENABLED=true, bot token e bot username in .env (riavvio del server necessario dopo modifiche a .env).",
     "TELEGRAM_BOT_LABEL": "Nome utente del bot",
-    "TELEGRAM_BOT_DESC": "Nome utente del bot Telegram (senza @).",
+    "TELEGRAM_BOT_DESC": "Nome utente del bot Telegram (senza @). Usato quando TELEGRAM_BOT_USERNAME non è configurato.",
     "ENABLE_DISCORD_LABEL": "Abilita accesso Discord",
     "ENABLE_DISCORD_DESC": "Consenti l'accesso Discord su questo sito. Richiede Discord Client ID e Client Secret in .env (riavvio del server necessario dopo modifiche a .env). Non influenza la consegna del bot PoracleNG.",
     "GROUP_OIDC": "SSO Esterno",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Zoek een gym (optioneel)",
     "SEARCH_HINT": "Typ gym naam...",
-    "CLEAR_ARIA": "Gymselectie wissen"
+    "CLEAR_ARIA": "Gymselectie wissen",
+    "RATE_LIMITED": "Te veel scannerverzoeken — doe het wat rustiger aan."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Meldingen worden verstuurd voor deze gebieden:",
@@ -1555,7 +1556,7 @@
     "ENABLE_TELEGRAM_LABEL": "Telegram-login inschakelen",
     "ENABLE_TELEGRAM_DESC": "Sta Telegram-login toe op deze site. Vereist TELEGRAM_ENABLED=true, bot token en bot username in .env (serverherstart vereist bij .env-wijzigingen).",
     "TELEGRAM_BOT_LABEL": "Bot-gebruikersnaam",
-    "TELEGRAM_BOT_DESC": "Gebruikersnaam van de Telegram-bot (zonder @).",
+    "TELEGRAM_BOT_DESC": "Gebruikersnaam van de Telegram-bot (zonder @). Wordt gebruikt als TELEGRAM_BOT_USERNAME niet is ingesteld.",
     "ENABLE_DISCORD_LABEL": "Discord-login inschakelen",
     "ENABLE_DISCORD_DESC": "Sta Discord-login toe op deze site. Vereist Discord Client ID en Client Secret in .env (serverherstart vereist bij .env-wijzigingen). Beïnvloedt de PoracleNG-botlevering niet.",
     "PROVIDER_URL_LABEL": "Map-tile-URL",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Szukaj areny (opcjonalnie)",
     "SEARCH_HINT": "Wpisz nazwę areny...",
-    "CLEAR_ARIA": "Wyczyść wybór areny"
+    "CLEAR_ARIA": "Wyczyść wybór areny",
+    "RATE_LIMITED": "Zbyt wiele zapytań do skanera — zwolnij trochę."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Powiadomienia będą wysyłane dla tych obszarów:",
@@ -1555,7 +1556,7 @@
     "ENABLE_TELEGRAM_LABEL": "Włącz logowanie Telegram",
     "ENABLE_TELEGRAM_DESC": "Zezwól na logowanie Telegram na tej stronie. Wymaga TELEGRAM_ENABLED=true, bot token i bot username w .env (wymagany restart serwera po zmianach w .env).",
     "TELEGRAM_BOT_LABEL": "Nazwa użytkownika bota",
-    "TELEGRAM_BOT_DESC": "Nazwa użytkownika bota Telegram (bez @).",
+    "TELEGRAM_BOT_DESC": "Nazwa użytkownika bota Telegram (bez @). Używane, gdy TELEGRAM_BOT_USERNAME nie jest skonfigurowane.",
     "ENABLE_DISCORD_LABEL": "Włącz logowanie Discord",
     "ENABLE_DISCORD_DESC": "Zezwól na logowanie Discord na tej stronie. Wymaga Discord Client ID i Client Secret w .env (wymagany restart serwera po zmianach w .env). Nie wpływa na dostarczanie bota PoracleNG.",
     "ENABLE_OIDC_LABEL": "Włącz logowanie przez zewnętrzne SSO",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Buscar um ginásio (opcional)",
     "SEARCH_HINT": "Digite o nome do ginásio...",
-    "CLEAR_ARIA": "Limpar seleção de ginásio"
+    "CLEAR_ARIA": "Limpar seleção de ginásio",
+    "RATE_LIMITED": "Muitas solicitações ao scanner — vá com mais calma."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Notificações serão enviadas para estas áreas:",
@@ -1554,7 +1555,7 @@
     "ENABLE_TELEGRAM_LABEL": "Ativar login do Telegram",
     "ENABLE_TELEGRAM_DESC": "Permitir login do Telegram neste site. Requer TELEGRAM_ENABLED=true, bot token e bot username em .env (reinicialização do servidor necessária após alterações em .env).",
     "TELEGRAM_BOT_LABEL": "Nome de usuário do bot",
-    "TELEGRAM_BOT_DESC": "Nome de usuário do bot do Telegram (sem @).",
+    "TELEGRAM_BOT_DESC": "Nome de usuário do bot do Telegram (sem @). Usado quando TELEGRAM_BOT_USERNAME não está configurado.",
     "ENABLE_DISCORD_LABEL": "Ativar login do Discord",
     "ENABLE_DISCORD_DESC": "Permitir login do Discord neste site. Requer Discord Client ID e Client Secret em .env (reinicialização do servidor necessária após alterações em .env). Não afeta a entrega do bot PoracleNG.",
     "ENABLE_OIDC_LABEL": "Ativar login SSO externo",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Pesquisar ginásio (opcional)",
     "SEARCH_HINT": "Escreve o nome do ginásio...",
-    "CLEAR_ARIA": "Limpar seleção de ginásio"
+    "CLEAR_ARIA": "Limpar seleção de ginásio",
+    "RATE_LIMITED": "Demasiados pedidos ao scanner — abrande um pouco."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "As notificações serão enviadas para estas áreas:",
@@ -1576,7 +1577,7 @@
     "ENABLE_TELEGRAM_LABEL": "Ativar login do Telegram",
     "ENABLE_TELEGRAM_DESC": "Permitir login Telegram neste site. Requer TELEGRAM_ENABLED=true, bot token e bot username em .env (reinício do servidor necessário após alterações em .env).",
     "TELEGRAM_BOT_LABEL": "Nome de utilizador do bot",
-    "TELEGRAM_BOT_DESC": "Nome de utilizador do bot Telegram (sem @).",
+    "TELEGRAM_BOT_DESC": "Nome de utilizador do bot Telegram (sem @). Usado quando TELEGRAM_BOT_USERNAME não está configurado.",
     "ENABLE_DISCORD_LABEL": "Ativar login do Discord",
     "ENABLE_DISCORD_DESC": "Permitir login Discord neste site. Requer Discord Client ID e Client Secret em .env (reinício do servidor necessário após alterações em .env). Não afeta a entrega do bot PoracleNG.",
     "PROVIDER_URL_LABEL": "URL dos mosaicos do mapa",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -1454,7 +1454,8 @@
   "GYM_PICKER": {
     "SEARCH_LABEL": "Sök efter ett gym (valfritt)",
     "SEARCH_HINT": "Skriv gym-namn...",
-    "CLEAR_ARIA": "Rensa gym-val"
+    "CLEAR_ARIA": "Rensa gym-val",
+    "RATE_LIMITED": "För många skannerförfrågningar — sakta ner lite."
   },
   "DELIVERY_PREVIEW": {
     "AREAS_LABEL": "Notiser skickas för dessa områden:",
@@ -1555,7 +1556,7 @@
     "ENABLE_TELEGRAM_LABEL": "Aktivera Telegram-inloggning",
     "ENABLE_TELEGRAM_DESC": "Tillåt Telegram-inloggning på denna webbplats. Kräver TELEGRAM_ENABLED=true, bot token och bot username i .env (serveromstart krävs efter .env-ändringar).",
     "TELEGRAM_BOT_LABEL": "Bot-användarnamn",
-    "TELEGRAM_BOT_DESC": "Telegram-bot-användarnamn (utan @).",
+    "TELEGRAM_BOT_DESC": "Telegram-bot-användarnamn (utan @). Används när TELEGRAM_BOT_USERNAME inte är konfigurerat.",
     "ENABLE_DISCORD_LABEL": "Aktivera Discord-inloggning",
     "ENABLE_DISCORD_DESC": "Tillåt Discord-inloggning på denna webbplats. Kräver Discord Client ID och Client Secret i .env (serveromstart krävs efter .env-ändringar). Påverkar inte PoracleNG-bot-leverans.",
     "ENABLE_OIDC_LABEL": "Aktivera extern SSO-inloggning",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Add Raid dialog no longer offers a level picker on the By Boss tab, where PoracleNG discards the chosen level and stores "any" (#615)
+- A 401 now clears the whole session rather than the access token alone, so the admin impersonation token and a dead refresh token no longer survive it (#616)
+- The delivery preview no longer spins forever in every alarm dialog when `disable_location` is on (#617)
+- Approving or rejecting a geofence no longer blanks the admin card: the response carries the owner and reviewer names, avatars and polygon the list projection adds (#618)
+- The gym picker's rate-limit message is translated instead of hardcoded English (#619)
+- The admin "Bot Username" setting is now read as a fallback for the Telegram login widget instead of saving nowhere (#620)
 - Invasion alarms no longer accept a grunt type containing control characters, or one longer than the column, which produced an alarm that could never fire or a 500 (#611)
 - Fort change alarms now refuse a `changeTypes` list longer than the five legal values, or one that repeats a value, instead of failing in the database (#612)
 - An admin can no longer block their own account, which since #609 removed their API access immediately, including the endpoint that would restore it (#613)

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -333,6 +333,25 @@ public partial class UserGeofenceService(
     public async Task<List<UserGeofence>> GetAllWithDetailsAsync()
     {
         var geofences = await this.GetAllAsync();
+        await this.EnrichWithDetailsAsync(geofences);
+        return geofences;
+    }
+
+    /// <summary>
+    /// Fills in the fields the admin list renders but the table does not store: owner and reviewer
+    /// names, and the parsed polygon with its point count.
+    /// </summary>
+    /// <remarks>
+    /// Shared with approve and reject so their responses carry the same projection. Returning the bare
+    /// row from those left the SPA -- which swaps the row for the response -- showing raw Discord
+    /// snowflakes and no map thumbnail until the page was reloaded. See #618.
+    /// </remarks>
+    private async Task EnrichWithDetailsAsync(List<UserGeofence> geofences)
+    {
+        if (geofences.Count == 0)
+        {
+            return;
+        }
 
         // Batch-fetch owner humans by distinct HumanId
         var humanIds = geofences.Select(g => g.HumanId).Distinct().ToList();
@@ -378,8 +397,6 @@ public partial class UserGeofenceService(
                 }
             }
         }
-
-        return geofences;
     }
 
     public async Task AdminDeleteAsync(string adminId, int id)
@@ -719,6 +736,7 @@ public partial class UserGeofenceService(
 
         LogGeofenceApproved(this._logger, adminId, geofence.KojiName, id, promotedName);
 
+        await this.EnrichWithDetailsAsync([updated]);
         return updated;
     }
 
@@ -762,6 +780,7 @@ public partial class UserGeofenceService(
 
         LogGeofenceRejected(this._logger, adminId, geofence.KojiName, id);
 
+        await this.EnrichWithDetailsAsync([updated]);
         return updated;
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminGeofenceControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminGeofenceControllerTests.cs
@@ -207,6 +207,51 @@ public class AdminGeofenceControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task ApproveSubmissionFillsInTheAvatarsTheListProjectionAdds()
+    {
+        // The SPA swaps the list row for this response, so a bare row blanked the card. See #618.
+        var approved = new UserGeofence
+        {
+            Id = 1,
+            KojiName = "pweb_111_downtown",
+            DisplayName = "Downtown",
+            HumanId = "111",
+            ReviewedBy = "123456789",
+            Status = "approved",
+        };
+        this._service.Setup(s => s.ApproveSubmissionAsync("123456789", 1, null, null, null)).ReturnsAsync(approved);
+
+        var result = await this._sut.ApproveSubmission(1, null);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var value = Assert.IsType<UserGeofence>(ok.Value);
+        Assert.False(string.IsNullOrEmpty(value.OwnerAvatarUrl));
+        Assert.False(string.IsNullOrEmpty(value.ReviewedByAvatarUrl));
+    }
+
+    [Fact]
+    public async Task RejectSubmissionFillsInTheAvatarsTheListProjectionAdds()
+    {
+        var rejected = new UserGeofence
+        {
+            Id = 2,
+            KojiName = "pweb_111_uptown",
+            DisplayName = "Uptown",
+            HumanId = "111",
+            ReviewedBy = "123456789",
+            Status = "rejected",
+        };
+        this._service.Setup(s => s.RejectSubmissionAsync("123456789", 2, "too big")).ReturnsAsync(rejected);
+
+        var result = await this._sut.RejectSubmission(2, new AdminGeofenceController.RejectRequest { ReviewNotes = "too big" });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var value = Assert.IsType<UserGeofence>(ok.Value);
+        Assert.False(string.IsNullOrEmpty(value.OwnerAvatarUrl));
+        Assert.False(string.IsNullOrEmpty(value.ReviewedByAvatarUrl));
+    }
+
+    [Fact]
     public async Task ApproveSubmissionReturnsNotFoundWhenNotFound()
     {
         this._service.Setup(s => s.ApproveSubmissionAsync("123456789", 99, null, null, null))

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
@@ -120,6 +120,35 @@ public class AuthControllerProvidersTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task ProvidersFallsBackToTheSiteSettingBotUsername()
+    {
+        // The admin page has always offered this field and nothing ever read it. See #620.
+        this._siteSettingService.Setup(s => s.GetValueAsync("telegram_bot")).ReturnsAsync("@uibot");
+        var controller = this.CreateController(telegram: new TelegramSettings { Enabled = true, BotUsername = "" });
+
+        var result = await controller.Providers();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var doc = JsonDocument.Parse(JsonSerializer.Serialize(ok.Value));
+        Assert.Equal("uibot", doc.RootElement.GetProperty("telegram").GetProperty("botUsername").GetString());
+    }
+
+    [Fact]
+    public async Task ProvidersPrefersTheConfiguredBotUsernameOverTheSiteSetting()
+    {
+        // A working env var must not be overridden by whatever was typed into the UI while the field
+        // was inert. See #620.
+        this._siteSettingService.Setup(s => s.GetValueAsync("telegram_bot")).ReturnsAsync("staleuibot");
+        var controller = this.CreateController(telegram: new TelegramSettings { Enabled = true, BotUsername = "envbot" });
+
+        var result = await controller.Providers();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var doc = JsonDocument.Parse(JsonSerializer.Serialize(ok.Value));
+        Assert.Equal("envbot", doc.RootElement.GetProperty("telegram").GetProperty("botUsername").GetString());
+    }
+
+    [Fact]
     public async Task ProvidersTelegramNotConfiguredWhenDisabledInEnv()
     {
         var controller = this.CreateController(telegram: new TelegramSettings { Enabled = false });

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
@@ -887,7 +887,10 @@ public class UserGeofenceServiceTests
         var result = await this._sut.GetAllWithDetailsAsync();
 
         Assert.Empty(result);
-        this._humanRepo.Verify(r => r.GetByIdsAsync(It.Is<IEnumerable<string>>(ids => !ids.Any())), Times.Once);
+
+        // No rows, no lookup. The enrichment is shared with approve and reject now (#618) and returns
+        // early on an empty list rather than asking the humans table about nobody.
+        this._humanRepo.Verify(r => r.GetByIdsAsync(It.IsAny<IEnumerable<string>>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #615
Closes #616
Closes #617
Closes #618
Closes #619
Closes #620

**#615 — raid By Boss level picker.** `trackingRaid.go` at prod's commit sets `level := 9000` unless `pokemonID == 9000`. The By Boss tab always submits a specific boss, so the picker's value never survived the request: the user chose level 5 and got "any". The picker is gone; no saved alarm changes.

**#616 — a 401 cleared one of four session keys.** `poracle_admin_token` (the impersonating admin's higher-privilege credential, which `stopImpersonating()` installs as the active token), `poracle_refresh_token` and the expiry all survived. Navigation is deliberately untouched — routing through `logout()` would append `loggedout=1` and suppress the OIDC auto-redirect.

**#617 — delivery preview spun forever.** A next-only subscriber on `getLocation()`; with `disable_location` the 403 left `loading` set in every alarm dialog. The quest summary dialog and the dashboard threw on the same call and now degrade to their existing defaults.

**#618 — approve/reject blanked the admin card.** Those endpoints returned the bare row while the list is built from an enriched projection, so the card dropped to raw snowflakes with no avatars and no map thumbnail (the polygon is parsed during enrichment). The enrichment is now shared; the controller adds the same avatars.

**#619 — gym picker rate-limit message** was hardcoded English. Now `GYM_PICKER.RATE_LIMITED` in all eleven locales.

**#620 — the admin "Bot Username" field** saved and was never read. Config keeps precedence and the setting is the fallback, so a deployment with a working `TELEGRAM_BOT_USERNAME` cannot have its widget repointed at a stale value typed in while the field was inert.

## Verification

- 1812 backend tests (4 new), 945 frontend tests (5 new), lint and prettier clean.
- The `GetAllWithDetailsAsync` empty-list test was updated deliberately: the shared enrichment returns early rather than asking the humans table about zero ids.
