### PR TITLE
fix: seven geofence and profile defects (#645-#651)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -18,7 +18,8 @@ public class ProfileController(
     IPoracleHumanProxy humanProxy,
     IProfileRepository profileRepository,
     IJwtService jwtService,
-    IUserRoleResolver roleResolver) : BaseApiController
+    IUserRoleResolver roleResolver,
+    IUserGeofenceRepository userGeofenceRepository) : BaseApiController
 {
     private readonly IProfileService _profileService = profileService;
     private readonly IHumanService _humanService = humanService;
@@ -26,6 +27,7 @@ public class ProfileController(
     private readonly IProfileRepository _profileRepository = profileRepository;
     private readonly IJwtService _jwtService = jwtService;
     private readonly IUserRoleResolver _roleResolver = roleResolver;
+    private readonly IUserGeofenceRepository _userGeofenceRepository = userGeofenceRepository;
 
     /// <summary>Matches the profiles.name column, so an over-long name is refused rather than 500ing.</summary>
     private const int MaxProfileNameLength = 255;
@@ -43,6 +45,48 @@ public class ProfileController(
         }
 
         return this.Ok(profiles);
+    }
+
+    /// <summary>
+    /// Drops any private geofence name from a submitted area list that the caller does not own.
+    /// </summary>
+    /// <remarks>
+    /// Public and admin areas are anyone's to select, so they pass through. What does not is another
+    /// user's private fence: PoracleNG's setAreas intersects against userSelectable fences and would
+    /// have stripped it, but this path writes the profile row directly. See #647.
+    /// </remarks>
+    private async Task<string> RemoveAreasTheCallerMayNotSelectAsync(string? area)
+    {
+        if (string.IsNullOrWhiteSpace(area))
+        {
+            return "[]";
+        }
+
+        List<string>? requested;
+        try
+        {
+            requested = JsonSerializer.Deserialize<List<string>>(area);
+        }
+        catch (JsonException)
+        {
+            return "[]";
+        }
+
+        if (requested is null || requested.Count == 0)
+        {
+            return "[]";
+        }
+
+        var privateNames = (await this._userGeofenceRepository.GetAllAsync())
+            .Where(g => !string.Equals(g.HumanId, this.UserId, StringComparison.OrdinalIgnoreCase))
+            .Select(g => g.KojiName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var allowed = requested
+            .Where(name => !string.IsNullOrWhiteSpace(name) && !privateNames.Contains(name))
+            .ToList();
+
+        return JsonSerializer.Serialize(allowed);
     }
 
     [HttpPost]
@@ -98,6 +142,20 @@ public class ProfileController(
             });
         }
 
+        // The request supplies its own geography, and nothing bounded it. Coordinates out of range reach
+        // the active-hours scheduler, which reads them as a timezone; an area list could name another
+        // user's private geofence, which PoracleNG's own setAreas filter would have stripped but a direct
+        // write does not. See #647.
+        if (profile.Latitude is < -90 or > 90 || profile.Longitude is < -180 or > 180)
+        {
+            return this.BadRequest(new
+            {
+                error = "Latitude must be between -90 and 90, and longitude between -180 and 180.",
+            });
+        }
+
+        var requestedAreas = await this.RemoveAreasTheCallerMayNotSelectAsync(profile.Area);
+
         // addProfile ignores area, latitude and longitude, so a new profile came up carrying whatever the
         // ACTIVE profile had -- every area subscription the user held, and a location that also drives the
         // active-hours timezone. Duplicate and import already write the geography directly after creating;
@@ -109,7 +167,7 @@ public class ProfileController(
                 Id = this.UserId,
                 ProfileNo = createdNo.Value,
                 Name = profile.Name.Trim(),
-                Area = profile.Area ?? "[]",
+                Area = requestedAreas,
                 Latitude = profile.Latitude,
                 Longitude = profile.Longitude,
             });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.html
@@ -111,7 +111,7 @@
                   <td class="col-status">
                     <span
                       class="status-chip"
-                      [class.status-pending]="geofence.status === 'pending_review'"
+                      [class.status-pending]="canReview(geofence)"
                       [class.status-active]="geofence.status === 'active'"
                       [class.status-approved]="geofence.status === 'approved'"
                       [class.status-rejected]="geofence.status === 'rejected'">
@@ -151,7 +151,7 @@
                       <button mat-icon-button (click)="openDetailDialog(geofence)" [matTooltip]="'ADMIN.VIEW_DETAILS' | translate">
                         <mat-icon>visibility</mat-icon>
                       </button>
