### PR TITLE
fix: editing a quick pick no longer drops its zero-valued filters (#654)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
@@ -1,0 +1,145 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideRouter } from '@angular/router';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { QuickPickAdminDialogComponent } from './quick-pick-admin-dialog.component';
+import { QuickPickDefinition } from '../../core/models';
+import { AuthService } from '../../core/services/auth.service';
+import { ConfigService } from '../../core/services/config.service';
+import { QuickPickService } from '../../core/services/quick-pick.service';
+
+describe('QuickPickAdminDialogComponent', () => {
+  let component: QuickPickAdminDialogComponent;
+  let quickPickService: { saveAdmin: jest.Mock; saveUser: jest.Mock };
+
+  function setup(data: QuickPickDefinition | null, isAdmin = true): void {
+    quickPickService = {
+      saveAdmin: jest.fn(() => of({})),
+      saveUser: jest.fn(() => of({})),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        provideTranslateService(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { apiHost: 'http://test-api' } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: QuickPickService, useValue: quickPickService },
+        { provide: AuthService, useValue: { isAdmin: () => isAdmin } },
+      ],
+      imports: [QuickPickAdminDialogComponent],
+    });
+
+    const fixture = TestBed.createComponent(QuickPickAdminDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  function savedDefinition(): QuickPickDefinition {
+    const call = quickPickService.saveAdmin.mock.calls[0] ?? quickPickService.saveUser.mock.calls[0];
+    return call[0] as QuickPickDefinition;
+  }
+
+  describe('editing an existing definition', () => {
+    // The built-in "nundo" preset is { minIv: 0, maxIv: 0 } -- that is the entire point of it. Skipping
+    // falsy values on save turned "0% IV only" into "any IV" for everyone who applied it afterwards.
+    // See #654.
+    const nundo: QuickPickDefinition = {
+      id: 'nundo',
+      name: 'Nundo',
+      alarmType: 'monster',
+      category: 'PvP',
+      description: 'Zero IV',
+      enabled: true,
+      filters: { maxIv: 0, minIv: 0 },
+      icon: 'pokeball',
+      scope: 'global',
+      sortOrder: 1,
+    };
+
+    it('keeps a stored filter whose value is zero', () => {
+      setup(nundo);
+
+      component.save();
+
+      const saved = savedDefinition();
+      expect(saved.filters['minIv']).toBe(0);
+      expect(saved.filters['maxIv']).toBe(0);
+    });
+
+    it('keeps a stored key the dialog has no control for', () => {
+      // quick-pick-apply reads filters['clean'] as its base bitmask, and no form exposes it.
+      setup({ ...nundo, filters: { clean: 5, maxIv: 0, minIv: 0 } });
+
+      component.save();
+
+      expect(savedDefinition().filters['clean']).toBe(5);
+    });
+  });
+
+  describe('creating a new definition', () => {
+    it('does not write out the form defaults that mean "not set"', () => {
+      // Most numeric controls default to 0. Persisting them would put an explicit minIv, pokemonId and
+      // pvpRankingLeague of 0 on every new pick, which is the mirror image of the bug above.
+      setup(null);
+      component.mainForm.patchValue({ name: 'Fresh', alarmType: 'monster' });
+
+      component.save();
+
+      const filters = savedDefinition().filters;
+      expect(filters['minIv']).toBeUndefined();
+      expect(filters['pokemonId']).toBeUndefined();
+      expect(filters['pvpRankingLeague']).toBeUndefined();
+    });
+
+    it('still writes a non-default value', () => {
+      setup(null);
+      component.mainForm.patchValue({ name: 'Hundo', alarmType: 'monster' });
+      component.monsterForm.patchValue({ minIv: 100 });
+
+      component.save();
+
+      expect(savedDefinition().filters['minIv']).toBe(100);
+    });
+  });
+
+  describe('scope', () => {
+    it('keeps a user-scoped pick user-scoped when an admin edits it', () => {
+      // Deciding from isAdmin alone republished an admin's own personal pick to every user. See #631.
+      setup({
+        id: 'mine',
+        name: 'Mine',
+        alarmType: 'monster',
+        category: 'Common',
+        description: '',
+        enabled: true,
+        filters: {},
+        icon: 'bolt',
+        scope: 'user',
+        sortOrder: 0,
+      });
+
+      component.save();
+
+      expect(quickPickService.saveUser).toHaveBeenCalled();
+      expect(quickPickService.saveAdmin).not.toHaveBeenCalled();
+    });
+
+    it('publishes a new pick globally when an admin creates it', () => {
+      setup(null);
+      component.mainForm.patchValue({ name: 'Global', alarmType: 'monster' });
+
+      component.save();
+
+      expect(quickPickService.saveAdmin).toHaveBeenCalled();
+    });
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -194,13 +194,29 @@ export class QuickPickAdminDialogComponent implements OnInit {
 
     const main = this.mainForm.getRawValue();
     const filterForm = this.getFilterForm(main.alarmType ?? 'monster');
-    const filters: Record<string, unknown> = {};
+    // Start from what is stored rather than rebuilding: any key the dialog has no control for used to be
+    // dropped on save, and quick-pick-apply reads filters['clean'] as its base bitmask while no form
+    // exposes it. See #654.
+    const stored: Record<string, unknown> = { ...(this.data?.filters ?? {}) };
+    const filters: Record<string, unknown> = stored;
     if (filterForm) {
       const raw = filterForm.getRawValue();
       Object.entries(raw).forEach(([key, value]) => {
-        if (value !== 0 && value !== '' && value !== null) {
-          filters[key] = value;
+        if (value === null || value === '' || value === undefined) {
+          delete filters[key];
+          return;
         }
+
+        // A stored 0 is kept, because 0 is a real filter value: the built-in nundo preset is
+        // { minIv: 0, maxIv: 0 }, and dropping those turned "0% IV only" into "any IV" for everyone who
+        // applied it afterwards. A 0 that was never stored is still skipped, because most of these
+        // controls default to 0 meaning "not set" -- writing them out would put an explicit minIv,
+        // pokemonId and pvpRankingLeague of 0 on every newly created pick.
+        if (value === 0 && !(key in stored)) {
+          return;
+        }
+
+        filters[key] = value;
       });
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Editing a quick pick no longer drops filters whose value is 0: the built-in Nundo preset is `minIv: 0, maxIv: 0`, so changing its description silently turned "0% IV only" into "any IV" for everyone who applied it afterwards (#654)
 - Rejecting a geofence submission no longer silently stops the owner's alerts: a rejected fence stays in the feed, as "remains private with review notes" always intended (#645)
 - An approved or under-review geofence can no longer be renamed, which used to move the area subscription to a name neither Koji nor the feed serves (#646)
 - Renaming a geofence keeps its region instead of clearing the Koji parent, and the rename dialog now pre-selects the region it already has (#648)


### PR DESCRIPTION
Closes #654

`save()` rebuilt `filters` from scratch and skipped falsy values. The demonstrable case is in live data: the **nundo** preset stores `{ "minIv": 0, "maxIv": 0 }`, which is the entire meaning of it. An admin who opens it and edits only the description saves a definition with no IV bounds at all — "Nundo" becomes "any Pokemon" for every user who applies it afterwards, silently.

Rebuilding rather than merging also drops any stored key the dialog has no control for. Nothing in live data hits that today, but `quick-pick-apply-dialog` reads `filters['clean']` as its base bitmask and no form exposes `clean`.

**The obvious fix would have caused the mirror-image bug.** Keeping every value including 0 sounds right until you look at the form defaults: `minIv`, `minCp`, `pokemonId`, `pvpRankingLeague`, `form`, `gender` and `minLevel` all default to `0` meaning *not set*, so every newly created pick would start carrying explicit zeros it never had. A stored 0 is therefore kept; a 0 that was never stored is still skipped. The create path behaves exactly as before.

That is the failure shape #653 was just written about, caught this time by checking what the loose behaviour was protecting before tightening it.

## Verification

- New spec, 6 tests. **The two that matter were confirmed red against the unfixed component and green after** — the other four are guard-rails that stay green either way, pinning the create-path behaviour I must not change.
- Live data was queried first: 15 distinct filter keys across all definitions, every one has a form control today, and exactly one definition (`nundo`) holds a falsy value.
- 955 frontend tests, lint and prettier clean.