### PR TITLE
fix: eight regressions introduced by today's own fixes (#656-#663)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -823,8 +823,16 @@ public partial class AuthController(
             // isAdmin resolved fresh rather than copied: this is the one place a long-lived session
             // routinely re-mints its token, so copying the claim let revoked admin rights live on. See #624.
             var roles = await this._roleResolver.ResolveAsync(this.UserId);
-            userInfo.IsAdmin = roles.IsAdmin;
-            userInfo.Token = this._jwtService.GenerateTokenWithReplacedProfile(this.User, dbProfileNo, roles.IsAdmin);
+
+            // Null means "leave the claim alone". Two cases need it: the resolver could not reach PoracleNG,
+            // where treating unknown as false stripped admin for the rest of the session (#656); and an
+            // impersonation session, which AdminController deliberately mints with IsAdmin = false and which
+            // would otherwise be re-elevated by resolving the impersonated user's own roles (#663).
+            bool? resolvedAdmin = roles.Resolved && this.User.FindFirst("impersonatedBy") is null
+                ? roles.IsAdmin
+                : null;
+            userInfo.IsAdmin = resolvedAdmin ?? this.IsAdmin;
+            userInfo.Token = this._jwtService.GenerateTokenWithReplacedProfile(this.User, dbProfileNo, resolvedAdmin);
         }
 
         return this.Ok(userInfo);

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -67,9 +67,11 @@ public class ProfileController(
         {
             requested = JsonSerializer.Deserialize<List<string>>(area);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            return "[]";
+            // Silently emptying a list we could not read is the worst of both: the caller asked for
+            // something and gets a 201 saying it worked. See #658.
+            throw new ArgumentException("area must be a JSON array of area names.", nameof(area), ex);
         }
 
         if (requested is null || requested.Count == 0)
@@ -77,8 +79,13 @@ public class ProfileController(
             return "[]";
         }
 
+        // Approved fences are excluded: approval promotes them to public Koji areas that anyone may
+        // select, and when no promotedName was supplied the public area's name IS the KojiName -- so
+        // denying it silently dropped a legitimate public area from the new profile. Only another
+        // user's still-private fence is refused. See #658.
         var privateNames = (await this._userGeofenceRepository.GetAllAsync())
             .Where(g => !string.Equals(g.HumanId, this.UserId, StringComparison.OrdinalIgnoreCase))
+            .Where(g => !string.Equals(g.Status, "approved", StringComparison.OrdinalIgnoreCase))
             .Select(g => g.KojiName)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -154,7 +161,15 @@ public class ProfileController(
             });
         }
 
-        var requestedAreas = await this.RemoveAreasTheCallerMayNotSelectAsync(profile.Area);
+        string requestedAreas;
+        try
+        {
+            requestedAreas = await this.RemoveAreasTheCallerMayNotSelectAsync(profile.Area);
+        }
+        catch (ArgumentException ex)
+        {
+            return this.BadRequest(new { error = ex.Message });
+        }
 
         // addProfile ignores area, latitude and longitude, so a new profile came up carrying whatever the
         // ACTIVE profile had -- every area subscription the user held, and a location that also drives the
