### PR TITLE
fix: a token re-issue no longer renews the session or its admin claim (#624, #626)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/IJwtService.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/IJwtService.cs
@@ -32,6 +32,11 @@ public interface IJwtService
     /// Generates a JWT by copying claims from an existing <see cref="ClaimsPrincipal"/>
     /// and replacing <c>profileNo</c>. Framework-injected claims (<c>exp</c>, <c>nbf</c>,
     /// <c>iat</c>, <c>iss</c>, <c>aud</c>) are filtered out to avoid duplication.
+    /// <para>
+    /// The re-issued token keeps the original <c>exp</c> rather than starting a fresh lifetime -- a
+    /// re-issue must never extend a session. Pass <paramref name="isAdmin"/> to replace the copied
+    /// claim with a freshly resolved value. See #624.
+    /// </para>
     /// </summary>
-    string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo);
+    string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo, bool? isAdmin = null);
 }

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/JwtService.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/JwtService.cs
@@ -46,7 +46,7 @@ public sealed class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
         return this.WriteToken(claims);
     }
 
-    public string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo)
+    public string GenerateTokenWithReplacedProfile(ClaimsPrincipal existingPrincipal, int profileNo, bool? isAdmin = null)
     {
         var claims = new List<Claim>();
         foreach (var claim in existingPrincipal.Claims)
@@ -66,7 +66,42 @@ public sealed class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
         }
 
         claims.Add(new Claim("profileNo", profileNo.ToString(CultureInfo.InvariantCulture)));
