### PR TITLE
fix: five defects across the alarm lists and areas (#639-#643)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/monster.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/monster.service.spec.ts
@@ -139,7 +139,9 @@ describe('MonsterService', () => {
 
     const req = httpMock.expectOne(`${API}/api/monsters/distance`);
     expect(req.request.method).toBe('PUT');
-    expect(req.request.body).toEqual({ distance: 5000 });
+    // A bare number, as every sibling service sends and as [FromBody] int binds. This assertion used
+    // to require the object shape that 400'd, which is how the bug survived. See #640.
+    expect(req.request.body).toBe(5000);
     req.flush(null);
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/monster.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/monster.service.ts
@@ -31,7 +31,9 @@ export class MonsterService {
   }
 
   updateAllDistance(distance: number): Observable<void> {
-    return this.http.put<void>(`${this.config.apiHost}/api/monsters/distance`, { distance });
+    // A bare number, as every sibling sends and as [FromBody] int binds. Wrapped in an object it
+    // could not deserialize, so this 400'd every time. See #640.
+    return this.http.put<void>(`${this.config.apiHost}/api/monsters/distance`, distance);
   }
 
   updateBulkDistance(uids: number[], distance: number): Observable<void> {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.html
@@ -211,9 +211,13 @@
     <!-- Floating Save Bar -->
     @if (hasChanges()) {
       <div class="save-bar">
-        <span class="save-info">{{ 'AREAS.SELECTION_SUMMARY' | translate: { count: selectedAreas().length } }}</span>
+        @if (selectionUnknown()) {
+          <span class="save-info">{{ 'AREAS.SELECTION_UNKNOWN' | translate }}</span>
+        } @else {
+          <span class="save-info">{{ 'AREAS.SELECTION_SUMMARY' | translate: { count: selectedAreas().length } }}</span>
+        }
         <button mat-button (click)="cancelChanges()">{{ 'AREAS.CANCEL_CHANGES' | translate }}</button>
-        <button mat-raised-button color="primary" (click)="saveAreas()" [disabled]="saving()">
+        <button mat-raised-button color="primary" (click)="saveAreas()" [disabled]="saving() || selectionUnknown()">
           @if (saving()) {
             <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
           } @else {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.ts
@@ -139,6 +139,9 @@ export class AreaListComponent implements OnInit {
 
   searchText = '';
 
+  /** True when the saved selection could not be read, which makes saving unsafe. See #643. */
+  readonly selectionUnknown = signal(false);
+
   readonly userLocationForMap = computed(() => {
     const loc = this.location();
     if (loc && loc.latitude && loc.longitude) {
@@ -333,8 +336,19 @@ export class AreaListComponent implements OnInit {
       .getSelected()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        error: () => check(),
+        // A page that could not read the current subscriptions must not offer to overwrite them. This
+        // arm used to advance the counter and nothing else, so a single failed GET /api/areas rendered
+        // every checkbox unticked and "0 areas selected" with no error -- and saving then posted only
+        // whatever the user ticked next, destroying every other subscription they had. See #643.
+        error: () => {
+          this.selectionUnknown.set(true);
+          this.snackBar.open(this.i18n.instant('AREAS.SNACK_LOAD_SELECTED_FAILED'), this.i18n.instant('TOAST.OK'), {
+            duration: 6000,
+          });
+          check();
+        },
         next: areas => {
+          this.selectionUnknown.set(false);
           this.savedSelection = [...areas];
           this.selectedAreas.set(areas);
           check();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
@@ -89,7 +89,7 @@ export class FortChangeEditDialogComponent {
         distance: dist,
         fortType: v.fortType,
         includeEmpty: v.includeEmpty ? 1 : 0,
-        template: v.template || null,
+        template: v.template || '',
       } as FortChangeUpdate)
       .subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-list.component.ts
@@ -88,7 +88,18 @@ export class FortChangeListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.fortChangeService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.fortChangeService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('FORT_CHANGES.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadItems();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.ts
@@ -98,7 +98,7 @@ export class GymEditDialogComponent {
         gymId: this.selectedGymId() ?? '',
         slotChanges: v.slotChanges ? 1 : 0,
         team: this.data.team,
-        template: v.template || null,
+        template: v.template || '',
       } as GymUpdate)
       .subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-list.component.ts
@@ -93,7 +93,18 @@ export class GymListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.gymService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.gymService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('GYMS.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadGyms();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.ts
@@ -116,7 +116,7 @@ export class InvasionEditDialogComponent {
         // also match female Mixed grunts.
         gender: this.hideGender ? (this.data.gender ?? 0) : (v.gender ?? 0),
         gruntType: this.data.gruntType ?? '',
-        template: v.template || null,
+        template: v.template || '',
       } as InvasionUpdate)
       .subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-list.component.ts
@@ -100,7 +100,18 @@ export class InvasionListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.invasionService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.invasionService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('INVASIONS.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadInvasions();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.ts
@@ -97,7 +97,7 @@ export class LureEditDialogComponent {
         clean: preserve(this.data.clean, AUTO_DELETE | EDIT, compose(!!v.clean, !!v.editInPlace, false)),
         distance: dist,
         lureId: this.data.lureId,
-        template: v.template || null,
+        template: v.template || '',
       } as LureUpdate)
       .subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-list.component.ts
@@ -90,7 +90,18 @@ export class LureListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.lureService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.lureService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('LURES.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadLures();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-list.component.ts
@@ -93,7 +93,18 @@ export class MaxBattleListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const ids = [...this.selectedIds()];
-      await firstValueFrom(this.maxBattleService.updateBulkDistance(ids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.maxBattleService.updateBulkDistance(ids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('MAX_BATTLES.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadData();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.ts
@@ -86,7 +86,7 @@ export class NestEditDialogComponent {
         distance: dist,
         minSpawnAvg: v.minSpawnAvg ?? 0,
         pokemonId: this.data.pokemonId,
-        template: v.template || null,
+        template: v.template || '',
       } as NestUpdate)
       .subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-list.component.ts
@@ -95,7 +95,18 @@ export class NestListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.nestService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.nestService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('NESTS.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadNests();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.ts
@@ -164,7 +164,7 @@ export class PokemonEditDialogComponent implements OnInit {
       pvpRankingWorst: values.pvpRankingLeague ? (values.pvpRankingWorst ?? 100) : 4096,
       size: values.size ?? -1,
       sta: values.sta ?? 0,
-      template: values.template || null,
+      template: values.template || '',
     };
 
     this.monsterService.update(this.data.uid, update).subscribe({

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.ts
@@ -191,7 +191,18 @@ export class PokemonListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.monsterService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.monsterService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('POKEMON.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadMonsters();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.ts
@@ -159,7 +159,7 @@ export class QuestEditDialogComponent {
       reward: this.data.reward,
       rewardType: this.data.rewardType,
       shiny: this.data.shiny,
-      template: values.template || null,
+      template: values.template || '',
     };
 
     this.questService.update(this.data.uid, update).subscribe({

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-list.component.ts
@@ -103,7 +103,18 @@ export class QuestListComponent implements OnInit {
     const distance = await firstValueFrom(ref.afterClosed());
     if (distance !== null && distance !== undefined) {
       const uids = [...this.selectedIds()];
-      await firstValueFrom(this.questService.updateBulkDistance(uids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        await firstValueFrom(this.questService.updateBulkDistance(uids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('QUESTS.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadQuests();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.ts
@@ -140,7 +140,7 @@ export class RaidEditDialogComponent {
         pokemonId: raid.pokemonId,
         rsvpChanges: values.rsvpChanges ?? 0,
         team: values.team ?? 4,
-        template: values.template || null,
+        template: values.template || '',
       };
       this.raidService.update(this.data.item.uid, update).subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which
@@ -166,7 +166,7 @@ export class RaidEditDialogComponent {
         level: egg.level,
         rsvpChanges: values.rsvpChanges ?? 0,
         team: values.team ?? 4,
-        template: values.template || null,
+        template: values.template || '',
       };
       this.eggService.update(this.data.item.uid, update).subscribe({
         // The server names what is wrong -- which alarm already uses these settings, which

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.html
@@ -66,7 +66,7 @@
     }
   </div>
 } @else {
-  <mat-tab-group>
+  <mat-tab-group [selectedIndex]="activeTab()" (selectedIndexChange)="activeTab.set($event)">
     <!-- Raids Tab -->
     <mat-tab>
       <ng-template mat-tab-label>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-list.component.ts
@@ -61,20 +61,23 @@ export class RaidListComponent implements OnInit {
   private readonly raidService = inject(RaidService);
   private readonly scannerService = inject(ScannerService);
   private readonly snackBar = inject(MatSnackBar);
-  readonly eggs = signal<Egg[]>([]);
+  /** Which tab is in front: 0 raids, 1 eggs. Bulk actions are scoped to it. See #642. */
+  readonly activeTab = signal(0);
 
+  readonly eggs = signal<Egg[]>([]);
   readonly gymNames = signal<Record<string, string>>({});
   readonly loading = signal(true);
   readonly raids = signal<Raid[]>([]);
+
   // Keyed "raid:12" / "egg:12", not by the bare uid. Raid and egg uids come from separate
   // auto-increment sequences and do collide; with one set of integers covering both grids, ticking
   // one card ticked the other, and the bulk actions sent both to the raid endpoint -- deleting or
   // resizing the raid twice and leaving the egg alone. See #540.
   readonly selectedIds = signal(new Set<string>());
-
   readonly selectMode = signal(false);
   readonly skeletonCards = Array.from({ length: 6 });
   readonly testAlertService = inject(TestAlertService);
+
   async bulkDelete(): Promise<void> {
     const ref = this.dialog.open(ConfirmDialogComponent, {
       data: {
@@ -120,8 +123,19 @@ export class RaidListComponent implements OnInit {
       const keys = [...this.selectedIds()];
       const selectedRaidUids = this.uidsOfKind(keys, 'raid');
       const selectedEggUids = this.uidsOfKind(keys, 'egg');
-      if (selectedRaidUids.length > 0) await firstValueFrom(this.raidService.updateBulkDistance(selectedRaidUids, distance));
-      if (selectedEggUids.length > 0) await firstValueFrom(this.eggService.updateBulkDistance(selectedEggUids, distance));
+      // The server refuses a radius that would take over an alarm the user did not select, and names
+      // the one in the way. Unguarded, that rejection cleared nothing, reloaded nothing and showed
+      // nothing -- indistinguishable from a successful no-op. See #641.
+      try {
+        if (selectedRaidUids.length > 0) await firstValueFrom(this.raidService.updateBulkDistance(selectedRaidUids, distance));
+        if (selectedEggUids.length > 0) await firstValueFrom(this.eggService.updateBulkDistance(selectedEggUids, distance));
+      } catch (err) {
+        const message = (err as { error?: { error?: string } })?.error?.error;
+        this.snackBar.open(message ?? this.i18n.instant('RAIDS.SNACK_FAILED_DISTANCE'), this.i18n.instant('TOAST.OK'), {
+          duration: 5000,
+        });
+        return;
+      }
       this.selectedIds.set(new Set());
       this.selectMode.set(false);
       this.loadData();
@@ -372,9 +386,15 @@ export class RaidListComponent implements OnInit {
   }
 
   selectAll(): void {
+    // The visible tab only. Selecting both meant a user on the Raids tab pressed Select All, saw a
+    // count that included eggs they could not see, and Delete took those too -- reported as a plain
+    // "deleted N alarms". Every other list scopes this to what is rendered. See #642.
     const keys = new Set<string>();
-    this.raids().forEach(r => keys.add(this.selectionKey('raid', r.uid)));
-    this.eggs().forEach(e => keys.add(this.selectionKey('egg', e.uid)));
+    if (this.activeTab() === 0) {
+      this.raids().forEach(r => keys.add(this.selectionKey('raid', r.uid)));
+    } else {
+      this.eggs().forEach(e => keys.add(this.selectionKey('egg', e.uid)));
+    }
     this.selectedIds.set(keys);
   }
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Rediger beskeden på stedet",
     "EDIT_HINT": "Opdaterer den eksisterende Discord-besked, når lokkemodulet ændres, i stedet for at sende en ny.",
     "EDIT_BADGE": "Rediger",
-    "CONFIRM_DELETE_TITLE": "Slet lokkemodul-alarm?"
+    "CONFIRM_DELETE_TITLE": "Slet lokkemodul-alarm?",
+    "SNACK_FAILED_DISTANCE": "Afstanden kunne ikke opdateres."
   },
   "NESTS": {
     "PAGE_TITLE": "Rede-alarmer",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Kunne ikke oprette alarm",
     "SNACK_FAILED_UPDATE": "Kunne ikke opdatere alarm",
     "SNACK_FAILED_DELETE": "Kunne ikke slette alarm",
-    "CONFIRM_DELETE_TITLE": "Slet rede-alarm?"
+    "CONFIRM_DELETE_TITLE": "Slet rede-alarm?",
+    "SNACK_FAILED_DISTANCE": "Afstanden kunne ikke opdateres."
   },
   "GYMS": {
     "PAGE_TITLE": "Gym-alarmer",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
     "TEAM_UNKNOWN": "Hold {{id}}",
-    "CONFIRM_DELETE_TITLE": "Slet gym-alarm?"
+    "CONFIRM_DELETE_TITLE": "Slet gym-alarm?",
+    "SNACK_FAILED_DISTANCE": "Afstanden kunne ikke opdateres."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-ændringsalarmer",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Kunne ikke opdatere placering",
     "SEARCH_AREAS": "Søg områder",
     "MANUAL_ADD_PLACEHOLDER": "Indtast et områdenavn og tryk Enter",
-    "FILTER_PLACEHOLDER": "Filtrer efter navn..."
+    "FILTER_PLACEHOLDER": "Filtrer efter navn...",
+    "SNACK_LOAD_SELECTED_FAILED": "Dine nuværende områder kunne ikke indlæses. Genindlæs, før du ændrer dem.",
+    "SELECTION_UNKNOWN": "Dine nuværende områder kunne ikke indlæses — genindlæs siden før du gemmer."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profiler",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Nachricht direkt bearbeiten",
     "EDIT_HINT": "Aktualisiert die vorhandene Discord-Nachricht bei Änderungen am Lockmodul, statt eine neue zu senden.",
     "EDIT_BADGE": "Bearbeiten",
-    "CONFIRM_DELETE_TITLE": "Lockmodul-Alarm löschen?"
+    "CONFIRM_DELETE_TITLE": "Lockmodul-Alarm löschen?",
+    "SNACK_FAILED_DISTANCE": "Die Entfernung konnte nicht aktualisiert werden."
   },
   "NESTS": {
     "PAGE_TITLE": "Nest-Alarme",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Alarm konnte nicht erstellt werden",
     "SNACK_FAILED_UPDATE": "Alarm konnte nicht aktualisiert werden",
     "SNACK_FAILED_DELETE": "Alarm konnte nicht gelöscht werden",
-    "CONFIRM_DELETE_TITLE": "Nest-Alarm löschen?"
+    "CONFIRM_DELETE_TITLE": "Nest-Alarm löschen?",
+    "SNACK_FAILED_DISTANCE": "Die Entfernung konnte nicht aktualisiert werden."
   },
   "GYMS": {
     "PAGE_TITLE": "Arena-Alarme",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Wagemut",
     "TEAM_INSTINCT": "Intuition",
     "TEAM_UNKNOWN": "Team {{id}}",
-    "CONFIRM_DELETE_TITLE": "Arena-Alarm löschen?"
+    "CONFIRM_DELETE_TITLE": "Arena-Alarm löschen?",
+    "SNACK_FAILED_DISTANCE": "Die Entfernung konnte nicht aktualisiert werden."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-Änderungs-Alarme",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Standort konnte nicht aktualisiert werden",
     "SEARCH_AREAS": "Gebiete suchen",
     "MANUAL_ADD_PLACEHOLDER": "Gebietsnamen eingeben und Eingabetaste drücken",
-    "FILTER_PLACEHOLDER": "Nach Name filtern..."
+    "FILTER_PLACEHOLDER": "Nach Name filtern...",
+    "SNACK_LOAD_SELECTED_FAILED": "Deine aktuellen Gebiete konnten nicht geladen werden. Lade neu, bevor du sie änderst.",
+    "SELECTION_UNKNOWN": "Deine aktuellen Gebiete konnten nicht geladen werden — lade die Seite neu, bevor du speicherst."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profile",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Edit message in place",
     "EDIT_HINT": "Update the existing Discord message when the lure changes instead of sending a new one.",
     "EDIT_BADGE": "Edit",
-    "CONFIRM_DELETE_TITLE": "Delete Lure Alarm?"
+    "CONFIRM_DELETE_TITLE": "Delete Lure Alarm?",
+    "SNACK_FAILED_DISTANCE": "Could not update the distance."
   },
   "NESTS": {
     "PAGE_TITLE": "Nest Alarms",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Failed to create alarm",
     "SNACK_FAILED_UPDATE": "Failed to update alarm",
     "SNACK_FAILED_DELETE": "Failed to delete alarm",
-    "CONFIRM_DELETE_TITLE": "Delete Nest Alarm?"
+    "CONFIRM_DELETE_TITLE": "Delete Nest Alarm?",
+    "SNACK_FAILED_DISTANCE": "Could not update the distance."
   },
   "GYMS": {
     "PAGE_TITLE": "Gym Alarms",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
     "TEAM_UNKNOWN": "Team {{id}}",
-    "CONFIRM_DELETE_TITLE": "Delete Gym Alarm?"
+    "CONFIRM_DELETE_TITLE": "Delete Gym Alarm?",
+    "SNACK_FAILED_DISTANCE": "Could not update the distance."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort Change Alarms",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_CLEARED": "Location cleared",
     "SNACK_LOCATION_FAILED": "Failed to update location",
     "SEARCH_AREAS": "Search areas",
-    "FILTER_PLACEHOLDER": "Filter by name..."
+    "FILTER_PLACEHOLDER": "Filter by name...",
+    "SNACK_LOAD_SELECTED_FAILED": "Could not load your current areas. Reload before changing them.",
+    "SELECTION_UNKNOWN": "Your current areas could not be loaded — reload the page before saving."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profiles",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Editar el mensaje en su lugar",
     "EDIT_HINT": "Actualiza el mensaje de Discord existente cuando cambia el cebo en lugar de enviar uno nuevo.",
     "EDIT_BADGE": "Editar",
-    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de cebo?"
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de cebo?",
+    "SNACK_FAILED_DISTANCE": "No se pudo actualizar la distancia."
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmas de Nido",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Error al crear la alarma",
     "SNACK_FAILED_UPDATE": "Error al actualizar la alarma",
     "SNACK_FAILED_DELETE": "Error al eliminar la alarma",
-    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de nido?"
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de nido?",
+    "SNACK_FAILED_DISTANCE": "No se pudo actualizar la distancia."
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmas de Gimnasio",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
     "TEAM_UNKNOWN": "Equipo {{id}}",
-    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de gimnasio?"
+    "CONFIRM_DELETE_TITLE": "¿Eliminar alarma de gimnasio?",
+    "SNACK_FAILED_DISTANCE": "No se pudo actualizar la distancia."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmas de Cambio de Fort",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Error al actualizar la ubicación",
     "SEARCH_AREAS": "Buscar zonas",
     "MANUAL_ADD_PLACEHOLDER": "Escribe un nombre de área y pulsa Intro",
-    "FILTER_PLACEHOLDER": "Filtrar por nombre..."
+    "FILTER_PLACEHOLDER": "Filtrar por nombre...",
+    "SNACK_LOAD_SELECTED_FAILED": "No se pudieron cargar tus áreas actuales. Recarga antes de cambiarlas.",
+    "SELECTION_UNKNOWN": "No se pudieron cargar tus áreas actuales: recarga la página antes de guardar."
   },
   "PROFILES": {
     "PAGE_TITLE": "Perfiles",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Modifier le message sur place",
     "EDIT_HINT": "Met à jour le message Discord existant lorsque le leurre change au lieu d’en envoyer un nouveau.",
     "EDIT_BADGE": "Modifier",
-    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de module leurre ?"
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de module leurre ?",
+    "SNACK_FAILED_DISTANCE": "Impossible de mettre à jour la distance."
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes Nid",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Échec de la création de l'alarme",
     "SNACK_FAILED_UPDATE": "Échec de la mise à jour de l'alarme",
     "SNACK_FAILED_DELETE": "Échec de la suppression de l'alarme",
-    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de nid ?"
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte de nid ?",
+    "SNACK_FAILED_DISTANCE": "Impossible de mettre à jour la distance."
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes Arène",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Bravoure",
     "TEAM_INSTINCT": "Intuition",
     "TEAM_UNKNOWN": "Équipe {{id}}",
-    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte d'arène ?"
+    "CONFIRM_DELETE_TITLE": "Supprimer l'alerte d'arène ?",
+    "SNACK_FAILED_DISTANCE": "Impossible de mettre à jour la distance."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes Changement de fort",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Échec de la mise à jour de la localisation",
     "SEARCH_AREAS": "Rechercher des zones",
     "MANUAL_ADD_PLACEHOLDER": "Saisissez un nom de zone et appuyez sur Entrée",
-    "FILTER_PLACEHOLDER": "Filtrer par nom..."
+    "FILTER_PLACEHOLDER": "Filtrer par nom...",
+    "SNACK_LOAD_SELECTED_FAILED": "Impossible de charger vos zones actuelles. Rechargez avant de les modifier.",
+    "SELECTION_UNKNOWN": "Vos zones actuelles n’ont pas pu être chargées — rechargez la page avant d’enregistrer."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profils",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Modifica il messaggio sul posto",
     "EDIT_HINT": "Aggiorna il messaggio Discord esistente quando il modulo esca cambia invece di inviarne uno nuovo.",
     "EDIT_BADGE": "Modifica",
-    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso esca?"
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso esca?",
+    "SNACK_FAILED_DISTANCE": "Impossibile aggiornare la distanza."
   },
   "NESTS": {
     "PAGE_TITLE": "Allarmi Nidi",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Creazione allarme fallita",
     "SNACK_FAILED_UPDATE": "Aggiornamento allarme fallito",
     "SNACK_FAILED_DELETE": "Eliminazione allarme fallita",
-    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso nido?"
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso nido?",
+    "SNACK_FAILED_DISTANCE": "Impossibile aggiornare la distanza."
   },
   "GYMS": {
     "PAGE_TITLE": "Allarmi Palestre",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Coraggio",
     "TEAM_INSTINCT": "Istinto",
     "TEAM_UNKNOWN": "Squadra {{id}}",
-    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso palestra?"
+    "CONFIRM_DELETE_TITLE": "Eliminare l'avviso palestra?",
+    "SNACK_FAILED_DISTANCE": "Impossibile aggiornare la distanza."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Allarmi Modifiche Forte",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Aggiornamento posizione fallito",
     "SEARCH_AREAS": "Cerca aree",
     "MANUAL_ADD_PLACEHOLDER": "Digita un nome di area e premi Invio",
-    "FILTER_PLACEHOLDER": "Filtra per nome..."
+    "FILTER_PLACEHOLDER": "Filtra per nome...",
+    "SNACK_LOAD_SELECTED_FAILED": "Impossibile caricare le tue aree attuali. Ricarica prima di modificarle.",
+    "SELECTION_UNKNOWN": "Le tue aree attuali non sono state caricate: ricarica la pagina prima di salvare."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profili",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Bericht ter plekke bewerken",
     "EDIT_HINT": "Werk het bestaande Discord-bericht bij wanneer de lokmodule verandert in plaats van een nieuw bericht te sturen.",
     "EDIT_BADGE": "Bewerken",
-    "CONFIRM_DELETE_TITLE": "Lokmodule-alarm verwijderen?"
+    "CONFIRM_DELETE_TITLE": "Lokmodule-alarm verwijderen?",
+    "SNACK_FAILED_DISTANCE": "De afstand kon niet worden bijgewerkt."
   },
   "NESTS": {
     "PAGE_TITLE": "Nest Alarmen",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Alarm aanmaken mislukt",
     "SNACK_FAILED_UPDATE": "Alarm bijwerken mislukt",
     "SNACK_FAILED_DELETE": "Alarm verwijderen mislukt",
-    "CONFIRM_DELETE_TITLE": "Nest-alarm verwijderen?"
+    "CONFIRM_DELETE_TITLE": "Nest-alarm verwijderen?",
+    "SNACK_FAILED_DISTANCE": "De afstand kon niet worden bijgewerkt."
   },
   "GYMS": {
     "PAGE_TITLE": "Gym Alarmen",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
     "TEAM_UNKNOWN": "Team {{id}}",
-    "CONFIRM_DELETE_TITLE": "Gym-alarm verwijderen?"
+    "CONFIRM_DELETE_TITLE": "Gym-alarm verwijderen?",
+    "SNACK_FAILED_DISTANCE": "De afstand kon niet worden bijgewerkt."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fortwijziging Alarmen",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Locatie bijwerken mislukt",
     "SEARCH_AREAS": "Gebieden zoeken",
     "MANUAL_ADD_PLACEHOLDER": "Typ een gebiedsnaam en druk op Enter",
-    "FILTER_PLACEHOLDER": "Filter op naam..."
+    "FILTER_PLACEHOLDER": "Filter op naam...",
+    "SNACK_LOAD_SELECTED_FAILED": "Je huidige gebieden konden niet worden geladen. Herlaad voordat je ze wijzigt.",
+    "SELECTION_UNKNOWN": "Je huidige gebieden konden niet worden geladen — herlaad de pagina voordat je opslaat."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profielen",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Edytuj wiadomość w miejscu",
     "EDIT_HINT": "Aktualizuje istniejącą wiadomość na Discordzie przy zmianie wabika zamiast wysyłać nową.",
     "EDIT_BADGE": "Edycja",
-    "CONFIRM_DELETE_TITLE": "Usunąć alarm wabika?"
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm wabika?",
+    "SNACK_FAILED_DISTANCE": "Nie udało się zaktualizować odległości."
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmy gniazd",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Nie udało się utworzyć alarmu",
     "SNACK_FAILED_UPDATE": "Nie udało się zaktualizować alarmu",
     "SNACK_FAILED_DELETE": "Nie udało się usunąć alarmu",
-    "CONFIRM_DELETE_TITLE": "Usunąć alarm gniazda?"
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm gniazda?",
+    "SNACK_FAILED_DISTANCE": "Nie udało się zaktualizować odległości."
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmy aren",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
     "TEAM_UNKNOWN": "Drużyna {{id}}",
-    "CONFIRM_DELETE_TITLE": "Usunąć alarm areny?"
+    "CONFIRM_DELETE_TITLE": "Usunąć alarm areny?",
+    "SNACK_FAILED_DISTANCE": "Nie udało się zaktualizować odległości."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmy zmian fortów",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Nie udało się zaktualizować lokalizacji",
     "SEARCH_AREAS": "Szukaj obszarów",
     "MANUAL_ADD_PLACEHOLDER": "Wpisz nazwę obszaru i naciśnij Enter",
-    "FILTER_PLACEHOLDER": "Filtruj według nazwy..."
+    "FILTER_PLACEHOLDER": "Filtruj według nazwy...",
+    "SNACK_LOAD_SELECTED_FAILED": "Nie udało się wczytać twoich obszarów. Odśwież przed ich zmianą.",
+    "SELECTION_UNKNOWN": "Nie udało się wczytać twoich obszarów — odśwież stronę przed zapisaniem."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profile",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Editar a mensagem no local",
     "EDIT_HINT": "Atualiza a mensagem existente do Discord quando a isca muda em vez de enviar uma nova.",
     "EDIT_BADGE": "Editar",
-    "CONFIRM_DELETE_TITLE": "Excluir alarme de isca?"
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de isca?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes de Ninho",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Falha ao criar alarme",
     "SNACK_FAILED_UPDATE": "Falha ao atualizar alarme",
     "SNACK_FAILED_DELETE": "Falha ao excluir alarme",
-    "CONFIRM_DELETE_TITLE": "Excluir alarme de ninho?"
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de ninho?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes de Ginásio",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
     "TEAM_UNKNOWN": "Time {{id}}",
-    "CONFIRM_DELETE_TITLE": "Excluir alarme de ginásio?"
+    "CONFIRM_DELETE_TITLE": "Excluir alarme de ginásio?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes de Mudança de Forte",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Falha ao atualizar localização",
     "SEARCH_AREAS": "Buscar áreas",
     "MANUAL_ADD_PLACEHOLDER": "Digite um nome de área e pressione Enter",
-    "FILTER_PLACEHOLDER": "Filtrar por nome..."
+    "FILTER_PLACEHOLDER": "Filtrar por nome...",
+    "SNACK_LOAD_SELECTED_FAILED": "Não foi possível carregar suas áreas atuais. Recarregue antes de alterá-las.",
+    "SELECTION_UNKNOWN": "Suas áreas atuais não foram carregadas — recarregue a página antes de salvar."
   },
   "PROFILES": {
     "PAGE_TITLE": "Perfis",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Editar a mensagem no local",
     "EDIT_HINT": "Atualiza a mensagem existente do Discord quando o engodo muda em vez de enviar uma nova.",
     "EDIT_BADGE": "Editar",
-    "CONFIRM_DELETE_TITLE": "Eliminar alerta de isco?"
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de isco?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "NESTS": {
     "PAGE_TITLE": "Alarmes de Ninhos",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Falha ao criar alarme",
     "SNACK_FAILED_UPDATE": "Falha ao atualizar alarme",
     "SNACK_FAILED_DELETE": "Falha ao eliminar alarme",
-    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ninho?"
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ninho?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "GYMS": {
     "PAGE_TITLE": "Alarmes de Ginásios",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinto",
     "TEAM_UNKNOWN": "Equipa {{id}}",
-    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ginásio?"
+    "CONFIRM_DELETE_TITLE": "Eliminar alerta de ginásio?",
+    "SNACK_FAILED_DISTANCE": "Não foi possível atualizar a distância."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Alarmes de Alterações de Forte",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Falha ao atualizar localização",
     "SEARCH_AREAS": "Pesquisar áreas",
     "MANUAL_ADD_PLACEHOLDER": "Escreve um nome de área e prime Enter",
-    "FILTER_PLACEHOLDER": "Filtrar por nome..."
+    "FILTER_PLACEHOLDER": "Filtrar por nome...",
+    "SNACK_LOAD_SELECTED_FAILED": "Não foi possível carregar as tuas áreas atuais. Recarrega antes de as alterares.",
+    "SELECTION_UNKNOWN": "As tuas áreas atuais não foram carregadas — recarrega a página antes de guardar."
   },
   "PROFILES": {
     "PAGE_TITLE": "Perfis",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -638,7 +638,8 @@
     "EDIT_MODE": "Redigera meddelandet på plats",
     "EDIT_HINT": "Uppdaterar det befintliga Discord-meddelandet när betet ändras i stället för att skicka ett nytt.",
     "EDIT_BADGE": "Redigera",
-    "CONFIRM_DELETE_TITLE": "Ta bort lockbete-larm?"
+    "CONFIRM_DELETE_TITLE": "Ta bort lockbete-larm?",
+    "SNACK_FAILED_DISTANCE": "Avståndet kunde inte uppdateras."
   },
   "NESTS": {
     "PAGE_TITLE": "Nästlarm",
@@ -656,7 +657,8 @@
     "SNACK_FAILED_CREATE": "Kunde inte skapa larm",
     "SNACK_FAILED_UPDATE": "Kunde inte uppdatera larm",
     "SNACK_FAILED_DELETE": "Kunde inte radera larm",
-    "CONFIRM_DELETE_TITLE": "Ta bort bo-larm?"
+    "CONFIRM_DELETE_TITLE": "Ta bort bo-larm?",
+    "SNACK_FAILED_DISTANCE": "Avståndet kunde inte uppdateras."
   },
   "GYMS": {
     "PAGE_TITLE": "Gymlarm",
@@ -682,7 +684,8 @@
     "TEAM_VALOR": "Valor",
     "TEAM_INSTINCT": "Instinct",
     "TEAM_UNKNOWN": "Lag {{id}}",
-    "CONFIRM_DELETE_TITLE": "Ta bort gym-larm?"
+    "CONFIRM_DELETE_TITLE": "Ta bort gym-larm?",
+    "SNACK_FAILED_DISTANCE": "Avståndet kunde inte uppdateras."
   },
   "FORT_CHANGES": {
     "PAGE_TITLE": "Fort-ändringslarm",
@@ -804,7 +807,9 @@
     "SNACK_LOCATION_FAILED": "Kunde inte uppdatera plats",
     "SEARCH_AREAS": "Sök områden",
     "MANUAL_ADD_PLACEHOLDER": "Skriv ett områdesnamn och tryck Enter",
-    "FILTER_PLACEHOLDER": "Filtrera efter namn..."
+    "FILTER_PLACEHOLDER": "Filtrera efter namn...",
+    "SNACK_LOAD_SELECTED_FAILED": "Dina nuvarande områden kunde inte laddas. Ladda om innan du ändrar dem.",
+    "SELECTION_UNKNOWN": "Dina nuvarande områden kunde inte laddas — ladda om sidan innan du sparar."
   },
   "PROFILES": {
     "PAGE_TITLE": "Profiler",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resetting an alarm's template to Default now sticks; nine of the ten edit dialogs sent a null the mapper skipped, so the choice was accepted and discarded (#639)
+- "Update Distance (all)" works on the Pokemon page: it was sending an object to an endpoint that binds a bare number, so it failed every time (#640)
+- Bulk "Update Distance" now reports failures instead of doing nothing visible, and shows the server's explanation of which alarm is in the way (#641)
+- Select All on the Raids page no longer selects hidden Eggs, which Delete then removed along with the raids (#642)
+- The Areas page no longer offers to save when it could not read your current areas, which turned one failed request into the loss of every subscription (#643)
 - Seeding the built-in quick picks no longer aborts partway: two invasion presets carry empty filters on purpose and were rejected by the save-time validation added in #604, so both the first-visit auto-seed and Reset to Defaults left a partial preset list (#637)
 - The admin Settings page shows every group on a fresh install; Alarm Types, Features, Administration and Analytics were hidden until their rows existed, and this page is the only thing that creates them (#629)
 - Resetting quick picks to defaults now clears the applied state of the picks it removes, instead of orphaning a row per user and profile (#630)


### PR DESCRIPTION
Closes #639
Closes #640
Closes #641
Closes #642
Closes #643

**#639 — Default template was accepted and discarded.** `ApplyUpdate` skips nulls by design; the selector's Default option is `""`; nine dialogs sent `values.template || null`. Choosing Default said "Updated" and changed nothing, with no way to clear a template through the UI. `max-battle` already sent `''` and worked.

**#640 — "Update Distance (all)" never worked on Pokemon.** `MonsterService` sent `{ distance }` where the controller binds `[FromBody] int`. Worth noting: `monster.service.spec.ts` **asserted the broken shape**, so the suite was defending the bug. That assertion is corrected here.

**#641 — bulk Update Distance failed silently everywhere.** An unguarded `await firstValueFrom(...)` on all ten lists: on a refusal the selection was never cleared, the list never reloaded, and no toast appeared — indistinguishable from success. The guards produce a specific message naming the alarm in the way, and it was discarded. `bulkDelete` was hardened for exactly this in #603. Three lists had no failure string, so `SNACK_FAILED_DISTANCE` is added for lures, nests and gyms in all eleven locales.

**#642 — Raids' Select All crossed into the hidden Eggs tab** and Delete honoured it, reported as a generic count. Now scoped to the visible tab.

**#643 — the Areas page could destroy every subscription from one failed request.** A failed `GET /api/areas` rendered as "0 areas selected" with no error; ticking one area and saving posted only that name. The save bar is now disabled with an explanation while the saved selection is unknown.

## Verification

- 949 frontend tests, lint and prettier clean. Locale files stay in sync (2 new keys × 11, plus 3 × 11 for the distance failures).