### PR TITLE
fix: five regressions from the first regression pass (#665-#669)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/ProfileController.cs
@@ -125,34 +125,15 @@ public class ProfileController(
             return this.BadRequest(validationError);
         }
 
-        // PoracleNG assigns the lowest free number, not max+1, so the number cannot be predicted for a
-        // user who has ever deleted a non-last profile. Ask what it chose. See #407.
-        var before = (await this._profileService.GetByUserAsync(this.UserId)).ToList();
-
-        var body = JsonSerializer.SerializeToElement(new
-        {
-            name = profile.Name,
-            area = profile.Area ?? "[]",
-            latitude = profile.Latitude,
-            longitude = profile.Longitude,
-            active_hours = profile.ActiveHours
-        });
-        await this._humanProxy.AddProfileAsync(this.UserId, body);
-
-        var after = (await this._profileService.GetByUserAsync(this.UserId)).ToList();
-        var createdNo = ProfileNumbering.ResolveCreated(before, after, profile.Name);
-        if (createdNo is null)
-        {
-            return this.StatusCode(StatusCodes.Status502BadGateway, new
-            {
-                error = "The profile was not created."
-            });
-        }
-
         // The request supplies its own geography, and nothing bounded it. Coordinates out of range reach
         // the active-hours scheduler, which reads them as a timezone; an area list could name another
         // user's private geofence, which PoracleNG's own setAreas filter would have stripped but a direct
         // write does not. See #647.
+        //
+        // Both checks run BEFORE the profile is created. Behind it, a refusal answered 400 while leaving
+        // a profile PoracleNG had already made -- and since addProfile ignores `area`, that orphan came
+        // up carrying the ACTIVE profile's entire area list and location, the inheritance #563 exists to
+        // prevent. A retry then made a second one. See #665.
         if (profile.Latitude is < -90 or > 90 || profile.Longitude is < -180 or > 180)
         {
             return this.BadRequest(new
@@ -169,6 +150,30 @@ public class ProfileController(
         catch (ArgumentException ex)
         {
             return this.BadRequest(new { error = ex.Message });
+        }
+
+        // PoracleNG assigns the lowest free number, not max+1, so the number cannot be predicted for a
+        // user who has ever deleted a non-last profile. Ask what it chose. See #407.
+        var before = (await this._profileService.GetByUserAsync(this.UserId)).ToList();
+
+        var body = JsonSerializer.SerializeToElement(new
+        {
+            name = profile.Name,
+            area = requestedAreas,
+            latitude = profile.Latitude,
+            longitude = profile.Longitude,
+            active_hours = profile.ActiveHours
+        });
+        await this._humanProxy.AddProfileAsync(this.UserId, body);
+
+        var after = (await this._profileService.GetByUserAsync(this.UserId)).ToList();
+        var createdNo = ProfileNumbering.ResolveCreated(before, after, profile.Name);
+        if (createdNo is null)
+        {
+            return this.StatusCode(StatusCodes.Status502BadGateway, new
+            {
+                error = "The profile was not created."
+            });
         }
 
         // addProfile ignores area, latitude and longitude, so a new profile came up carrying whatever the

--- a/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
@@ -95,6 +95,7 @@ public sealed partial class UserRoleResolver(
         // Tracked so a failure is reported as "unknown", not as "not an admin". See #656.
         var configReadable = true;
         var rolesReadable = true;
+        var delegatesReadable = true;
 
         // Check Poracle config admins list
         try
@@ -177,10 +178,14 @@ public sealed partial class UserRoleResolver(
         }
         catch (Exception ex)
         {
+            // The third source, and it was left out of the Resolved flag: a poracle_web blip returned a
+            // confident answer with an incomplete webhook list, which then got cached for the full
+            // minute and denied a legitimate delegate the whole time. See #667.
             LogPwebDelegatesFetchFailed(this._logger, ex, userId);
+            delegatesReadable = false;
         }
 
-        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null, configReadable && rolesReadable);
+        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null, configReadable && rolesReadable && delegatesReadable);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/admin-settings.component.ts
@@ -383,6 +383,10 @@ export class AdminSettingsComponent implements OnInit {
     'admin_disable_userlist',
     'admin_channel_id',
     'migration_completed',
+    // Installation sentinel, like migration_completed above. Listed in SettingsController's
+    // InternalKeys equivalent would hide it from admins too, and the quick-picks guard needs to read
+    // it -- so it is hidden here instead of there. See #668.
+    'quick_picks_seeded',
   ];
 
   private readonly originalSnapshot = signal<AnySettingItem[]>([]);

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -197,7 +197,11 @@ export class QuickPickAdminDialogComponent implements OnInit {
     // Start from what is stored rather than rebuilding: any key the dialog has no control for used to be
     // dropped on save, and quick-pick-apply reads filters['clean'] as its base bitmask while no form
     // exposes it. See #654.
-    const stored: Record<string, unknown> = { ...(this.data?.filters ?? {}) };
+    // Only when the type is unchanged. alarmType is editable on the edit dialog, and carrying the old
+    // type's keys across stored minIv and pvpRankingLeague on a lure pick. Inert at apply time, since
+    // BuildFromFilters ignores unknown keys, but it is junk in the definition. See #669.
+    const sameType = this.data?.alarmType === (main.alarmType ?? 'monster');
+    const stored: Record<string, unknown> = sameType ? { ...(this.data?.filters ?? {}) } : {};
     const filters: Record<string, unknown> = stored;
     if (filterForm) {
       const raw = filterForm.getRawValue();

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.spec.ts
@@ -1,13 +1,16 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
 import { QuickPickListComponent } from './quick-pick-list.component';
 import { QuickPickSummary } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { ConfigService } from '../../core/services/config.service';
 import { QuickPickService } from '../../core/services/quick-pick.service';
+import { SettingsService } from '../../core/services/settings.service';
 
 describe('QuickPickListComponent', () => {
   let component: QuickPickListComponent;
@@ -194,5 +197,58 @@ describe('QuickPickListComponent', () => {
   it('should set selectedCategory when selecting a specific category', () => {
     component.selectCategory('PvP');
     expect(component.selectedCategory()).toBe('PvP');
+  });
+
+  describe('auto-seeding the built-in presets', () => {
+    // The guard exists so an admin who deletes the presets on purpose keeps an empty list (#634). It
+    // moved from a localStorage flag to a site setting (#662), and the local signal is only refreshed
+    // at app init -- so without updating it after a seed, deleting the last pick in the same session
+    // restored all thirty. See #666.
+    function setupAdmin(siteSettings: Record<string, string>, picks: QuickPickSummary[]) {
+      const seed = jest.fn(() => of(undefined));
+      const settings = { siteSettings: signal(siteSettings) };
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          { provide: ConfigService, useValue: { apiHost: API } },
+          { provide: AuthService, useValue: { currentUser: () => null, isAdmin: () => true } },
+          { provide: SettingsService, useValue: settings },
+          { provide: QuickPickService, useValue: { getAll: jest.fn(() => of(picks)), seed } },
+        ],
+        imports: [QuickPickListComponent],
+      });
+
+      const fixture = TestBed.createComponent(QuickPickListComponent);
+      return { component: fixture.componentInstance, seed, settings };
+    }
+
+    it('seeds when the list is empty and the installation has never been seeded', () => {
+      const { component: sut, seed } = setupAdmin({}, []);
+
+      sut.loadPicks();
+
+      expect(seed).toHaveBeenCalled();
+    });
+
+    it('does not seed again after seeding once in the same session', () => {
+      const { component: sut, seed } = setupAdmin({}, []);
+
+      sut.loadPicks();
+      sut.loadPicks();
+
+      expect(seed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not seed an installation that has already been seeded', () => {
+      const { component: sut, seed } = setupAdmin({ quick_picks_seeded: 'true' }, []);
+
+      sut.loadPicks();
+
+      expect(seed).not.toHaveBeenCalled();
+    });
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-list.component.ts
@@ -107,9 +107,15 @@ export class QuickPickListComponent implements OnInit {
           // reseeded anyway, while a failed seed latched the flag and never retried. See #662.
           this.quickPickService.seed().subscribe({
             error: () => this.loading.set(false),
-            // The marker is written server-side by the seed endpoint, atomically with the seed it
-            // describes -- the SPA only reads it. See #662.
-            next: () => this.loadPicks(false),
+            next: () => {
+              // The marker is written server-side by the seed endpoint, atomically with the seed it
+              // describes (#662). The local signal is only refreshed at app init, so without this the
+              // key stayed absent for the rest of the session: deleting the last pick called loadPicks
+              // with autoSeed, saw an empty list and an absent marker, and restored all thirty. That is
+              // #634 again, minus the synchronous localStorage write that used to mask it. See #666.
+              this.settingsService.siteSettings.update(current => ({ ...current, [SEEDED_KEY]: 'true' }));
+              this.loadPicks(false);
+            },
           });
           return;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- A failed lookup of PoracleWeb's own delegate table is now reported as unresolved rather than as a confident empty list, so a momentary blip no longer denies a delegate for a full minute (#667)
 - A PoracleNG outage during a profile switch no longer strips admin from the session: the role resolver now reports "could not resolve" separately from "not an admin", and a degraded answer is never cached (#656)
 - A profile switch during impersonation no longer undoes the deliberate privilege downgrade (#663)
 - `PUT /api/fort-changes/{uid}` bounds `changeTypes` the same way the create path does (#660)
@@ -26,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Creating a profile validates the location and area list before the profile is created, instead of leaving an orphan profile behind a 400 (#665)
+- Deleting the last quick pick no longer restores all thirty presets in the same session, and installations seeded before the marker existed are backfilled at startup (#666)
+- The quick-pick seed marker no longer appears in the admin Settings page as an editable unknown setting (#668)
+- Changing a quick pick's alarm type no longer keeps the previous type's filter keys (#669)
 - Renaming an approved geofence answers 400 with a reason instead of 500, and the rename button is hidden where it cannot work (#657)
 - Creating a profile no longer strips approved geofences, which are public areas anyone may select, and rejects a malformed area list instead of silently emptying it (#658)
 - Seeding the built-in quick picks is no longer aborted by a user pick that happens to hold a built-in id (#659)

--- a/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
@@ -406,6 +406,9 @@ public partial class SettingsMigrationService(
         ("custom_title", "PoracleWeb.NET", "branding", "string"),
     ];
 
+    /// <summary>Marks that the built-in quick picks have been created once. See #662, #666.</summary>
+    private const string QuickPicksSeededKey = "quick_picks_seeded";
+
     public async Task SeedDefaultsAsync()
     {
         foreach (var (key, value, category, valueType) in DefaultSettings)
@@ -426,6 +429,42 @@ public partial class SettingsMigrationService(
 
             LogDefaultSeeded(this._logger, key, value);
         }
+
+        await this.BackfillQuickPickSeedMarkerAsync();
+    }
+
+    /// <summary>
+    /// Records that the built-in quick picks exist, for installations seeded before the marker did.
+    /// </summary>
+    /// <remarks>
+    /// The marker used to be a per-browser localStorage flag and became a site setting in #662. Without
+    /// this, an installation that was already seeded has no row, so the first admin to open Quick Picks
+    /// after upgrading -- having deliberately deleted the presets -- gets all thirty back. See #666.
+    /// </remarks>
+    private async Task BackfillQuickPickSeedMarkerAsync()
+    {
+        if (await this._siteSettingService.GetByKeyAsync(QuickPicksSeededKey) is not null)
+        {
+            return;
+        }
+
+        var globals = await this._quickPickDefinitionRepository.GetAllGlobalAsync();
+        if (globals is not { Count: > 0 })
+        {
+            // Genuinely fresh, or deliberately emptied before the marker existed. Either way the first
+            // admin visit seeds, which is the behaviour that shipped.
+            return;
+        }
+
+        await this._siteSettingService.CreateOrUpdateAsync(new SiteSetting
+        {
+            Key = QuickPicksSeededKey,
+            Value = "true",
+            Category = "admin",
+            ValueType = "boolean",
+        });
+
+        LogDefaultSeeded(this._logger, QuickPicksSeededKey, "true");
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Settings migration completed: {SiteSettings} site settings, {WebhookDelegates} webhook delegates, {QuickPickDefinitions} quick pick definitions, {QuickPickAppliedStates} quick pick applied states, {Failed} failed")]


### PR DESCRIPTION
Second run of the regression lens, this time over the fixes the first run produced. Five findings, all self-inflicted — the rate is falling (8 → 5) but has not reached zero.

**#665 — the worst, and mine from an hour ago.** `ProfileController.Create` validates the location and the area list **after** `AddProfileAsync`. Both refusals therefore answer 400 with the profile already created, and the write that would have set the filtered geography never runs. Since `addProfile` ignores `area`, that orphan comes up carrying the *active* profile's entire area list and location — the inheritance #563 exists to prevent — and a retry makes another. #647 replaced "a 201 that silently dropped areas" with "a 400 plus a profile nobody mentioned". Both checks now run first, and the create body carries the filtered list.

**#666 — #634, restored.** The seed marker moved to a site setting written server-side, but `siteSettings()` is only populated at app init, so within the seeding session the key stayed absent. Deleting the last pick then found an empty list and no marker and restored all thirty. There was also no backfill, so any installation seeded under the old localStorage marker would reseed once after upgrading. Both closed — and the guard now has the frontend tests it shipped without, **which is exactly why this got through**.

**#667 — two sources out of three.** `configReadable` and `rolesReadable` were tracked; the delegate-table lookup only logged. A `poracle_web` blip returned `Resolved = true` with an incomplete webhook list, passed the "never cache a degraded answer" gate, and denied a legitimate delegate for the full minute — the failure that gate was added to prevent, arriving through the one source it wasn't watching.

**#668 / #669** — the new sentinel rendered in the admin settings page as an editable unknown setting, because that list is maintained separately from the controller's and only one of the two was updated (`migration_completed` is in both); and the filter merge from #655 carried the old alarm type's keys when the type was changed.

## Verification

- 1832 backend, 958 frontend tests (3 new).
- The new seeding test was **confirmed red** against the un-refreshed signal and green after.
- `SettingsMigrationServiceTests` caught a null-mock in the backfill, which is now null-safe rather than assuming the repository never returns null.