-                      @if (geofence.status === 'pending_review') {
+                      @if (canReview(geofence)) {
                         <button
                           mat-icon-button
                           color="primary"
@@ -202,7 +202,7 @@
                     </div>
                     <div
                       class="submission-card-accent"
-                      [class.accent-pending]="geofence.status === 'pending_review'"
+                      [class.accent-pending]="canReview(geofence)"
                       [class.accent-active]="geofence.status === 'active'"
                       [class.accent-approved]="geofence.status === 'approved'"
                       [class.accent-rejected]="geofence.status === 'rejected'"></div>
@@ -285,7 +285,7 @@
                           [matTooltip]="'ADMIN.VIEW_GEOFENCE_DETAILS' | translate">
                           <mat-icon>visibility</mat-icon>
                         </button>
-                        @if (geofence.status === 'pending_review') {
+                        @if (canReview(geofence)) {
                           <button
                             mat-raised-button
                             color="primary"
@@ -336,7 +336,7 @@
                         <td class="col-status">
                           <span
                             class="status-chip"
-                            [class.status-pending]="geofence.status === 'pending_review'"
+                            [class.status-pending]="canReview(geofence)"
                             [class.status-active]="geofence.status === 'active'"
                             [class.status-approved]="geofence.status === 'approved'"
                             [class.status-rejected]="geofence.status === 'rejected'">
@@ -363,7 +363,7 @@
                             <button mat-icon-button (click)="openDetailDialog(geofence)" [matTooltip]="'ADMIN.VIEW_DETAILS' | translate">
                               <mat-icon>visibility</mat-icon>
                             </button>
-                            @if (geofence.status === 'pending_review') {
+                            @if (canReview(geofence)) {
                               <button
                                 mat-icon-button
                                 color="primary"

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.spec.ts
@@ -656,14 +656,21 @@ describe('GeofenceSubmissionsComponent', () => {
     expect(notesItem).toBeTruthy();
   });
 
-  it('should show Review button only for pending_review geofences', () => {
+  it('offers Review for pending and rejected submissions, matching what the API accepts', () => {
+    // ApprovableStatuses is { pending_review, rejected } -- an admin reconsidering a rejection is the
+    // intended case, and gating on pending_review alone made a mistaken rejection irreversible from the
+    // SPA. See #649.
     const fixture = setup();
     component.ngOnInit();
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
     const reviewButtons = compiled.querySelectorAll('button[color="primary"]');
-    expect(reviewButtons).toHaveLength(1); // Only the pending_review geofence gets a Review button
+    expect(reviewButtons).toHaveLength(2);
+    expect(component.canReview({ status: 'pending_review' })).toBe(true);
+    expect(component.canReview({ status: 'rejected' })).toBe(true);
+    expect(component.canReview({ status: 'approved' })).toBe(false);
+    expect(component.canReview({ status: 'active' })).toBe(false);
   });
 
   it('should show empty state when no geofences match the filter', () => {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/geofence-submissions/geofence-submissions.component.ts
@@ -202,6 +202,16 @@ export class GeofenceSubmissionsComponent implements OnInit, AfterViewInit, OnDe
     }
   }
 
+  /**
+   * Whether the Review action applies, matching what the API will accept.
+   */
+  /* UserGeofenceService.ApprovableStatuses is { pending_review, rejected } -- an admin reconsidering a
+   * rejection is the intended case. All three view modes gated on pending_review alone, so a
+   * mistaken rejection was irreversible from the SPA while the endpoint would have taken it. See #649. */
+  canReview(geofence: { status: string }): boolean {
+    return geofence.status === 'pending_review' || geofence.status === 'rejected';
+  }
+
   getPointCount(geofence: UserGeofence): number {
     return geofence.pointCount ?? geofence.polygon?.length ?? 0;
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.ts
@@ -153,7 +153,10 @@ export class GeofenceListComponent implements OnInit {
     // Pre-fill dialog with existing values
     const instance = ref.componentInstance;
     instance.displayName = geofence.displayName;
-    const region = this.geofenceRegions().find(r => r.name === geofence.groupName);
+    // groupName was written from region.displayName at creation, and GeofenceRegion carries name and
+    // displayName as different fields -- so matching on name never hit, the picker opened empty, and
+    // confirming closed with parentId 0 and wiped the region. See #648.
+    const region = this.geofenceRegions().find(r => r.displayName === geofence.groupName || r.name === geofence.groupName);
     if (region) {
       instance.selectedRegionId = region.id;
     }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles-overview/profile-overview.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/profiles-overview/profile-overview.component.ts
@@ -298,6 +298,11 @@ export class ProfileOverviewComponent implements OnInit {
             this.snackBar.open(this.i18n.instant('PROFILES.SNACK_FAILED_DELETE'), this.i18n.instant('TOAST.OK'), { duration: 3000 }),
           next: () => {
             this.snackBar.open(this.i18n.instant('PROFILES.SNACK_DELETED'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
+            // PoracleNG reassigns current_profile_no when the active profile goes, and /api/auth/me is the
+            // only place the refreshed token is stored. Switch, duplicate and import all do this; delete did
+            // not, so the profileNo claim kept naming a profile that no longer exists and every alarm read
+            // and write in between targeted it. See #651.
+            void this.authService.loadCurrentUser();
             this.loadAll();
           },
         });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/region-selector/region-selector.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/region-selector/region-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, output, signal } from '@angular/core';
+import { Component, effect, computed, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
@@ -40,7 +40,32 @@ export interface RegionGroup {
 })
 export class RegionSelectorComponent {
   readonly regions = input<RegionOption[]>([]);
+  readonly selectedOption = signal<RegionOption | null>(null);
+  /**
+   * The region the caller says is already chosen, by id or label.
+   */
+  /* Declared and then never read: the chip rendered purely off selectedOption, which starts null. So
+   * the approval dialog showed an empty picker for a submission that already carried a region, while
+   * still submitting the seeded id -- the admin approved a region they were never shown, and any touch
+   * of the picker replaced it with 0. See #650. */
+  readonly selectedValue = input<string | number | null>(null);
+
+  /** Mirrors selectedValue into the visible selection whenever either side changes. See #650. */
+  private readonly seedFromSelectedValue = effect(() => {
+    const wanted = this.selectedValue();
+    const available = this.regions();
+    if (wanted === null || wanted === undefined || wanted === '') {
+      return;
+    }
+
+    const match = available.find(r => r.id === wanted || r.label === wanted || r.shortLabel === wanted);
+    if (match && this.selectedOption()?.id !== match.id) {
+      this.selectedOption.set(match);
+    }
+  });
+
   readonly searchText = signal('');
+
   readonly filteredGroups = computed((): RegionGroup[] => {
     const search = this.searchText().toLowerCase();
     const all = this.regions();
@@ -61,12 +86,10 @@ export class RegionSelectorComponent {
   });
 
   readonly label = input('Select Region');
+
   readonly placeholder = input('Search regions...');
 
   readonly regionSelected = output<RegionOption>();
-
-  readonly selectedOption = signal<RegionOption | null>(null);
-  readonly selectedValue = input<string | number | null>(null);
 
   readonly showCounts = input(false);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Creating a profile no longer accepts an unbounded location or an area list naming another user's private geofence, both of which were written straight to the database (#647)
 - A login that carries no refresh token now clears any refresh token left behind by a previous session, instead of inheriting it and letting the refresh interceptor swap in a JWT minted for the previous user (#625)
 - A token re-issue no longer restarts the session clock: profile switches and profile resyncs keep the original expiry instead of applying the 24-hour default, so a short OIDC access token stays short and revocation propagates as documented (#624)
 - `isAdmin` is resolved live on every token re-issue rather than copied forward, so removing someone's admin rights takes effect instead of surviving indefinitely while they switch profile (#624)
@@ -22,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rejecting a geofence submission no longer silently stops the owner's alerts: a rejected fence stays in the feed, as "remains private with review notes" always intended (#645)
+- An approved or under-review geofence can no longer be renamed, which used to move the area subscription to a name neither Koji nor the feed serves (#646)
+- Renaming a geofence keeps its region instead of clearing the Koji parent, and the rename dialog now pre-selects the region it already has (#648)
+- Admins can review a rejected geofence submission again, which the API has always allowed (#649)
+- The region picker shows the region that is already selected instead of an empty box (#650)
+- Deleting a profile refreshes the session, so the JWT stops naming a profile that no longer exists (#651)
 - Resetting an alarm's template to Default now sticks; nine of the ten edit dialogs sent a null the mapper skipped, so the choice was accepted and discarded (#639)
 - "Update Distance (all)" works on the Pokemon page: it was sending an object to an endpoint that binds a bare number, so it failed every time (#640)
 - Bulk "Update Distance" now reports failures instead of doing nothing visible, and shows the server's explanation of which alarm is in the way (#641)

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/UserGeofenceRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/UserGeofenceRepository.cs
@@ -60,7 +60,10 @@ public class UserGeofenceRepository(PoracleWebContext context) : IUserGeofenceRe
     {
         var entities = await this._context.UserGeofences
             .AsNoTracking()
-            .Where(g => g.Status == "active" || g.Status == "pending_review")
+            // "rejected" is served too. Rejection means "not public", not "switched off": it writes only
+            // status, notes and reviewer, so dropping the row from the feed stopped the owner's alerts
+            // while their area lists still named the fence and the UI still showed it Active. See #645.
+            .Where(g => g.Status == "active" || g.Status == "pending_review" || g.Status == "rejected")
             .OrderBy(g => g.KojiName)
             .ToListAsync();
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserGeofenceService.cs
@@ -221,6 +221,18 @@ public partial class UserGeofenceService(
         // over 50 characters, or carrying characters outside the allowlist -- could be applied by editing
         // an existing geofence instead. The polygon-side validation on this feature is thorough, which
         // made the gap look like an oversight rather than a decision. See #585.
+        // Once a fence is approved, Koji owns it under PromotedName and the area lists hold that name,
+        // not KojiName. Renaming then rewrote the subscription to a name neither Koji nor the feed
+        // serves, silently unsubscribing the owner from a live public area -- and PublicAreaName still
+        // returned the promoted name, so a later admin delete cleaned the wrong entry. A submission
+        // under review is frozen for the same reason: the admin is looking at the name as submitted.
+        // See #646.
+        if (!RenameableStatuses.Contains(geofence.Status))
+        {
+            throw new InvalidOperationException(
+                $"A geofence cannot be renamed while its status is '{geofence.Status}'.");
+        }
+
         var trimmedName = displayName?.Trim() ?? string.Empty;
         if (string.IsNullOrEmpty(trimmedName) || trimmedName.Length > 50)
         {
@@ -250,7 +262,10 @@ public partial class UserGeofenceService(
         geofence.KojiName = newKojiName;
         // group_name is NOT NULL, and the rename dialog does not always send one -- keep what is there rather than clearing it.
         geofence.GroupName = string.IsNullOrWhiteSpace(groupName) ? geofence.GroupName : groupName;
-        geofence.ParentId = parentId ?? geofence.ParentId;
+        // Same treatment as group_name above: 0 is the dialog's "nothing selected", not a request to
+        // clear the parent. Taken literally it wiped the region of every renamed geofence, and a later
+        // approval then sent __parent: null to Koji and landed the area ungrouped. See #648.
+        geofence.ParentId = parentId is > 0 ? parentId.Value : geofence.ParentId;
         var updated = await this._repository.UpdateAsync(geofence);
 
         // Every profile that was subscribed stays subscribed, under the new name. This is the whole
@@ -887,6 +902,10 @@ public partial class UserGeofenceService(
     /// Statuses an admin may approve from. See the comment in <see cref="ApproveSubmissionAsync"/> for why
     /// <c>active</c> and <c>approved</c> are not among them.
     /// </summary>
+    /// <summary>Statuses a geofence may still be renamed in. See #646.</summary>
+    private static readonly HashSet<string> RenameableStatuses =
+        new(StringComparer.OrdinalIgnoreCase) { "active", "rejected" };
+
     private static readonly HashSet<string> ApprovableStatuses =
         new(StringComparer.Ordinal) { "pending_review", "rejected" };
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ProfileControllerTests.cs
@@ -19,12 +19,13 @@ public class ProfileControllerTests : ControllerTestBase
     private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<IProfileRepository> _profileRepository = new();
     private readonly Mock<Pgan.PoracleWebNet.Api.Services.IUserRoleResolver> _roleResolver = new();
+    private readonly Mock<IUserGeofenceRepository> _userGeofenceRepository = new();
 
     public ProfileControllerTests()
     {
         this._jwtService.Setup(j => j.GenerateTokenWithReplacedProfile(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<int>(), It.IsAny<bool?>()))
             .Returns("test-jwt-token");
-        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, this._profileRepository.Object, this._jwtService.Object, this._roleResolver.Object);
+        this._sut = new ProfileController(this._profileService.Object, this._humanService.Object, this._humanProxy.Object, this._profileRepository.Object, this._jwtService.Object, this._roleResolver.Object, this._userGeofenceRepository.Object);
         SetupUser(this._sut);
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserGeofenceServiceTests.cs
@@ -1595,4 +1595,77 @@ public class UserGeofenceServiceTests
 
         Assert.Equal("somewhere new", result.KojiName);
     }
+
+    // ── Rename guards (#646, #648) ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("approved")]
+    [InlineData("pending_review")]
+    public async Task RenameIsRefusedOnceTheGeofenceHasLeftTheOwnersHands(string status)
+    {
+        // Approval moves the fence to Koji under PromotedName and the area lists hold that name, so a
+        // rename rewrote the subscription to a name nothing serves. See #646.
+        this._repository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new UserGeofence
+        {
+            Id = 1,
+            HumanId = "u1",
+            KojiName = "downtown",
+            DisplayName = "Downtown",
+            Status = status,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._sut.RenameAsync("u1", 1, "Uptown", null, null));
+
+        this._repository.Verify(r => r.UpdateAsync(It.IsAny<UserGeofence>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RenameKeepsTheRegionWhenTheDialogSendsNoSelection()
+    {
+        // 0 is the dialog's "nothing selected", not a request to clear the parent. Taken literally it
+        // wiped the region of every renamed geofence. See #648.
+        this._repository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new UserGeofence
+        {
+            Id = 1,
+            HumanId = "u1",
+            KojiName = "downtown",
+            DisplayName = "Downtown",
+            Status = "active",
+            ParentId = 42,
+            GroupName = "North",
+        });
+        UserGeofence? saved = null;
+        this._repository.Setup(r => r.UpdateAsync(It.IsAny<UserGeofence>()))
+            .Callback<UserGeofence>(g => saved = g)
+            .ReturnsAsync((UserGeofence g) => g);
+
+        await this._sut.RenameAsync("u1", 1, "Uptown", null, 0);
+
+        Assert.Equal(42, saved?.ParentId);
+        Assert.Equal("North", saved?.GroupName);
+    }
+
+    [Fact]
+    public async Task RenameStillAppliesARegionThatWasActuallyChosen()
+    {
+        this._repository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new UserGeofence
+        {
+            Id = 1,
+            HumanId = "u1",
+            KojiName = "downtown",
+            DisplayName = "Downtown",
+            Status = "active",
+            ParentId = 42,
+        });
+        UserGeofence? saved = null;
+        this._repository.Setup(r => r.UpdateAsync(It.IsAny<UserGeofence>()))
+            .Callback<UserGeofence>(g => saved = g)
+            .ReturnsAsync((UserGeofence g) => g);
+
+        await this._sut.RenameAsync("u1", 1, "Uptown", "South", 7);
+
+        Assert.Equal(7, saved?.ParentId);
+        Assert.Equal("South", saved?.GroupName);
+    }
 }


### PR DESCRIPTION
Closes #645
Closes #646
Closes #647
Closes #648
Closes #649
Closes #650
Closes #651

**#645 — a rejection silently switched the fence off.** The feed query served `active` and `pending_review` only, while rejection writes just status, notes and reviewer. So the polygon left PoracleJS's view while the name stayed in `humans.area` and every `profiles.area`, and the card still read **Active**. The fence also could not be resubmitted and still consumed one of the owner's ten slots. CLAUDE.md already states the contract: `rejected` "remains private with review notes".

**#646 — renaming an approved fence unsubscribed its owner.** Koji owns it under `PromotedName` once approved, and the area lists hold that name; rename rewrote the subscription to a name neither Koji nor the feed serves. `PublicAreaName` still returned the promoted name, so a later admin delete cleaned the wrong entry. Rename is now refused for `approved` and `pending_review`.

**#647 — `POST /api/profiles` wrote caller-supplied geography verbatim.** It binds the domain model, and validation attributes live on the `*Create` DTOs. Coordinates now carry the location endpoint's bounds, and a private geofence name belonging to someone else is dropped — PoracleNG's `setAreas` filter would have stripped it, but this path writes the row directly.

**#648 — every rename wiped the region.** The pre-fill matched `r.name === geofence.groupName` when creation stored `region.displayName`, so the picker always opened empty and closed with `parentId: 0`; `ParentId = parentId ?? …` then took 0 literally. Both halves fixed: match on `displayName`, and treat `parentId <= 0` as "keep", as `groupName` already was.

**#649 / #650 / #651** — Review is offered for `rejected` too, matching `ApprovableStatuses`; the region selector finally reads its `selectedValue` input, so admins stop approving a region they were never shown; and deleting a profile refreshes the session instead of leaving the `profileNo` claim naming a profile PoracleNG has already replaced.

## Verification

- 1826 backend tests (4 new: rename refused for both frozen statuses, region preserved on a 0, region applied when actually chosen), 949 frontend tests.
- One frontend test was updated deliberately: it asserted Review appears for `pending_review` only, which was the defect.