-        return this.WriteToken(claims);
+
+        // A re-issue must not extend the session. This used to end in WriteToken(claims), which applies
+        // the configured default of 24 hours -- so an OIDC login's deliberately short 30-minute access
+        // token became a day-long one on the first profile switch, and a user who switched profile once
+        // a day never expired at all. Revocation is supposed to propagate within roughly one access
+        // token's lifetime; renewing on re-issue quietly removed that bound. See #624.
+        var remaining = RemainingMinutes(existingPrincipal);
+        if (isAdmin is { } resolved)
+        {
+            // Copied verbatim, isAdmin outlived the rights it described: nothing revalidates the claim,
+            // so de-admining someone had no effect while they kept switching profile.
+            claims.RemoveAll(c => string.Equals(c.Type, "isAdmin", StringComparison.Ordinal));
+            claims.Add(new Claim("isAdmin", resolved.ToString().ToLowerInvariant()));
+        }
+
+        return remaining is { } minutes
+            ? this.WriteToken(claims, minutes)
+            : this.WriteToken(claims);
+    }
+
+    /// <summary>
+    /// Whole minutes left on the principal's own <c>exp</c>, or null when it carries none.
+    /// </summary>
+    private static int? RemainingMinutes(ClaimsPrincipal principal)
+    {
+        var exp = principal.FindFirst("exp")?.Value ?? principal.FindFirst(JwtRegisteredClaimNames.Exp)?.Value;
+        if (!long.TryParse(exp, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+        {
+            return null;
+        }
+
+        var remaining = DateTimeOffset.FromUnixTimeSeconds(seconds) - DateTimeOffset.UtcNow;
+
+        // The request authenticated, so the token was live when it arrived; a floor of one minute keeps
+        // a token that expires mid-request from being re-issued already dead.
+        return Math.Max(1, (int)Math.Ceiling(remaining.TotalMinutes));
     }
 
     private static List<Claim> BuildClaims(UserInfo user)

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/ServiceCollectionExtensions.cs
@@ -169,6 +169,10 @@ public static class ServiceCollectionExtensions
         // Register JWT service (shared token generation across controllers)
         services.AddSingleton<IJwtService, JwtService>();
 
+        // Admin status and delegated webhooks, resolved live rather than trusted from a claim minted
+        // at login. See #624 and #626.
+        services.AddScoped<Services.IUserRoleResolver, Services.UserRoleResolver>();
+
         // Register settings
         services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
         services.Configure<DiscordSettings>(configuration.GetSection("Discord"));

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Services;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
 
@@ -17,6 +18,7 @@ public partial class AdminController(
     IPoracleHumanProxy humanProxy,
     IOptions<PoracleSettings> poracleSettings,
     IJwtService jwtService,
+    IUserRoleResolver roleResolver,
     ILogger<AdminController> logger) : BaseApiController
 {
     private readonly IHumanService _humanService = humanService;
@@ -27,6 +29,7 @@ public partial class AdminController(
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
     private readonly IJwtService _jwtService = jwtService;
+    private readonly IUserRoleResolver _roleResolver = roleResolver;
     private readonly ILogger<AdminController> _logger = logger;
 
     /// <summary>Caps one avatar batch. The admin user list is the only caller and batches per viewport.</summary>
@@ -76,7 +79,11 @@ public partial class AdminController(
         // Resolved live rather than read from the JWT claim. The claim is minted at login and lives 24
         // hours, so revoking a delegate left them managing the webhook until they happened to sign in
         // again -- and impersonation authorises off the same claim. See #601.
-        var managed = (await this._webhookDelegateService.GetManagedWebhookIdsAsync(this.UserId)).ToArray();
+        // The union the JWT claim is built from, not the local table alone. Resolving from
+        // poracle_web.webhook_delegates only meant a delegate configured in PoracleJS -- the
+        // delegateAdministration mechanism -- saw the nav item, got an empty page here, and a 403 from
+        // impersonate. See #626.
+        var managed = (await this._roleResolver.ResolveAsync(this.UserId)).ManagedWebhooks ?? [];
         if (managed.Length == 0)
         {
             return this.Ok(Array.Empty<object>());
@@ -566,8 +573,10 @@ public partial class AdminController(
         // Allow admins or delegates who manage this specific webhook. Resolved live rather than read from
         // the JWT claim: the claim is minted at login and lives 24 hours, so a revoked delegate could keep
         // impersonating the webhook until they next signed in. See #601.
+        // Same union as the claim and as my-webhooks, so a PoracleJS-configured delegate is not refused
+        // by an endpoint the nav item just offered them. See #626.
         var isDelegate = !this.IsAdmin
-            && (await this._webhookDelegateService.GetManagedWebhookIdsAsync(this.UserId))
+            && ((await this._roleResolver.ResolveAsync(this.UserId)).ManagedWebhooks ?? [])
                 .Contains(request.UserId, StringComparer.Ordinal);
         if (!this.IsAdmin && !isDelegate)
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Services;
 using Pgan.PoracleWebNet.Api.Services.Oidc;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -23,6 +24,7 @@ public partial class AuthController(
     ISiteSettingService siteSettingService,
     IWebhookDelegateService webhookDelegateService,
     IJwtService jwtService,
+    IUserRoleResolver roleResolver,
     IOidcClient oidcClient,
     IOidcSessionService oidcSessionService,
     IOptions<DiscordSettings> discordSettings,
@@ -50,6 +52,7 @@ public partial class AuthController(
     private readonly ISiteSettingService _siteSettingService = siteSettingService;
     private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
     private readonly IJwtService _jwtService = jwtService;
+    private readonly IUserRoleResolver _roleResolver = roleResolver;
     private readonly IOidcClient _oidcClient = oidcClient;
     private readonly IOidcSessionService _oidcSessionService = oidcSessionService;
     private readonly DiscordSettings _discordSettings = discordSettings.Value;
@@ -817,7 +820,11 @@ public partial class AuthController(
             // out-of-band profile changes this branch exists to absorb. Replace the profile on the
             // current principal instead, which is what every other profile-replacement site does and
             // which copies every non-registered claim. See #484.
-            userInfo.Token = this._jwtService.GenerateTokenWithReplacedProfile(this.User, dbProfileNo);
+            // isAdmin resolved fresh rather than copied: this is the one place a long-lived session
+            // routinely re-mints its token, so copying the claim let revoked admin rights live on. See #624.
+            var roles = await this._roleResolver.ResolveAsync(this.UserId);
+            userInfo.IsAdmin = roles.IsAdmin;
+            userInfo.Token = this._jwtService.GenerateTokenWithReplacedProfile(this.User, dbProfileNo, roles.IsAdmin);
         }
 
         return this.Ok(userInfo);
@@ -868,102 +875,17 @@ public partial class AuthController(
     /// Calls PoracleJS getAdministrationRoles once and returns (isAdmin, managedWebhooks).
     /// managedWebhooks merges: Poracle-resolved webhook delegation + our own webhook delegate service layer.
     /// </summary>
+    /// <summary>
+    /// The caller's current admin status and delegated webhooks.
+    /// </summary>
+    /// <remarks>
+    /// The body of this moved to <see cref="IUserRoleResolver"/> so the admin endpoints and the token
+    /// re-issue paths can ask the same question login asks. See #624 and #626.
+    /// </remarks>
     private async Task<(bool isAdmin, string[]? managedWebhooks)> GetRolesAsync(string userId)
     {
-        // Fast path: configured admin IDs
-        if (!string.IsNullOrEmpty(this._poracleSettings.AdminIds))
-        {
-            var adminIds = this._poracleSettings.AdminIds.Split(',',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (adminIds.Contains(userId))
-            {
-                return (true, null);
-            }
-        }
-
-        // Check Poracle config admins list
-        try
-        {
-            var config = await this._poracleApiProxy.GetConfigAsync();
-            if (config?.Admins != null &&
-                (config.Admins.Discord.Contains(userId) || config.Admins.Telegram.Contains(userId)))
-            {
-                return (true, null);
-            }
-        }
-        catch (Exception ex)
-        {
-            LogPoracleConfigFetchFailed(this._logger, ex, userId);
-        }
-
-        // Call getAdministrationRoles once — resolves delegation including Discord guild roles
-        var managed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var isAdmin = false;
-
-        try
-        {
-            var rolesJson = await this._poracleApiProxy.GetAdminRolesAsync(userId);
-            if (!string.IsNullOrEmpty(rolesJson))
-            {
-                using var doc = JsonDocument.Parse(rolesJson);
-                var root = doc.RootElement;
-
-                // Some versions return isAdmin at root; others wrap under admin.discord
-                if (root.TryGetProperty("isAdmin", out var isAdminProp) && isAdminProp.ValueKind == JsonValueKind.True)
-                {
-                    isAdmin = true;
-                }
-
-                // Parse admin.discord.webhooks — the authoritative delegate webhook list
-                if (root.TryGetProperty("admin", out var adminEl) &&
-                    adminEl.TryGetProperty("discord", out var discordEl))
-                {
-                    if (!isAdmin &&
-                        discordEl.TryGetProperty("isAdmin", out var discordAdmin) &&
-                        discordAdmin.ValueKind == JsonValueKind.True)
-                    {
-                        isAdmin = true;
-                    }
-
-                    if (discordEl.TryGetProperty("webhooks", out var webhooks) &&
-                        webhooks.ValueKind == JsonValueKind.Array)
-                    {
-                        foreach (var wh in webhooks.EnumerateArray())
-                        {
-                            if (wh.GetString() is { } id)
-                            {
-                                managed.Add(id);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            LogAdminRolesFetchFailed(this._logger, ex, userId);
-        }
-
-        if (isAdmin)
-        {
-            return (true, null);
-        }
-
-        // Also merge our own webhook delegate service layer
-        try
-        {
-            var managedWebhookIds = await this._webhookDelegateService.GetManagedWebhookIdsAsync(userId);
-            foreach (var webhookId in managedWebhookIds)
-            {
-                managed.Add(webhookId);
-            }
-        }
-        catch (Exception ex)
-        {
-            LogPwebDelegatesFetchFailed(this._logger, ex, userId);
-        }
-
-        return (false, managed.Count > 0 ? managed.ToArray() : null);
+        var roles = await this._roleResolver.ResolveAsync(userId);
+        return (roles.IsAdmin, roles.ManagedWebhooks);
     }
 
     /// <summary>
@@ -1297,15 +1219,6 @@ public partial class AuthController(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "OIDC refresh tokens are enabled but the provider returned no refresh token (offline_access not granted?); falling back to a standard session.")]
     private static partial void LogOidcRefreshUnavailable(ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]
-    private static partial void LogPoracleConfigFetchFailed(ILogger logger, Exception ex, string userId);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch administration roles for {UserId}.")]
-    private static partial void LogAdminRolesFetchFailed(ILogger logger, Exception ex, string userId);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch webhook delegates for {UserId}.")]
-    private static partial void LogPwebDelegatesFetchFailed(ILogger logger, Exception ex, string userId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Auth attempt blocked: {Method} login is disabled by site setting.")]
     private static partial void LogAuthMethodDisabled(ILogger logger, string method);

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Pgan.PoracleWebNet.Api.Filters;
 using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Services;
 using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Models;
@@ -16,13 +17,15 @@ public class ProfileController(
     IHumanService humanService,
     IPoracleHumanProxy humanProxy,
     IProfileRepository profileRepository,
-    IJwtService jwtService) : BaseApiController
+    IJwtService jwtService,
+    IUserRoleResolver roleResolver) : BaseApiController
 {
     private readonly IProfileService _profileService = profileService;
     private readonly IHumanService _humanService = humanService;
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly IProfileRepository _profileRepository = profileRepository;
     private readonly IJwtService _jwtService = jwtService;
+    private readonly IUserRoleResolver _roleResolver = roleResolver;
 
     /// <summary>Matches the profiles.name column, so an over-long name is refused rather than 500ing.</summary>
     private const int MaxProfileNameLength = 255;
@@ -185,7 +188,10 @@ public class ProfileController(
         await this._humanProxy.SwitchProfileAsync(this.UserId, profileNo);
 
         // Issue a new JWT with the updated profileNo so all subsequent API calls use it
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, profileNo);
+        // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
+        // user kept their isAdmin claim alive indefinitely. See #624.
+        var roles = await this._roleResolver.ResolveAsync(this.UserId);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, profileNo, roles.IsAdmin);
 
         return this.Ok(new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Pgan.PoracleWebNet.Api.Filters;
 using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Services;
 using Pgan.PoracleWebNet.Core.Abstractions.Repositories;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
 
@@ -18,11 +19,13 @@ public partial class ProfileOverviewController(
     IProfileRepository profileRepository,
     IPoracleHumanProxy humanProxy,
     IJwtService jwtService,
+    IUserRoleResolver roleResolver,
     ILogger<ProfileOverviewController> logger) : BaseApiController
 {
     private readonly IProfileOverviewService _profileOverviewService = profileOverviewService;
     private readonly IPoracleHumanProxy _humanProxy = humanProxy;
     private readonly IJwtService _jwtService = jwtService;
+    private readonly IUserRoleResolver _roleResolver = roleResolver;
     private readonly IProfileService _profileService = profileService;
     private readonly IProfileRepository _profileRepository = profileRepository;
     private readonly ILogger<ProfileOverviewController> _logger = logger;
@@ -108,7 +111,10 @@ public partial class ProfileOverviewController(
             newProfileNo, request.Name.Trim(), source.Area ?? "[]", source.Latitude, source.Longitude);
 
         // Issue a new JWT so the current profile stays correct
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo);
+        // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
+        // user kept their isAdmin claim alive indefinitely. See #624.
+        var roles = await this._roleResolver.ResolveAsync(this.UserId);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, roles.IsAdmin);
 
         return this.Ok(new
         {
@@ -203,7 +209,10 @@ public partial class ProfileOverviewController(
         // never chose for it. Restore what the file actually declared. See #522.
         await this.WriteGeographyAsync(newProfileNo, profileName, "[]", 0.0, 0.0);
 
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo);
+        // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
+        // user kept their isAdmin claim alive indefinitely. See #624.
+        var roles = await this._roleResolver.ResolveAsync(this.UserId);
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, roles.IsAdmin);
 
         return this.Ok(new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+
+namespace Pgan.PoracleWebNet.Api.Services;
+
+/// <summary>
+/// A user's admin status and the webhooks they may administer, resolved from live sources.
+/// </summary>
+public readonly record struct UserRoles(bool IsAdmin, string[]? ManagedWebhooks);
+
+/// <summary>
+/// Resolves admin status and delegated webhooks from the configured admin list, Poracle's config,
+/// PoracleNG's <c>getAdministrationRoles</c>, and PoracleWeb's own delegate table.
+/// </summary>
+public interface IUserRoleResolver
+{
+    /// <summary>Resolves the user's current roles.</summary>
+    Task<UserRoles> ResolveAsync(string userId);
+}
+
+/// <summary>
+/// The single place roles are worked out.
+/// </summary>
+/// <remarks>
+/// This used to live as a private method on <c>AuthController</c>, which meant login was the only
+/// thing that could see it. Two defects came out of that: the <c>isAdmin</c> claim was minted once and
+/// then copied verbatim through every token re-issue, so revoking someone's admin rights never took
+/// effect while they kept switching profile (#624); and the admin endpoints that resolve delegated
+/// webhooks live went to the local table alone, so a delegate configured in PoracleJS could see the
+/// My Webhooks nav item and get an empty page and a 403 (#626).
+/// <para>
+/// Results are cached for a minute. Both PoracleNG calls are network round-trips and the resolver now
+/// sits on paths that are not login, so an uncached implementation would put two HTTP requests on
+/// every profile switch. A minute is short enough that revoking rights still takes effect promptly.
+/// </para>
+/// </remarks>
+public sealed partial class UserRoleResolver(
+    IPoracleApiProxy poracleApiProxy,
+    IWebhookDelegateService webhookDelegateService,
+    IOptions<PoracleSettings> poracleSettings,
+    IMemoryCache cache,
+    ILogger<UserRoleResolver> logger) : IUserRoleResolver
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(1);
+
+    private readonly IMemoryCache _cache = cache;
+    private readonly ILogger<UserRoleResolver> _logger = logger;
+    private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
+    private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
+    private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
+
+    public async Task<UserRoles> ResolveAsync(string userId)
+    {
+        var cacheKey = $"roles:{userId}";
+        if (this._cache.TryGetValue<UserRoles>(cacheKey, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = await this.ResolveUncachedAsync(userId);
+        this._cache.Set(cacheKey, resolved, CacheTtl);
+        return resolved;
+    }
+
+    private async Task<UserRoles> ResolveUncachedAsync(string userId)
+    {
+        // Fast path: configured admin IDs
+        if (!string.IsNullOrEmpty(this._poracleSettings.AdminIds))
+        {
+            var adminIds = this._poracleSettings.AdminIds.Split(',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (adminIds.Contains(userId))
+            {
+                return new UserRoles(true, null);
+            }
+        }
+
+        // Check Poracle config admins list
+        try
+        {
+            var config = await this._poracleApiProxy.GetConfigAsync();
+            if (config?.Admins != null &&
+                (config.Admins.Discord.Contains(userId) || config.Admins.Telegram.Contains(userId)))
+            {
+                return new UserRoles(true, null);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogPoracleConfigFetchFailed(this._logger, ex, userId);
+        }
+
+        // Call getAdministrationRoles once — resolves delegation including Discord guild roles
+        var managed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var isAdmin = false;
+
+        try
+        {
+            var rolesJson = await this._poracleApiProxy.GetAdminRolesAsync(userId);
+            if (!string.IsNullOrEmpty(rolesJson))
+            {
+                using var doc = JsonDocument.Parse(rolesJson);
+                var root = doc.RootElement;
+
+                // Some versions return isAdmin at root; others wrap under admin.discord
+                if (root.TryGetProperty("isAdmin", out var isAdminProp) && isAdminProp.ValueKind == JsonValueKind.True)
+                {
+                    isAdmin = true;
+                }
+
+                // Parse admin.discord.webhooks — the authoritative delegate webhook list
+                if (root.TryGetProperty("admin", out var adminEl) &&
+                    adminEl.TryGetProperty("discord", out var discordEl))
+                {
+                    if (!isAdmin &&
+                        discordEl.TryGetProperty("isAdmin", out var discordAdmin) &&
+                        discordAdmin.ValueKind == JsonValueKind.True)
+                    {
+                        isAdmin = true;
+                    }
+
+                    if (discordEl.TryGetProperty("webhooks", out var webhooks) &&
+                        webhooks.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var wh in webhooks.EnumerateArray())
+                        {
+                            if (wh.GetString() is { } id)
+                            {
+                                managed.Add(id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LogAdminRolesFetchFailed(this._logger, ex, userId);
+        }
+
+        if (isAdmin)
+        {
+            return new UserRoles(true, null);
+        }
+
+        // Also merge our own webhook delegate service layer
+        try
+        {
+            var managedWebhookIds = await this._webhookDelegateService.GetManagedWebhookIdsAsync(userId);
+            foreach (var webhookId in managedWebhookIds)
+            {
+                managed.Add(webhookId);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogPwebDelegatesFetchFailed(this._logger, ex, userId);
+        }
+
+        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null);
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]
+    private static partial void LogPoracleConfigFetchFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch administration roles for {UserId}.")]
+    private static partial void LogAdminRolesFetchFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch webhook delegates for {UserId}.")]
+    private static partial void LogPwebDelegatesFetchFailed(ILogger logger, Exception ex, string userId);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- A token re-issue no longer restarts the session clock: profile switches and profile resyncs keep the original expiry instead of applying the 24-hour default, so a short OIDC access token stays short and revocation propagates as documented (#624)
+- `isAdmin` is resolved live on every token re-issue rather than copied forward, so removing someone's admin rights takes effect instead of surviving indefinitely while they switch profile (#624)
+- Webhook delegates configured in PoracleJS can use the My Webhooks page again: the live resolution now unions PoracleNG's delegate list with PoracleWeb's own table, as the JWT claim always did (#626)
 - Pinned `SQLitePCLRaw.bundle_e_sqlite3` forward to 2.1.12 in the test project, clearing the high-severity GHSA-2m69-gcr7-jv3q advisory the build reported
 - **Blocking a user was not enforced by the API** ([#609](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/609)). The earlier fix only signed the browser out; the API kept serving a blocked account, and anything not using the web app was unaffected entirely. Blocking now refuses immediately, and unblocking restores access at once.
 - **Blocking a user did not block them** ([#597](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/597)). Blocking stopped notifications being delivered and left the web session untouched, so a blocked account kept full access for up to a day, and signing in again issued a fresh token.

--- a/Tests/Pgan.PoracleWebNet.Tests/Configuration/JwtServiceReissueTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Configuration/JwtServiceReissueTests.cs
@@ -1,0 +1,107 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Pgan.PoracleWebNet.Api.Configuration;
+
+namespace Pgan.PoracleWebNet.Tests.Configuration;
+
+/// <summary>
+/// A token re-issue must not extend the session or carry a stale <c>isAdmin</c> claim. See #624.
+/// </summary>
+public class JwtServiceReissueTests
+{
+    private static readonly JwtSettings Settings = new()
+    {
+        Secret = "this-is-a-test-signing-key-long-enough-for-hmac-sha256",
+        Issuer = "PoracleWeb.Api",
+        Audience = "PoracleWeb.App",
+        ExpirationMinutes = 1440,
+    };
+
+    private static ClaimsPrincipal PrincipalExpiringIn(TimeSpan remaining, bool isAdmin = true)
+    {
+        var expiresAt = DateTimeOffset.UtcNow.Add(remaining).ToUnixTimeSeconds();
+        var identity = new ClaimsIdentity(
+        [
+            new Claim("userId", "u1"),
+            new Claim("username", "Tester"),
+            new Claim("isAdmin", isAdmin.ToString().ToLowerInvariant()),
+            new Claim("profileNo", "0"),
+            new Claim("exp", expiresAt.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+        ], "TestAuth");
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static JwtSecurityToken Read(string token) => new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+    [Fact]
+    public void ReissueKeepsTheOriginalExpiryRatherThanStartingAFreshLifetime()
+    {
+        // An OIDC access token is deliberately short so revocation propagates. Re-issuing at the
+        // configured default turned a 30-minute session into a 24-hour one on the first profile switch.
+        var sut = new JwtService(Options.Create(Settings));
+        var principal = PrincipalExpiringIn(TimeSpan.FromMinutes(30));
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(principal, 2));
+
+        var remaining = token.ValidTo - DateTime.UtcNow;
+        Assert.InRange(remaining.TotalMinutes, 25, 35);
+    }
+
+    [Fact]
+    public void ReissueDoesNotRenewASessionThatIsAlmostOver()
+    {
+        var sut = new JwtService(Options.Create(Settings));
+        var principal = PrincipalExpiringIn(TimeSpan.FromMinutes(2));
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(principal, 2));
+
+        Assert.True((token.ValidTo - DateTime.UtcNow).TotalMinutes < 10);
+    }
+
+    [Fact]
+    public void ReissueReplacesIsAdminWhenAFreshValueIsSupplied()
+    {
+        // Copied verbatim, the claim outlived the rights it described: a de-admined user who switched
+        // profile once a day never lost access.
+        var sut = new JwtService(Options.Create(Settings));
+        var principal = PrincipalExpiringIn(TimeSpan.FromHours(1), isAdmin: true);
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(principal, 2, isAdmin: false));
+
+        Assert.Equal("false", token.Claims.Single(c => c.Type == "isAdmin").Value);
+    }
+
+    [Fact]
+    public void ReissueKeepsTheExistingIsAdminWhenNoFreshValueIsSupplied()
+    {
+        var sut = new JwtService(Options.Create(Settings));
+        var principal = PrincipalExpiringIn(TimeSpan.FromHours(1), isAdmin: true);
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(principal, 2));
+
+        Assert.Equal("true", token.Claims.Single(c => c.Type == "isAdmin").Value);
+    }
+
+    [Fact]
+    public void ReissueFallsBackToTheConfiguredLifetimeWhenThePrincipalCarriesNoExpiry()
+    {
+        var sut = new JwtService(Options.Create(Settings));
+        var identity = new ClaimsIdentity([new Claim("userId", "u1"), new Claim("profileNo", "0")], "TestAuth");
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(new ClaimsPrincipal(identity), 1));
+
+        Assert.InRange((token.ValidTo - DateTime.UtcNow).TotalMinutes, 1400, 1441);
+    }
+
+    [Fact]
+    public void ReissueStillReplacesTheProfileNumber()
+    {
+        var sut = new JwtService(Options.Create(Settings));
+
+        var token = Read(sut.GenerateTokenWithReplacedProfile(PrincipalExpiringIn(TimeSpan.FromHours(1)), 7));
+
+        Assert.Equal("7", token.Claims.Single(c => c.Type == "profileNo").Value);
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -18,6 +18,7 @@ public class AdminControllerTests : ControllerTestBase
     private readonly Mock<IPoracleHumanProxy> _humanProxy = new();
     private readonly Mock<IWebhookDelegateService> _webhookDelegateService = new();
     private readonly Mock<IJwtService> _jwtService = new();
+    private readonly Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver> _roleResolver = new();
     private readonly Mock<ILogger<AdminController>> _logger = new();
     private readonly AdminController _sut;
 
@@ -35,6 +36,7 @@ public class AdminControllerTests : ControllerTestBase
             this._humanProxy.Object,
             poracleSettings,
             this._jwtService.Object,
+            this._roleResolver.Object,
             this._logger.Object);
     }
 
@@ -385,8 +387,11 @@ public class AdminControllerTests : ControllerTestBase
         SetupUser(this._sut, isAdmin: false, managedWebhooks: ["u1"]);
         // Delegation is resolved live now, not read from the JWT claim, so a revoked delegate loses access
         // immediately rather than at their next sign-in. See #601.
-        this._webhookDelegateService.Setup(s => s.GetManagedWebhookIdsAsync("123456789"))
-            .ReturnsAsync(["u1"]);
+        // Resolved through IUserRoleResolver, which unions the local delegate table with the webhooks
+        // PoracleNG reports -- a PoracleJS-configured delegate was refused by the local-table-only
+        // lookup. See #626.
+        this._roleResolver.Setup(r => r.ResolveAsync("123456789"))
+            .ReturnsAsync(new Pgan.PoracleWebNet.Api.Services.UserRoles(false, ["u1"]));
         this._humanService.Setup(s => s.GetByIdAsync("u1")).ReturnsAsync(new Human { Id = "u1", Name = "WH", Type = "webhook", Enabled = 1, AdminDisable = 0, CurrentProfileNo = 1 });
 
         var result = await this._sut.ImpersonateById(new AdminController.ImpersonateRequest("u1"));

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerLoginOriginTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerLoginOriginTests.cs
@@ -106,6 +106,7 @@ public class AuthControllerLoginOriginTests
             new Mock<ISiteSettingService>().Object,
             new Mock<IWebhookDelegateService>().Object,
             new Mock<IJwtService>().Object,
+            new Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver>().Object,
             new Mock<IOidcClient>().Object,
             new Mock<IOidcSessionService>().Object,
             Options.Create(new DiscordSettings { ClientId = "test-id", ClientSecret = "test-secret" }),

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
@@ -25,7 +25,7 @@ public class AuthControllerMeTests : ControllerTestBase
     {
         this._jwtService.Setup(j => j.GenerateToken(It.IsAny<UserInfo>()))
             .Returns("refreshed-jwt-token");
-        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>()))
+        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()))
             .Returns("refreshed-jwt-token");
 
         var config = new ConfigurationBuilder().Build();
@@ -36,6 +36,7 @@ public class AuthControllerMeTests : ControllerTestBase
             new Mock<ISiteSettingService>().Object,
             new Mock<IWebhookDelegateService>().Object,
             this._jwtService.Object,
+            new Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver>().Object,
             new Mock<Pgan.PoracleWebNet.Api.Services.Oidc.IOidcClient>().Object,
             new Mock<Pgan.PoracleWebNet.Api.Services.Oidc.IOidcSessionService>().Object,
             Options.Create(new DiscordSettings()),
@@ -95,7 +96,9 @@ public class AuthControllerMeTests : ControllerTestBase
         Assert.Equal(1, userInfo.ProfileNo);
         Assert.Equal("refreshed-jwt-token", userInfo.Token);
         this._jwtService.Verify(
-            j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), 1), Times.Once);
+            // isAdmin is passed explicitly now: this is the one place a long-lived session routinely
+            // re-mints its token, so copying the claim let revoked admin rights survive. See #624.
+            j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), 1, It.IsAny<bool?>()), Times.Once);
     }
 
     [Fact]
@@ -145,7 +148,7 @@ public class AuthControllerMeTests : ControllerTestBase
 
         Assert.IsType<UnauthorizedObjectResult>(result);
         this._jwtService.Verify(
-            j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>()), Times.Never);
+            j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()), Times.Never);
     }
 
     /// <summary>
@@ -163,8 +166,8 @@ public class AuthControllerMeTests : ControllerTestBase
 
         ClaimsPrincipal? seen = null;
         this._jwtService
-            .Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>()))
-            .Callback<ClaimsPrincipal, int>((p, _) => seen = p)
+            .Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()))
+            .Callback<ClaimsPrincipal, int, bool?>((p, _, _) => seen = p)
             .Returns("refreshed-jwt-token");
 
         await this._sut.Me();

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
@@ -27,6 +27,7 @@ public class AuthControllerProvidersTests : ControllerTestBase
             this._siteSettingService.Object,
             new Mock<IWebhookDelegateService>().Object,
             new Mock<IJwtService>().Object,
+            new Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver>().Object,
             new Mock<IOidcClient>().Object,
             new Mock<IOidcSessionService>().Object,
             Options.Create(discord ?? new DiscordSettings { ClientId = "test-id", ClientSecret = "test-secret" }),

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
@@ -18,12 +18,13 @@ public class ProfileControllerTests : ControllerTestBase
 
     private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<IProfileRepository> _profileRepository = new();
+    private readonly Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver> _roleResolver = new();
 
     public ProfileControllerTests()
     {
-        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>()))
+        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()))
             .Returns("test-jwt-token");
-        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, this._profileRepository.Object, this._jwtService.Object);
+        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, this._profileRepository.Object, this._jwtService.Object, this._roleResolver.Object);
         SetupUser(this._sut);
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileOverviewControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileOverviewControllerTests.cs
@@ -18,10 +18,11 @@ public class ProfileOverviewControllerTests : ControllerTestBase
     private readonly ProfileOverviewController _sut;
 
     private readonly Mock<IJwtService> _jwtService = new();
+    private readonly Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver> _roleResolver = new();
 
     public ProfileOverviewControllerTests()
     {
-        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>()))
+        this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()))
             .Returns("test-jwt-token");
         this._sut = new ProfileOverviewController(
             this._service.Object,
@@ -29,6 +30,7 @@ public class ProfileOverviewControllerTests : ControllerTestBase
             this._profileRepository.Object,
             this._humanProxy.Object,
             this._jwtService.Object,
+            this._roleResolver.Object,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<ProfileOverviewController>.Instance);
         SetupUser(this._sut);
     }


### PR DESCRIPTION
Closes #624
Closes #626

**The session renewed itself.** `GenerateTokenWithReplacedProfile` ended in `WriteToken(claims)` — the overload that applies `JwtSettings.ExpirationMinutes` (1440). It runs on every profile switch and every `/api/auth/me` profile resync. An OIDC login issues a 30-minute access token on purpose, so that revoking a session propagates within roughly one lifetime; a single profile switch turned that into 24 hours, and logout's refresh-family revoke could no longer reach it. Someone switching profile once a day never expired at all. The re-issue now carries the principal's own `exp` through, with a one-minute floor.

**`isAdmin` was copied forward forever.** Every admin check is `User.FindFirstValue("isAdmin") == "true"` and nothing revalidates it. Combined with the above, removing a user from `Poracle:AdminIds` had no effect for as long as they kept switching profile — full `/api/admin/*`, including purge, block and impersonate-anyone. Each re-issue now resolves it live.

**Delegates configured in PoracleJS were locked out (#626).** Role resolution moved out of `AuthController`, where login was its only caller, into `IUserRoleResolver`. Since #601 the admin endpoints resolved delegated webhooks from `poracle_web.webhook_delegates` alone, while the JWT claim is the **union** of that table and PoracleNG's `getAdministrationRoles`. A delegate configured through `delegateAdministration` saw the nav item, an empty My Webhooks page, and a 403 from impersonate. Both paths now ask the same question.

Results are cached for a minute: the resolver makes up to two PoracleNG round-trips and now sits on paths that are not login, so an uncached version would put two HTTP calls on every profile switch. A minute keeps revocation prompt.

## Verification

- 1818 backend tests (6 new in `JwtServiceReissueTests`), covering: a short expiry survives re-issue, an almost-over session is not renewed, a supplied `isAdmin` replaces the copied one, an unsupplied one is preserved, a principal with no `exp` falls back to the configured lifetime, and the profile number is still replaced.
- Role resolution moved verbatim — the login paths behave exactly as before.