### PR TITLE
fix: seven defects across admin settings and quick picks (#629-#634, #637)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -514,11 +514,11 @@ export class AdminSettingsComponent implements OnInit {
     const query = this.searchQuery().trim();
     const base = SETTING_GROUPS.filter(g => {
       if (oidcMode && localProviderGroups.has(g.labelKey)) return false;
-      return (
-        g.settings.some(s => this.settingMap().has(s.key)) ||
-        (g.labelKey === 'ADMIN_SETTINGS.GROUP_DISCORD' && this.discordConfig() !== null) ||
-        (g.labelKey === 'ADMIN_SETTINGS.GROUP_TELEGRAM' && this.telegramConfig() !== null)
-      );
+      // Deliberately not gated on a key already having a row. A fresh install seeds exactly one
+      // (custom_title), so Alarm Types, Features, Administration and Analytics were filtered out of the
+      // DOM entirely -- and since this page is the only writer, the row could never appear. The
+      // row-level guard below already renders an absent key correctly. See #629.
+      return true;
     });
     if (!query) return base;
     return base.map(g => ({ ...g, settings: g.settings.filter(s => this.settingMatches(s)) })).filter(g => g.settings.length > 0);
@@ -685,7 +685,13 @@ export class AdminSettingsComponent implements OnInit {
   }
 
   saveAllModified(): void {
-    const entries = Array.from(this.modifiedSettings().entries());
+    // Enables first. The anti-lockout guard on the server reads the *other* login key from the
+    // database, so turning Discord off and Telegram on in one batch failed on whichever request landed
+    // first: the Discord PUT still saw enable_telegram false and answered 400, leaving a partial save
+    // and a message about a state the admin was in the middle of leaving. See #633.
+    const entries = Array.from(this.modifiedSettings().entries()).sort(
+      ([, a], [, b]) => Number(this.isDisablingLogin(b)) - Number(this.isDisablingLogin(a)),
+    );
     if (!entries.length) return;
     this.bulkSaving.set(true);
     let done = 0,
@@ -811,6 +817,11 @@ export class AdminSettingsComponent implements OnInit {
           ? errorMessages.join(' ')
           : this.i18n.instant('ADMIN_SETTINGS.SAVE_PARTIAL', { done, errors });
     this.snackBar.open(msg, this.i18n.instant('COMMON.OK'), { duration: errors ? 5000 : 3000 });
+  }
+
+  /** Whether a pending value would switch a login method off. See #633. */
+  private isDisablingLogin(value: unknown): boolean {
+    return String(value).toLowerCase() === 'false';
   }
 
   private settingMatches(meta: SettingMeta): boolean {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-users.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-users.component.ts
@@ -56,7 +56,11 @@ export class AdminUsersComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly dialog = inject(MatDialog);
-  private readonly discordUsers = computed(() => this.allUsers().filter(u => u.type?.startsWith('discord')));
+  // Everything that is not a webhook, so this tab and the Webhooks tab together account for every
+  // account. Filtering to discord* meant a Telegram user appeared in neither list, and every admin
+  // action here is list-driven -- so they could not be blocked, paused, purged or impersonated at all.
+  // See #632.
+  private readonly discordUsers = computed(() => this.allUsers().filter(u => u.type !== 'webhook'));
 
   private readonly i18n = inject(I18nService);
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -134,6 +134,15 @@ export class QuickPickAdminDialogComponent implements OnInit {
 
   readonly saving = signal(false);
 
+  /**
+   * Where this pick belongs: an edit keeps its own scope, a new one follows who is creating it.
+   */
+  /* Deciding purely from isAdmin meant an admin editing their *own* personal pick posted scope
+   * 'global', and SaveAdminPickAsync then republished it to every user and stripped its owner. The
+   * list's delete path already branched on scope; only save did not. See #631. */
+  readonly targetScope = (): 'global' | 'user' =>
+    this.isEdit ? (this.data?.scope === 'global' ? 'global' : 'user') : this.isAdmin ? 'global' : 'user';
+
   get currentAlarmType(): string {
     return this.mainForm.controls.alarmType.value ?? 'monster';
   }
@@ -204,11 +213,11 @@ export class QuickPickAdminDialogComponent implements OnInit {
       enabled: main.enabled ?? true,
       filters,
       icon: main.icon ?? 'bolt',
-      scope: this.isAdmin ? 'global' : 'user',
+      scope: this.targetScope(),
       sortOrder: main.sortOrder ?? 0,
     };
 
-    const obs = this.isAdmin ? this.quickPickService.saveAdmin(definition) : this.quickPickService.saveUser(definition);
+    const obs = this.targetScope() === 'global' ? this.quickPickService.saveAdmin(definition) : this.quickPickService.saveUser(definition);
 
     obs.subscribe({
       error: () => {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
@@ -15,6 +15,9 @@ import { I18nService } from '../../core/services/i18n.service';
 import { QuickPickService } from '../../core/services/quick-pick.service';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 
+/** Marks that the built-in presets have been seeded once, so an empty list stays empty. See #634. */
+const SEEDED_KEY = 'poracle-quick-picks-seeded';
+
 @Component({
   imports: [
     MatCardModule,
@@ -94,8 +97,11 @@ export class QuickPickListComponent implements OnInit {
         this.loading.set(false);
       },
       next: picks => {
-        if (picks.length === 0 && autoSeed && this.isAdmin()) {
-          // First visit with no picks — seed defaults and reload
+        if (picks.length === 0 && autoSeed && this.isAdmin() && !localStorage.getItem(SEEDED_KEY)) {
+          // First visit with no picks — seed defaults and reload. Guarded by a marker because this ran
+          // on *every* empty read: an admin who deleted the presets on purpose got all thirty back on
+          // their next visit, with no prompt and no way to keep an empty list. See #634.
+          localStorage.setItem(SEEDED_KEY, '1');
           this.quickPickService.seed().subscribe({
             error: () => this.loading.set(false),
             next: () => this.loadPicks(false),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Seeding the built-in quick picks no longer aborts partway: two invasion presets carry empty filters on purpose and were rejected by the save-time validation added in #604, so both the first-visit auto-seed and Reset to Defaults left a partial preset list (#637)
+- The admin Settings page shows every group on a fresh install; Alarm Types, Features, Administration and Analytics were hidden until their rows existed, and this page is the only thing that creates them (#629)
+- Resetting quick picks to defaults now clears the applied state of the picks it removes, instead of orphaning a row per user and profile (#630)
+- An admin editing their own personal quick pick no longer publishes it to every user, and an admin save can no longer take over a pick belonging to someone else (#631)
+- Telegram accounts appear in the admin Users list, so they can be blocked, paused, purged and impersonated like any other account (#632)
+- Switching login provider in one save no longer fails on whichever request lands first: enables are applied before disables so the anti-lockout guard never sees a half-applied batch (#633)
+- Deleting all global quick picks sticks instead of being undone by an auto-reseed on the next admin visit (#634)
 - The impersonation banner no longer survives a 401 with a Stop button that does nothing; with no admin token to restore, it now signs out (#627)
 - After a session expires, the login page no longer bounces to the dashboard and back, and the OIDC auto-redirect runs as it should (#628)
 - The Add Raid dialog no longer offers a level picker on the By Boss tab, where PoracleNG discards the chosen level and stores "any" (#615)

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -133,6 +133,17 @@ public partial class QuickPickService(
     /// </remarks>
     private static void EnsureFiltersAreUsable(QuickPickDefinition definition)
     {
+        // Nothing to check, and checking anyway broke seeding. Two built-ins -- all-invasions and
+        // invasion-leader -- carry no filters on purpose because ApplyInvasionAsync fans them out across
+        // grunt types at apply time, so the sample alarm built here has no grunt_type and the Create DTO
+        // requires one. SeedDefaultsAsync goes through this method, so it threw partway and left a
+        // partial preset list behind both entry points that call it. Apply-time validation (#565) still
+        // covers the alarm that actually gets built. See #637.
+        if (definition.Filters is null || definition.Filters.Count == 0)
+        {
+            return;
+        }
+
         try
         {
             BuildSampleAlarm(definition, 0, new QuickPickApplyRequest());
@@ -155,6 +166,18 @@ public partial class QuickPickService(
         EnsureFiltersAreUsable(definition);
 
         definition.Id = await this.EnsureIdAsync(definition);
+
+        // Given an id, this used to convert whatever it found into a global pick -- including a private
+        // one belonging to somebody else, which then appeared for every user and vanished from its
+        // owner's list. SaveUserPickAsync has always had this guard. See #631.
+        var existing = await this._definitionRepository.GetByIdAsync(definition.Id);
+        if (existing is not null
+            && !string.Equals(existing.Scope, "global", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AlarmValidationException(
+                "That quick pick belongs to a user. Publish a copy instead of converting theirs.");
+        }
+
         definition.Scope = "global";
         definition.OwnerUserId = null;
 
@@ -580,6 +603,16 @@ public partial class QuickPickService(
         // Delete any existing global quick picks so we can re-seed cleanly
         var existingGlobal = await this._definitionRepository.GetAllGlobalAsync();
         var existingCount = existingGlobal.Count;
+
+        // Applied state goes with the definitions it belongs to, exactly as DeleteAdminPickAsync does
+        // (#470). Without this, every user kept a row pointing at a definition that no longer exists:
+        // GetAllAsync iterates definitions, so the state was never listed and never cleaned, and the
+        // alarms it owned lost their Remove button for good. Worse, a later pick generating a colliding
+        // slug re-attached that state, and its trackedUids then named unrelated alarms. See #630.
+        foreach (var stale in existingGlobal)
+        {
+            await this._appliedStateRepository.DeleteByQuickPickIdAsync(stale.Id);
+        }
 
         await this._definitionRepository.DeleteAllGlobalAsync();
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
@@ -326,6 +326,71 @@ public class QuickPickServiceSecurityTests
     // then collapsed to /api/quick-picks/ so the pick could not be deleted or applied through any path.
 
     [Fact]
+    public async Task SaveAdminPickRefusesToTakeOverAUsersPrivatePick()
+    {
+        // Given an id it converted whatever it found into a global pick -- so an admin editing their own
+        // personal pick republished it to everyone, and an admin could take over anybody's. See #631.
+        this._definitionRepository.Setup(r => r.GetByIdAsync("someones-pick"))
+            .ReturnsAsync(new QuickPickDefinition { Id = "someones-pick", Scope = "user", OwnerUserId = "u2" });
+
+        await Assert.ThrowsAsync<AlarmValidationException>(
+            () => this._sut.SaveAdminPickAsync(new QuickPickDefinition { Id = "someones-pick", Name = "Mine now" }));
+
+        this._definitionRepository.Verify(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickDefinition>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveAdminPickStillUpdatesAnExistingGlobalPick()
+    {
+        this._definitionRepository.Setup(r => r.GetByIdAsync("raid-5star"))
+            .ReturnsAsync(new QuickPickDefinition { Id = "raid-5star", Scope = "global" });
+
+        var saved = await this._sut.SaveAdminPickAsync(new QuickPickDefinition { Id = "raid-5star", Name = "Five star" });
+
+        Assert.Equal("global", saved.Scope);
+        this._definitionRepository.Verify(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickDefinition>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SeedingDefaultsCreatesEveryBuiltInPick()
+    {
+        // Save-time filter validation (#604) rejected all-invasions and invasion-leader, whose filter
+        // sets are empty on purpose, so seeding aborted partway and left a partial preset list behind
+        // both the first-visit auto-seed and Reset to Defaults. See #637.
+        this._definitionRepository.Setup(r => r.GetAllGlobalAsync()).ReturnsAsync([]);
+        this._definitionRepository.Setup(r => r.GetByIdAsync(It.IsAny<string>())).ReturnsAsync((QuickPickDefinition?)null);
+        var created = new List<string>();
+        this._definitionRepository.Setup(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickDefinition>()))
+            .Callback<QuickPickDefinition>(d => created.Add(d.Id))
+            .Returns(Task.CompletedTask);
+
+        await this._sut.SeedDefaultsAsync();
+
+        var expected = (await this._sut.GetDefaultPicksAsync()).Select(d => d.Id).ToList();
+        Assert.Equal(expected.Count, created.Count);
+        Assert.Contains("all-invasions", created);
+        Assert.Contains("invasion-leader", created);
+    }
+
+    [Fact]
+    public async Task SeedingDefaultsClearsTheAppliedStateOfEveryPickItRemoves()
+    {
+        // Left behind, that state named a definition that no longer exists: never listed, never cleaned,
+        // and the alarms it owned lost their Remove button for good. See #630.
+        this._definitionRepository.Setup(r => r.GetAllGlobalAsync())
+            .ReturnsAsync([
+                new QuickPickDefinition { Id = "old-one", Scope = "global" },
+                new QuickPickDefinition { Id = "old-two", Scope = "global" },
+            ]);
+        this._definitionRepository.Setup(r => r.GetByIdAsync(It.IsAny<string>())).ReturnsAsync((QuickPickDefinition?)null);
+
+        await this._sut.SeedDefaultsAsync();
+
+        this._appliedStateRepository.Verify(r => r.DeleteByQuickPickIdAsync("old-one", null), Times.Once);
+        this._appliedStateRepository.Verify(r => r.DeleteByQuickPickIdAsync("old-two", null), Times.Once);
+    }
+
+    [Fact]
     public async Task SaveAdminPickGeneratesASlugWhenNoIdIsSupplied()
     {
         this._definitionRepository.Setup(r => r.GetByIdAsync(It.IsAny<string>())).ReturnsAsync((QuickPickDefinition?)null);


### PR DESCRIPTION
Closes #629
Closes #630
Closes #631
Closes #632
Closes #633
Closes #634
Closes #637

**#637 — seeding has been broken since #604**, and it turned up because a test written for #630 tripped over it. `SeedDefaultsAsync` creates the built-ins through `SaveAdminPickAsync`, which now validates filters; `all-invasions` and `invasion-leader` carry **empty** filter sets on purpose (`ApplyInvasionAsync` fans them out across grunt types at apply time), so the sample alarm has no `gruntType` and the `[Required]` on the Create DTO threw. The loop aborted at sort order 50, so both the first-visit auto-seed and Reset to Defaults left a partial preset list. A definition with no filters now has nothing to check; apply-time validation (#565) still covers the alarm that gets built.

**#629 — a fresh install could not reach any `disable_*` toggle.** `visibleGroups` kept a group only if one of its keys already had a row, and the seed writes exactly one (`custom_title`). Four groups were filtered out of the DOM, and this page is the only thing that writes those rows — a closed loop.

**#630 — Reset to Defaults orphaned applied state.** Unlike the single-pick delete (#470), the reseed dropped definitions without clearing `quick_pick_applied_states`. The stale rows were never listed and never cleaned, the alarms they owned lost their Remove button, and a later pick generating a colliding slug re-attached state whose `trackedUids` then named unrelated alarms.

**#631 — an admin's own personal pick got published to everyone.** The dialog chose scope from `isAdmin` rather than from the pick. `SaveAdminPickAsync` also had no ownership guard and would convert *any* user's private pick to a global one.

**#632 — Telegram accounts were administrable by nobody.** The Users tab filtered to `discord*` and the Webhooks tab to `webhook`, so `telegram:user` appeared in neither, and every admin action is list-driven. The Users tab is now the exact complement of the Webhooks tab.

**#633 — switching login provider raced the anti-lockout guard**, which reads the *other* key from the database. Enables are now applied before disables.

**#634 — deleting all global quick picks was undone** by an auto-reseed on the next admin visit. Now guarded by a marker, so an empty list stays empty.

## Verification

- 1822 backend tests (4 new), 949 frontend tests, lint and prettier clean.
- The new seeding test asserts every built-in is created and names the two that were being dropped, so #637 cannot come back silently.