### PR TITLE
fix: end a session properly when a 401 discards it (#625, #627, #628)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/interceptors/error.interceptor.ts
@@ -46,9 +46,7 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         // the refresh token and its expiry, so the next load tried to refresh a session the server had
         // already rejected. Navigation is deliberately left alone: routing through AuthService.logout()
         // would append loggedout=1 and suppress the OIDC auto-redirect. See #616.
-        localStorage.removeItem('poracle_token');
-        localStorage.removeItem('poracle_admin_token');
-        tokenStore.clear();
+        tokenStore.clearAll();
         // Preserve any existing query params (e.g. ?error=missing_required_role)
         const params = new URLSearchParams(window.location.search);
         router.navigate(['/login'], { queryParams: Object.fromEntries(params) });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.spec.ts
@@ -288,9 +288,13 @@ describe('AuthService', () => {
       expect(router.navigate).toHaveBeenCalledWith(['/admin']);
     });
 
-    it('should do nothing when no admin token exists', async () => {
+    it('logs out when there is no admin token to go back to', async () => {
+      // Returning silently left a visible Stop impersonating button that did nothing at all -- reachable
+      // whenever a 401 discarded the admin token while the banner was still up. See #627.
       await service.stopImpersonating();
-      expect(router.navigate).not.toHaveBeenCalled();
+
+      expect(service.isImpersonating()).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { loggedout: 1 } });
     });
   });
 