@@ -249,7 +264,15 @@ public class ProfileController(
         // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
         // user kept their isAdmin claim alive indefinitely. See #624.
         var roles = await this._roleResolver.ResolveAsync(this.UserId);
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, profileNo, roles.IsAdmin);
+
+        // Null means "leave the claim alone". Two cases need it: the resolver could not reach PoracleNG,
+        // where treating unknown as false stripped admin for the rest of the session (#656); and an
+        // impersonation session, which AdminController deliberately mints with IsAdmin = false and which
+        // would otherwise be re-elevated by resolving the impersonated user's own roles (#663).
+        bool? resolvedAdmin = roles.Resolved && this.User.FindFirst("impersonatedBy") is null
+            ? roles.IsAdmin
+            : null;
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, profileNo, resolvedAdmin);
 
         return this.Ok(new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileOverviewController.cs
@@ -114,7 +114,15 @@ public partial class ProfileOverviewController(
         // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
         // user kept their isAdmin claim alive indefinitely. See #624.
         var roles = await this._roleResolver.ResolveAsync(this.UserId);
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, roles.IsAdmin);
+
+        // Null means "leave the claim alone". Two cases need it: the resolver could not reach PoracleNG,
+        // where treating unknown as false stripped admin for the rest of the session (#656); and an
+        // impersonation session, which AdminController deliberately mints with IsAdmin = false and which
+        // would otherwise be re-elevated by resolving the impersonated user's own roles (#663).
+        bool? resolvedAdmin = roles.Resolved && this.User.FindFirst("impersonatedBy") is null
+            ? roles.IsAdmin
+            : null;
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, resolvedAdmin);
 
         return this.Ok(new
         {
@@ -212,7 +220,15 @@ public partial class ProfileOverviewController(
         // Resolved fresh, not copied from the old token: a profile switch was the way a de-admined
         // user kept their isAdmin claim alive indefinitely. See #624.
         var roles = await this._roleResolver.ResolveAsync(this.UserId);
-        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, roles.IsAdmin);
+
+        // Null means "leave the claim alone". Two cases need it: the resolver could not reach PoracleNG,
+        // where treating unknown as false stripped admin for the rest of the session (#656); and an
+        // impersonation session, which AdminController deliberately mints with IsAdmin = false and which
+        // would otherwise be re-elevated by resolving the impersonated user's own roles (#663).
+        bool? resolvedAdmin = roles.Resolved && this.User.FindFirst("impersonatedBy") is null
+            ? roles.IsAdmin
+            : null;
+        var newToken = this._jwtService.GenerateTokenWithReplacedProfile(this.User, this.ProfileNo, resolvedAdmin);
 
         return this.Ok(new
         {

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/QuickPickController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/QuickPickController.cs
@@ -5,9 +5,12 @@ using Pgan.PoracleWebNet.Core.Models;
 namespace Pgan.PoracleWebNet.Api.Controllers;
 
 [Route("api/quick-picks")]
-public class QuickPickController(IQuickPickService quickPickService) : BaseApiController
+public class QuickPickController(
+    IQuickPickService quickPickService,
+    ISiteSettingService siteSettingService) : BaseApiController
 {
     private readonly IQuickPickService _quickPickService = quickPickService;
+    private readonly ISiteSettingService _siteSettingService = siteSettingService;
 
     [HttpGet]
     public async Task<IActionResult> GetAll()
@@ -166,6 +169,9 @@ public class QuickPickController(IQuickPickService quickPickService) : BaseApiCo
         return this.NoContent();
     }
 
+    /// <summary>Marks that the built-in presets have been created once. See #634, #662.</summary>
+    private const string QuickPicksSeededKey = "quick_picks_seeded";
+
     [HttpPost("seed")]
     public async Task<IActionResult> Seed()
     {
@@ -175,6 +181,18 @@ public class QuickPickController(IQuickPickService quickPickService) : BaseApiCo
         }
 
         await this._quickPickService.SeedDefaultsAsync();
+
+        // Whether an installation has been seeded is a property of the installation. The SPA used to
+        // record it in localStorage, so a second admin or a different browser reseeded anyway, and a
+        // failed seed latched the flag and never retried. Written here, after the seed actually
+        // succeeded. See #662.
+        await this._siteSettingService.CreateOrUpdateAsync(new SiteSetting
+        {
+            Key = QuickPicksSeededKey,
+            Value = "true",
+            Category = "admin",
+            ValueType = "boolean",
+        });
         return this.NoContent();
     }
 }

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/UserGeofenceController.cs
@@ -55,6 +55,12 @@ public partial class UserGeofenceController(
             // does not exist.
             return this.NotFound();
         }
+        catch (InvalidOperationException ex)
+        {
+            // The rename status guard (#646) threw straight past these arms as an unhandled 500.
+            // CreateGeofence already has this arm; rename was not given it. See #657.
+            return this.BadRequest(new { error = ex.Message });
+        }
         catch (ArgumentException ex)
         {
             return this.BadRequest(new { error = ex.Message });

--- a/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
@@ -9,7 +9,14 @@ namespace Pgan.PoracleWebNet.Api.Services;
 /// <summary>
 /// A user's admin status and the webhooks they may administer, resolved from live sources.
 /// </summary>
-public readonly record struct UserRoles(bool IsAdmin, string[]? ManagedWebhooks);
+/// <param name="IsAdmin">Whether the user is an admin. Meaningless when <paramref name="Resolved"/> is false.</param>
+/// <param name="ManagedWebhooks">Webhooks the user may administer, or null.</param>
+/// <param name="Resolved">
+/// False when a source we needed was unreachable. Callers that stamp roles onto a token must treat
+/// this as "do not change the claim" rather than as "not an admin" -- a PoracleNG blip during a
+/// profile switch otherwise stripped admin for the rest of the session. See #656.
+/// </param>
+public readonly record struct UserRoles(bool IsAdmin, string[]? ManagedWebhooks, bool Resolved = true);
 
 /// <summary>
 /// Resolves admin status and delegated webhooks from the configured admin list, Poracle's config,
@@ -61,7 +68,14 @@ public sealed partial class UserRoleResolver(
         }
 
         var resolved = await this.ResolveUncachedAsync(userId);
-        this._cache.Set(cacheKey, resolved, CacheTtl);
+
+        // A degraded answer is never cached: doing so would hold a user at the wrong privilege level for
+        // the full minute after a momentary outage. See #656.
+        if (resolved.Resolved)
+        {
+            this._cache.Set(cacheKey, resolved, CacheTtl);
+        }
+
         return resolved;
     }
 
@@ -78,6 +92,10 @@ public sealed partial class UserRoleResolver(
             }
         }
 
+        // Tracked so a failure is reported as "unknown", not as "not an admin". See #656.
+        var configReadable = true;
+        var rolesReadable = true;
+
         // Check Poracle config admins list
         try
         {
@@ -91,6 +109,7 @@ public sealed partial class UserRoleResolver(
         catch (Exception ex)
         {
             LogPoracleConfigFetchFailed(this._logger, ex, userId);
+            configReadable = false;
         }
 
         // Call getAdministrationRoles once — resolves delegation including Discord guild roles
@@ -139,6 +158,7 @@ public sealed partial class UserRoleResolver(
         catch (Exception ex)
         {
             LogAdminRolesFetchFailed(this._logger, ex, userId);
+            rolesReadable = false;
         }
 
         if (isAdmin)
@@ -160,7 +180,7 @@ public sealed partial class UserRoleResolver(
             LogPwebDelegatesFetchFailed(this._logger, ex, userId);
         }
 
-        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null);
+        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null, configReadable && rolesReadable);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.html
@@ -138,9 +138,11 @@
                     <mat-icon>send</mat-icon>
                   </button>
                 }
-                <button mat-icon-button [matTooltip]="'GEOFENCES.RENAME_TOOLTIP' | translate" (click)="editGeofence(geofence)">
-                  <mat-icon>edit</mat-icon>
-                </button>
+                @if (geofence.status === 'active' || geofence.status === 'rejected') {
+                  <button mat-icon-button [matTooltip]="'GEOFENCES.RENAME_TOOLTIP' | translate" (click)="editGeofence(geofence)">
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                }
                 @if (geofence.status !== 'pending_review' && geofence.status !== 'approved') {
                   <button
                     mat-icon-button

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
@@ -13,10 +13,11 @@ import { QuickPickSummary } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { QuickPickService } from '../../core/services/quick-pick.service';
+import { SettingsService } from '../../core/services/settings.service';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 
-/** Marks that the built-in presets have been seeded once, so an empty list stays empty. See #634. */
-const SEEDED_KEY = 'poracle-quick-picks-seeded';
+/** Site setting marking that the built-in presets have been seeded once. See #634, #662. */
+const SEEDED_KEY = 'quick_picks_seeded';
 
 @Component({
   imports: [
@@ -40,6 +41,7 @@ export class QuickPickListComponent implements OnInit {
   private readonly dialog = inject(MatDialog);
   private readonly i18n = inject(I18nService);
   private readonly quickPickService = inject(QuickPickService);
+  private readonly settingsService = inject(SettingsService);
   private readonly snackBar = inject(MatSnackBar);
 
   readonly alarmTypeColors: Record<string, string> = {
@@ -97,13 +99,16 @@ export class QuickPickListComponent implements OnInit {
         this.loading.set(false);
       },
       next: picks => {
-        if (picks.length === 0 && autoSeed && this.isAdmin() && !localStorage.getItem(SEEDED_KEY)) {
-          // First visit with no picks — seed defaults and reload. Guarded by a marker because this ran
-          // on *every* empty read: an admin who deleted the presets on purpose got all thirty back on
-          // their next visit, with no prompt and no way to keep an empty list. See #634.
-          localStorage.setItem(SEEDED_KEY, '1');
+        if (picks.length === 0 && autoSeed && this.isAdmin() && this.settingsService.siteSettings()[SEEDED_KEY] !== 'true') {
+          // First visit with no picks — seed defaults and reload. Guarded because this ran on *every*
+          // empty read: an admin who deleted the presets on purpose got all thirty back on their next
+          // visit (#634). The marker is a site setting, not localStorage: whether an installation has
+          // been seeded is a property of the installation, and a per-browser flag meant a second admin
+          // reseeded anyway, while a failed seed latched the flag and never retried. See #662.
           this.quickPickService.seed().subscribe({
             error: () => this.loading.set(false),
+            // The marker is written server-side by the seed endpoint, atomically with the seed it
+            // describes -- the SPA only reads it. See #662.
             next: () => this.loadPicks(false),
           });
           return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- A PoracleNG outage during a profile switch no longer strips admin from the session: the role resolver now reports "could not resolve" separately from "not an admin", and a degraded answer is never cached (#656)
+- A profile switch during impersonation no longer undoes the deliberate privilege downgrade (#663)
+- `PUT /api/fort-changes/{uid}` bounds `changeTypes` the same way the create path does (#660)
 - Creating a profile no longer accepts an unbounded location or an area list naming another user's private geofence, both of which were written straight to the database (#647)
 - A login that carries no refresh token now clears any refresh token left behind by a previous session, instead of inheriting it and letting the refresh interceptor swap in a JWT minted for the previous user (#625)
 - A token re-issue no longer restarts the session clock: profile switches and profile resyncs keep the original expiry instead of applying the 24-hour default, so a short OIDC access token stays short and revocation propagates as documented (#624)
@@ -23,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Renaming an approved geofence answers 400 with a reason instead of 500, and the rename button is hidden where it cannot work (#657)
+- Creating a profile no longer strips approved geofences, which are public areas anyone may select, and rejects a malformed area list instead of silently emptying it (#658)
+- Seeding the built-in quick picks is no longer aborted by a user pick that happens to hold a built-in id (#659)
+- The invasion `gruntType` length bound is the column's actual width (255), not an invented 35 (#661)
+- Whether the built-in quick picks have been seeded is recorded server-side, so a second admin or a different browser no longer reseeds them and a failed seed retries (#662)
 - Editing a quick pick no longer drops filters whose value is 0: the built-in Nundo preset is `minIv: 0, maxIv: 0`, so changing its description silently turned "0% IV only" into "any IV" for everyone who applied it afterwards (#654)
 - Rejecting a geofence submission no longer silently stops the owner's alerts: a rejected fence stays in the feed, as "remains private with review notes" always intended (#645)
 - An approved or under-review geofence can no longer be renamed, which used to move the area subscription to a name neither Koji nor the feed serves (#646)

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IQuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IQuickPickService.cs
@@ -9,7 +9,11 @@ public interface IQuickPickService
 
     /// <summary>Ownership-scoped read: global picks are public, user picks are visible only to their owner.</summary>
     public Task<QuickPickDefinition?> GetVisibleByIdAsync(string userId, string id);
-    public Task<QuickPickDefinition> SaveAdminPickAsync(QuickPickDefinition definition);
+    /// <summary>
+    /// Saves a global quick pick. <paramref name="isSeeding"/> skips the ownership guard, which the
+    /// seeding path shares and would otherwise trip over a user pick holding a built-in id. See #659.
+    /// </summary>
+    public Task<QuickPickDefinition> SaveAdminPickAsync(QuickPickDefinition definition, bool isSeeding = false);
     public Task<QuickPickDefinition> SaveUserPickAsync(string userId, QuickPickDefinition definition);
     public Task<bool> DeleteAdminPickAsync(string id);
     public Task<bool> DeleteUserPickAsync(string userId, string id);

--- a/Core/Pgan.PoracleWebNet.Core.Models/FortChangeUpdate.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/FortChangeUpdate.cs
@@ -29,6 +29,10 @@ public class FortChangeUpdate
         get; set;
     }
 
+    // The same two bounds the create DTO carries (#612). Left off here, an update could still push an
+    // unbounded or repeating list into the JSON text column. See #660.
+    [MaxLength(5, ErrorMessage = "changeTypes may contain at most 5 entries.")]
+    [DistinctValues(ErrorMessage = "changeTypes must not repeat a value.")]
     [AllowedStringValues(
         FortChangeOptions.ChangeTypeName,
         FortChangeOptions.ChangeTypeLocation,

--- a/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/InvasionService.cs
@@ -227,8 +227,13 @@ public partial class InvasionService(IPoracleTrackingProxy proxy, IFeatureGate f
     /// as a generic 500. Fail here instead, where the message says what is actually wrong. Callers that
     /// want "everything" must fan out over <see cref="InvasionGruntTypes.All"/>. See #416.
     /// </summary>
-    /// <summary>The grunt_type column width upstream.</summary>
-    private const int MaxGruntTypeLength = 35;
+    /// <summary>
+    /// The grunt_type column width upstream: <c>varchar(255)</c>, per PoracleNG's initial schema
+    /// migration at the commit production runs. This said 35, which was an invented limit wearing a
+    /// factual justification -- in a fix whose whole point was refusing the impossible rather than
+    /// allowing only the known. See #661.
+    /// </summary>
+    private const int MaxGruntTypeLength = 255;
 
     private static void RequireGruntType(Invasion model)
     {

--- a/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/QuickPickService.cs
@@ -161,7 +161,7 @@ public partial class QuickPickService(
     public async Task<QuickPickDefinition?> GetVisibleByIdAsync(string userId, string id) =>
         await this.LoadDefinitionAsync(userId, id);
 
-    public async Task<QuickPickDefinition> SaveAdminPickAsync(QuickPickDefinition definition)
+    public async Task<QuickPickDefinition> SaveAdminPickAsync(QuickPickDefinition definition, bool isSeeding = false)
     {
         EnsureFiltersAreUsable(definition);
 
@@ -170,12 +170,19 @@ public partial class QuickPickService(
         // Given an id, this used to convert whatever it found into a global pick -- including a private
         // one belonging to somebody else, which then appeared for every user and vanished from its
         // owner's list. SaveUserPickAsync has always had this guard. See #631.
-        var existing = await this._definitionRepository.GetByIdAsync(definition.Id);
-        if (existing is not null
-            && !string.Equals(existing.Scope, "global", StringComparison.OrdinalIgnoreCase))
+        //
+        // Skipped when seeding. SeedDefaultsAsync creates the built-ins through this method, so a
+        // user-scoped pick that happens to hold a built-in id aborted the seed partway -- the same
+        // partial-preset-list failure #637 fixed, reintroduced by the guard in the same commit. See #659.
+        if (!isSeeding)
         {
-            throw new AlarmValidationException(
-                "That quick pick belongs to a user. Publish a copy instead of converting theirs.");
+            var existing = await this._definitionRepository.GetByIdAsync(definition.Id);
+            if (existing is not null
+                && !string.Equals(existing.Scope, "global", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new AlarmValidationException(
+                    "That quick pick belongs to a user. Publish a copy instead of converting theirs.");
+            }
         }
 
         definition.Scope = "global";
@@ -620,7 +627,7 @@ public partial class QuickPickService(
 
         foreach (var definition in Defaults)
         {
-            await this.SaveAdminPickAsync(definition);
+            await this.SaveAdminPickAsync(definition, isSeeding: true);
         }
     }
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/InvasionServiceTests.cs
@@ -346,9 +346,23 @@ public class InvasionServiceTests
     [Fact]
     public async Task CreateAsyncRefusesAGruntTypeLongerThanTheColumn()
     {
+        // varchar(255) upstream. This asserted 35, an invented limit the fix's own rationale forbade.
+        // See #661.
         var ex = await Assert.ThrowsAsync<AlarmValidationException>(
-            () => this._sut.CreateAsync("user1", new Invasion { GruntType = new string('a', 36) }));
+            () => this._sut.CreateAsync("user1", new Invasion { GruntType = new string('a', 256) }));
 
-        Assert.Contains("35", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("255", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateAsyncAcceptsAGruntTypeTheColumnCanHold()
+    {
+        // The legitimate-case-still-passes half. See #661.
+        this._proxy.Setup(p => p.CreateAsync("invasion", "user1", It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingCreateResult([12], 0, 0, 1));
+
+        var result = await this._sut.CreateAsync("user1", new Invasion { GruntType = new string('a', 255) });
+
+        Assert.Equal(12, result.Uid);
     }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/QuickPickServiceSecurityTests.cs
@@ -326,6 +326,26 @@ public class QuickPickServiceSecurityTests
     // then collapsed to /api/quick-picks/ so the pick could not be deleted or applied through any path.
 
     [Fact]
+    public async Task SeedingIsNotBlockedByAUserPickHoldingABuiltInId()
+    {
+        // SeedDefaultsAsync creates the built-ins through SaveAdminPickAsync, so the ownership guard
+        // added alongside it ran there too: one user-scoped pick holding a built-in id aborted the seed
+        // partway -- the same partial-preset-list failure the same commit had just fixed. See #659.
+        this._definitionRepository.Setup(r => r.GetAllGlobalAsync()).ReturnsAsync([]);
+        this._definitionRepository.Setup(r => r.GetByIdAsync(It.IsAny<string>()))
+            .ReturnsAsync(new QuickPickDefinition { Id = "nundo", Scope = "user", OwnerUserId = "u2" });
+        var created = new List<string>();
+        this._definitionRepository.Setup(r => r.CreateOrUpdateAsync(It.IsAny<QuickPickDefinition>()))
+            .Callback<QuickPickDefinition>(d => created.Add(d.Id))
+            .Returns(Task.CompletedTask);
+
+        await this._sut.SeedDefaultsAsync();
+
+        var expected = (await this._sut.GetDefaultPicksAsync()).Count();
+        Assert.Equal(expected, created.Count);
+    }
+
+    [Fact]
     public async Task SaveAdminPickRefusesToTakeOverAUsersPrivatePick()
     {
         // Given an id it converted whatever it found into a global pick -- so an admin editing their own

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserRoleResolverTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserRoleResolverTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Pgan.PoracleWebNet.Api.Configuration;
+using Pgan.PoracleWebNet.Api.Services;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// The resolver must distinguish "resolved: not an admin" from "could not resolve". Treating the second
+/// as the first meant a PoracleNG blip during a profile switch stripped admin for the rest of the
+/// session, and cached that answer for a minute. See #656.
+/// </summary>
+public class UserRoleResolverTests
+{
+    private readonly Mock<IPoracleApiProxy> _poracleApiProxy = new();
+    private readonly Mock<IWebhookDelegateService> _webhookDelegateService = new();
+
+    private UserRoleResolver CreateSut(string adminIds = "") => new(
+        this._poracleApiProxy.Object,
+        this._webhookDelegateService.Object,
+        Options.Create(new PoracleSettings { AdminIds = adminIds }),
+        new MemoryCache(new MemoryCacheOptions()),
+        NullLogger<UserRoleResolver>.Instance);
+
+    [Fact]
+    public async Task AnUnreachablePoracleIsReportedAsUnresolvedRatherThanAsNotAnAdmin()
+    {
+        this._poracleApiProxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new HttpRequestException("down"));
+        this._poracleApiProxy.Setup(p => p.GetAdminRolesAsync(It.IsAny<string>())).ThrowsAsync(new HttpRequestException("down"));
+        this._webhookDelegateService.Setup(s => s.GetManagedWebhookIdsAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.False(roles.Resolved);
+    }
+
+    [Fact]
+    public async Task ADegradedAnswerIsNotCached()
+    {
+        // Caching it would hold the user at the wrong privilege level for the full minute after a
+        // momentary outage.
+        this._poracleApiProxy.Setup(p => p.GetConfigAsync()).ThrowsAsync(new HttpRequestException("down"));
+        this._poracleApiProxy.Setup(p => p.GetAdminRolesAsync(It.IsAny<string>())).ThrowsAsync(new HttpRequestException("down"));
+        this._webhookDelegateService.Setup(s => s.GetManagedWebhookIdsAsync(It.IsAny<string>())).ReturnsAsync([]);
+        var sut = this.CreateSut();
+
+        await sut.ResolveAsync("u1");
+        await sut.ResolveAsync("u1");
+
+        this._poracleApiProxy.Verify(p => p.GetAdminRolesAsync("u1"), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task AConfiguredAdminNeedsNoNetworkAndIsAlwaysResolved()
+    {
+        var roles = await this.CreateSut("u1,u2").ResolveAsync("u1");
+
+        Assert.True(roles.IsAdmin);
+        Assert.True(roles.Resolved);
+        this._poracleApiProxy.Verify(p => p.GetConfigAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AGenuineNonAdminIsResolvedAndCached()
+    {
+        // The legitimate-case-still-passes half: a clean "no" must still be a usable answer, and must
+        // still be cached.
+        this._poracleApiProxy.Setup(p => p.GetConfigAsync()).ReturnsAsync((PoracleConfig?)null!);
+        this._poracleApiProxy.Setup(p => p.GetAdminRolesAsync(It.IsAny<string>())).ReturnsAsync("{}");
+        this._webhookDelegateService.Setup(s => s.GetManagedWebhookIdsAsync(It.IsAny<string>())).ReturnsAsync([]);
+        var sut = this.CreateSut();
+
+        var roles = await sut.ResolveAsync("u1");
+        await sut.ResolveAsync("u1");
+
+        Assert.False(roles.IsAdmin);
+        Assert.True(roles.Resolved);
+        this._poracleApiProxy.Verify(p => p.GetAdminRolesAsync("u1"), Times.Once);
+    }
+}


### PR DESCRIPTION
Every defect here was caused by a fix merged earlier today. They were found by the **regression lens** added in #653 — an audit whose only question is what the last day's merges broke and which siblings they missed. It had never been run before; this is its first pass.

**#656 — a PoracleNG blip now de-admins a live session.** `UserRoleResolver` could not distinguish *"resolved: not an admin"* from *"could not resolve"*, and #635 wired that result into every token re-issue. A momentary outage during a profile switch stripped admin for the rest of the session, and cached the false for 60 seconds. Before #635 the claim was copied forward and an outage could not demote anyone — so the fix made things worse than the bug. The resolver now reports `Resolved: false`, callers pass `null` to leave the claim alone, and a degraded answer is never cached.

**#657 — the rename guard from #652 surfaced as a 500.** It throws `InvalidOperationException`; `RenameGeofence` catches three other types. `CreateGeofence` two methods below already had the arm. The button was also rendered on every status, while submit and delete beside it are gated — so every approved fence showed a button whose only outcome was a server error.

**#658 — the profile-create filter from #652 denied public areas.** It built its deny-set from every other user's geofence regardless of status, but an *approved* fence is a public Koji area anyone may select — and when no `promotedName` was given, the public name **is** the `KojiName` being denied. A legitimate area vanished from the new profile, with a 201.

**#659 — #638's ownership guard aborts the seeding #638 fixed.** `SeedDefaultsAsync` creates the built-ins through `SaveAdminPickAsync`, so a user-scoped pick holding a built-in id aborts the seed partway. Both changes were in the same commit. This is the case `CLAUDE.md` names verbatim under "find the other callers" — written the same day, and it still slipped through, because the two halves were reviewed as separate items in one diff.

**#660 / #661 — #614's sibling and its invented limit.** `FortChangeUpdate.ChangeTypes` never got the bounds `FortChangeCreate` did, so `PUT` still reaches the database error. And `MaxGruntTypeLength = 35` was documented as "the column width upstream" when the column is `varchar(255)` — an invented allowlist-shaped limit in the one fix whose entire rationale was avoiding them.

**#662 / #663** — the quick-pick seed marker was per-browser localStorage for an installation-level fact (a second admin reseeded anyway; a failed seed latched it forever), now a site setting written by the seed endpoint itself; and a profile switch during impersonation re-resolved the *impersonated* user's roles, undoing the deliberate `IsAdmin = false`.

## Verification

- 1832 backend tests (5 new), 955 frontend tests.
- New `UserRoleResolverTests` pins all four states: unreachable reports unresolved, a degraded answer is not cached, a configured admin needs no network, and — the legitimate-case-still-passes half — a genuine "no" is still resolved and still cached.
- The seeding test asserts every built-in is created even when a user pick holds a built-in id.
- The grunt-length test now asserts 255 accepted and 256 refused, replacing one that enshrined the invented 35.