### PR TITLE
chore: clear the SQLitePCLRaw high-severity advisory in the test project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned `SQLitePCLRaw.bundle_e_sqlite3` forward to 2.1.12 in the test project, clearing the high-severity GHSA-2m69-gcr7-jv3q advisory the build reported
 - **Blocking a user was not enforced by the API** ([#609](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/609)). The earlier fix only signed the browser out; the API kept serving a blocked account, and anything not using the web app was unaffected entirely. Blocking now refuses immediately, and unblocking restores access at once.
 - **Blocking a user did not block them** ([#597](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/597)). Blocking stopped notifications being delivered and left the web session untouched, so a blocked account kept full access for up to a day, and signing in again issued a fresh token.
 - **Rate limits could be bypassed by forging a header** ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)). `X-Forwarded-For` was believed from any caller, so a client could name a different address on each request and hand itself a fresh allowance — including on the sign-in endpoints the limit exists to protect. It is now honoured only from proxies the deployment declares, via `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS`.

--- a/Tests/Pgan.PoracleWebNet.Tests/Pgan.PoracleWebNet.Tests.csproj
+++ b/Tests/Pgan.PoracleWebNet.Tests/Pgan.PoracleWebNet.Tests.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <!-- EFCore.Sqlite 10.0.10 still pulls SQLitePCLRaw 2.1.11, which carries GHSA-2m69-gcr7-jv3q.
+         Pinned forward so the build stops reporting a high-severity advisory. Test-only. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />


### PR DESCRIPTION
`dotnet build` reported `NU1903: SQLitePCLRaw.lib.e_sqlite3 2.1.11 has a known high severity vulnerability` (GHSA-2m69-gcr7-jv3q) on every build. It arrives transitively through `Microsoft.EntityFrameworkCore.Sqlite` 10.0.10, which is already the latest — so the fix is a forward pin rather than a version bump.

Test-only dependency; nothing shipped is affected. `dotnet list package --vulnerable --include-transitive` is now clean across the solution, and all 1812 backend tests pass unchanged.