@@ -341,6 +345,22 @@ describe('AuthService', () => {
     it('should resolve with null when no token exists', async () => {
       const result = await service.waitForUser();
       expect(result).toBeNull();
+    });
+  });
+
+  describe('a session discarded by a 401', () => {
+    it('forgets the user and the impersonation state, not just the tokens', () => {
+      // Left set, currentUser rendered the login page inside the signed-in shell and bounced the user
+      // to /dashboard on the next navigation; _isImpersonating kept a banner whose button did nothing.
+      // See #627, #628.
+      localStorage.setItem('poracle_admin_token', 'admin-jwt');
+
+      service.clearSession();
+
+      expect(service.isLoggedIn()).toBe(false);
+      expect(service.isAuthenticated()).toBe(false);
+      expect(service.isImpersonating()).toBe(false);
+      expect(localStorage.getItem('poracle_admin_token')).toBeNull();
     });
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/auth.service.ts
@@ -36,6 +36,10 @@ export class AuthService {
     // A definitively failed silent refresh ends the session.
     this.tokenStore.forceLogout$.subscribe(() => this.logout());
 
+    // The 401 path discards the session from under us; without this the app kept rendering the
+    // signed-in shell and an impersonation banner around the login page. See #627, #628.
+    this.tokenStore.sessionCleared$.subscribe(() => this.clearSession());
+
     const token = localStorage.getItem(TOKEN_KEY);
     if (token) {
       this.loadCurrentUser();
@@ -46,6 +50,22 @@ export class AuthService {
 
   clearProfileResynced(): void {
     this._profileResynced.set(false);
+  }
+
+  /**
+   * Discards every trace of the session without navigating.
+   */
+  /* The 401 path used to remove token keys by hand, which left `currentUser` and `_isImpersonating`
+   * set -- so the login page rendered inside the signed-in shell, complete with an impersonation
+   * banner whose Stop button did nothing, and bounced back to /dashboard on the next navigation.
+   * Deliberately does not navigate: the interceptor preserves the current query params, and going
+   * through logout() would append loggedout=1 and suppress the OIDC auto-redirect. See #627, #628. */
+  clearSession(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(ADMIN_TOKEN_KEY);
+    this._isImpersonating.set(false);
+    this.currentUser.set(null);
+    this.userLoaded$.next(null);
   }
 
   getProviders(): Observable<AuthProviders> {
@@ -163,7 +183,14 @@ export class AuthService {
   /** Restore the admin's original token. */
   async stopImpersonating(): Promise<void> {
     const adminToken = localStorage.getItem(ADMIN_TOKEN_KEY);
-    if (adminToken) {
+    if (!adminToken) {
+      // Nothing to go back to -- the admin token was discarded with the rest of the session. Silently
+      // returning left a visible button that did nothing at all. See #627.
+      this.logout();
+      return;
+    }
+
+    {
       localStorage.setItem(TOKEN_KEY, adminToken);
       localStorage.removeItem(ADMIN_TOKEN_KEY);
       this._isImpersonating.set(false);
@@ -182,7 +209,9 @@ export class AuthService {
   }
 
   private handleAuthResponse(res: LoginResponse): void {
-    localStorage.setItem(TOKEN_KEY, res.token);
+    // Through the store rather than a bare setItem, so a leftover refresh token and expiry from a
+    // previous OIDC session are cleared instead of inherited. See #625.
+    this.tokenStore.storeTokens(res.token, null);
     this.currentUser.set(res.user);
     this.userLoaded$.next(res.user);
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/token-store.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/token-store.service.spec.ts
@@ -97,4 +97,44 @@ describe('TokenStoreService', () => {
     service.revoke();
     httpMock.expectNone('/api/auth/oidc/refresh/revoke');
   });
+
+  describe('a login that carries no refresh token', () => {
+    it('clears a refresh token left behind by a previous session', () => {
+      // A Discord or Telegram login on a browser that had held an OIDC session used to inherit that
+      // session's refresh token, and the refresh interceptor then swapped in a JWT minted for the
+      // previous user. See #625.
+      localStorage.setItem('poracle_refresh_token', 'previous-users-token');
+      localStorage.setItem('poracle_token_expires_at', '1');
+
+      service.storeTokens('new-jwt', null);
+
+      expect(localStorage.getItem('poracle_refresh_token')).toBeNull();
+      expect(service.hasRefreshToken()).toBe(false);
+    });
+
+    it('still keeps a refresh token the new login supplies', () => {
+      service.storeTokens('new-jwt', 'new-refresh', 1800);
+
+      expect(localStorage.getItem('poracle_refresh_token')).toBe('new-refresh');
+    });
+  });
+
+  describe('clearAll', () => {
+    it('discards every key a session consists of and announces it', () => {
+      localStorage.setItem('poracle_token', 'jwt');
+      localStorage.setItem('poracle_admin_token', 'admin-jwt');
+      localStorage.setItem('poracle_refresh_token', 'refresh');
+      localStorage.setItem('poracle_token_expires_at', '1');
+      let announced = false;
+      service.sessionCleared$.subscribe(() => (announced = true));
+
+      service.clearAll();
+
+      expect(localStorage.getItem('poracle_token')).toBeNull();
+      expect(localStorage.getItem('poracle_admin_token')).toBeNull();
+      expect(localStorage.getItem('poracle_refresh_token')).toBeNull();
+      expect(localStorage.getItem('poracle_token_expires_at')).toBeNull();
+      expect(announced).toBe(true);
+    });
+  });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/token-store.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/token-store.service.ts
@@ -7,6 +7,8 @@ import { ConfigService } from './config.service';
 const TOKEN_KEY = 'poracle_token';
 const REFRESH_KEY = 'poracle_refresh_token';
 const EXPIRES_KEY = 'poracle_token_expires_at';
+// Owned by AuthService, cleared here so the 401 path can end a session without constructing it.
+const ADMIN_TOKEN_KEY = 'poracle_admin_token';
 
 /** Refresh proactively this many ms before the access token's `exp`. */
 const EXPIRY_SKEW_MS = 60_000;
@@ -34,10 +36,27 @@ export class TokenStoreService {
   /** Emits when a refresh definitively fails — AuthService subscribes and logs the user out. */
   readonly forceLogout$ = new Subject<void>();
 
+  /** Emits when the session was discarded from under the app — AuthService resets its own state. */
+  readonly sessionCleared$ = new Subject<void>();
+
   /** Clears the refresh token + expiry (the main JWT is owned by AuthService). */
   clear(): void {
     localStorage.removeItem(REFRESH_KEY);
     localStorage.removeItem(EXPIRES_KEY);
+  }
+
+  /**
+   * Discards every key a session consists of, and tells AuthService to forget the user.
+   */
+  /* The 401 path used to remove poracle_token by hand, leaving the admin impersonation token, the
+   * refresh token and the expiry behind, and leaving AuthService still holding a user. It lives here
+   * rather than on AuthService because an interceptor that injects AuthService constructs it, and
+   * constructing it fires a /api/auth/me request. See #616, #627, #628. */
+  clearAll(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(ADMIN_TOKEN_KEY);
+    this.clear();
+    this.sessionCleared$.next();
   }
 
   getAccessToken(): string | null {
@@ -110,8 +129,15 @@ export class TokenStoreService {
   storeTokens(token: string, refreshToken: string | null, expiresInSeconds?: number): void {
     localStorage.setItem(TOKEN_KEY, token);
 
+    // Cleared, not left alone, when the new login has no refresh token of its own. A Discord or
+    // Telegram login on a browser that previously held an OIDC session used to inherit that session's
+    // refresh token: the refresh interceptor then saw hasRefreshToken() true, posted the stale token,
+    // and replaced the JWT with one minted for the previous user. See #625.
     if (refreshToken) {
       localStorage.setItem(REFRESH_KEY, refreshToken);
+    } else {
+      localStorage.removeItem(REFRESH_KEY);
+      localStorage.removeItem(EXPIRES_KEY);
     }
 
     const expiresAt = expiresInSeconds ? Date.now() + expiresInSeconds * 1000 : this.decodeExpiry(token);

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/auth/login.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/auth/login.component.spec.ts
@@ -48,6 +48,7 @@ describe('LoginComponent', () => {
             getProviders: jest.fn(() => (opts?.providersError ? throwError(() => new Error('fail')) : of(providers))),
             loginWithOidc: jest.fn(),
             getTelegramConfig: jest.fn(() => of({ botUsername: '', enabled: false })),
+            isAuthenticated: jest.fn(() => false),
             isLoggedIn: jest.fn(() => false),
             loginWithDiscord: jest.fn(),
             loginWithTelegram: jest.fn(),

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/auth/login.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/auth/login.component.ts
@@ -198,8 +198,10 @@ export class LoginComponent implements OnInit {
       localStorage.removeItem('poracle_admin_token');
     }
 
-    // If already logged in and no error, redirect
-    if (!errorCode && this.auth.isLoggedIn()) {
+    // Keyed on the token, not on a currentUser that outlived it. After a 401 the user object was still
+    // set, so login sent the user to /dashboard, authGuard found no token and sent them back, and the
+    // OIDC auto-redirect below never ran. See #628.
+    if (!errorCode && this.auth.isAuthenticated()) {
       this.router.navigate(['/dashboard']);
       return;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- A login that carries no refresh token now clears any refresh token left behind by a previous session, instead of inheriting it and letting the refresh interceptor swap in a JWT minted for the previous user (#625)
 - A token re-issue no longer restarts the session clock: profile switches and profile resyncs keep the original expiry instead of applying the 24-hour default, so a short OIDC access token stays short and revocation propagates as documented (#624)
 - `isAdmin` is resolved live on every token re-issue rather than copied forward, so removing someone's admin rights takes effect instead of surviving indefinitely while they switch profile (#624)
 - Webhook delegates configured in PoracleJS can use the My Webhooks page again: the live resolution now unions PoracleNG's delegate list with PoracleWeb's own table, as the JWT claim always did (#626)
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The impersonation banner no longer survives a 401 with a Stop button that does nothing; with no admin token to restore, it now signs out (#627)
+- After a session expires, the login page no longer bounces to the dashboard and back, and the OIDC auto-redirect runs as it should (#628)
 - The Add Raid dialog no longer offers a level picker on the By Boss tab, where PoracleNG discards the chosen level and stores "any" (#615)
 - A 401 now clears the whole session rather than the access token alone, so the admin impersonation token and a dead refresh token no longer survive it (#616)
 - The delivery preview no longer spins forever in every alarm dialog when `disable_location` is on (#617)


### PR DESCRIPTION
Closes #625
Closes #627
Closes #628

**#625 — a stale refresh token outlived its session.** `storeTokens` wrote `poracle_refresh_token` only when the new login supplied one and never removed an existing value. A Discord or Telegram login on a browser that had held an OIDC session inherited that session's refresh token and expiry; `oidcRefreshInterceptor` then posted it and overwrote the JWT with one minted for **the previous user**. `handleAuthResponse` bypassed the store entirely, which is how the Telegram path reached that state — it now goes through it.

**#627 / #628 — the 401 path cleared tokens and nothing else.** `AuthService` kept `currentUser` and `_isImpersonating`, so the app rendered the login page inside the full signed-in shell with a "Viewing as" banner, and the login page's own `isLoggedIn()` check sent the user to `/dashboard` where `authGuard` sent them back — with the OIDC auto-redirect never firing because the router reuses the component.

Teardown lives on `TokenStoreService.clearAll()`, not `AuthService`: an interceptor that injects `AuthService` **constructs** it, and its constructor fires `/api/auth/me`. The store announces the teardown and `AuthService` listens. `stopImpersonating()` now signs out when there is no admin token to restore, instead of returning silently behind a visible button.

Navigation is deliberately unchanged — still `/login` with the current query params preserved, not `logout()`'s `loggedout=1`.

## Verification

- 949 frontend tests (4 new): a login with no refresh token clears the previous one, a supplied one is kept, `clearAll` discards all four keys and announces it, and `clearSession` forgets the user and the impersonation state.
- One existing test was updated deliberately: `stopImpersonating` with no admin token asserted "does nothing", which was the defect.