### PR TITLE
fix: a type change no longer resets a quick pick's clean bits (#671, #672)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
@@ -85,6 +85,42 @@ describe('QuickPickAdminDialogComponent', () => {
     });
   });
 
+  describe('changing the alarm type', () => {
+    const monsterPick: QuickPickDefinition = {
+      id: 'p',
+      name: 'P',
+      alarmType: 'monster',
+      category: 'PvP',
+      description: '',
+      enabled: true,
+      filters: { clean: 5, minIv: 0, pvpRankingLeague: 1500 },
+      icon: 'pokeball',
+      scope: 'global',
+      sortOrder: 1,
+    };
+
+    it('drops the previous type’s filters', () => {
+      setup(monsterPick);
+      component.mainForm.patchValue({ alarmType: 'lure' });
+
+      component.save();
+
+      expect(savedDefinition().filters['pvpRankingLeague']).toBeUndefined();
+      expect(savedDefinition().filters['minIv']).toBeUndefined();
+    });
+
+    it('keeps clean, which belongs to no type', () => {
+      // quick-pick-apply reads it as the base bitmask, and clearing wholesale reset a pick's
+      // auto-delete, edit and summary bits on a type change. See #671.
+      setup(monsterPick);
+      component.mainForm.patchValue({ alarmType: 'lure' });
+
+      component.save();
+
+      expect(savedDefinition().filters['clean']).toBe(5);
+    });
+  });
+
   describe('creating a new definition', () => {
     it('does not write out the form defaults that mean "not set"', () => {
       // Most numeric controls default to 0. Persisting them would put an explicit minIv, pokemonId and

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -16,6 +16,14 @@ import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { QuickPickService } from '../../core/services/quick-pick.service';
 
+/**
+ * Filter keys that belong to no particular alarm type, and so survive a type change.
+ *
+ * `clean` is the only one: every other key is owned by one alarm type's form, while `clean` is read by
+ * the apply dialog as its base bitmask and is exposed by no form at all. See #671.
+ */
+const TYPE_AGNOSTIC_FILTER_KEYS = new Set(['clean']);
+
 @Component({
   imports: [
     ReactiveFormsModule,
@@ -197,11 +205,16 @@ export class QuickPickAdminDialogComponent implements OnInit {
     // Start from what is stored rather than rebuilding: any key the dialog has no control for used to be
     // dropped on save, and quick-pick-apply reads filters['clean'] as its base bitmask while no form
     // exposes it. See #654.
-    // Only when the type is unchanged. alarmType is editable on the edit dialog, and carrying the old
-    // type's keys across stored minIv and pvpRankingLeague on a lure pick. Inert at apply time, since
-    // BuildFromFilters ignores unknown keys, but it is junk in the definition. See #669.
+    // A type change clears the old type's filters -- carrying them across stored minIv and
+    // pvpRankingLeague on a lure pick (#669) -- but keeps the keys that belong to no type. Clearing
+    // wholesale threw away `clean`, which quick-pick-apply reads as its base bitmask, so changing a
+    // pick's type silently reset its auto-delete, edit and summary bits: the preservation #654 added,
+    // undone by the fix for #669. See #671.
     const sameType = this.data?.alarmType === (main.alarmType ?? 'monster');
-    const stored: Record<string, unknown> = sameType ? { ...(this.data?.filters ?? {}) } : {};
+    const previous = this.data?.filters ?? {};
+    const stored: Record<string, unknown> = sameType
+      ? { ...previous }
+      : Object.fromEntries(Object.entries(previous).filter(([key]) => TYPE_AGNOSTIC_FILTER_KEYS.has(key)));
     const filters: Record<string, unknown> = stored;
     if (filterForm) {
       const raw = filterForm.getRawValue();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Changing a quick pick's alarm type no longer resets its auto-delete, edit-in-place and summary bits (#671)
 - Creating a profile validates the location and area list before the profile is created, instead of leaving an orphan profile behind a 400 (#665)
 - Deleting the last quick pick no longer restores all thirty presets in the same session, and installations seeded before the marker existed are backfilled at startup (#666)
 - The quick-pick seed marker no longer appears in the admin Settings page as an editable unknown setting (#668)

--- a/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/SettingsMigrationService.cs
@@ -437,9 +437,15 @@ public partial class SettingsMigrationService(
     /// Records that the built-in quick picks exist, for installations seeded before the marker did.
     /// </summary>
     /// <remarks>
-    /// The marker used to be a per-browser localStorage flag and became a site setting in #662. Without
-    /// this, an installation that was already seeded has no row, so the first admin to open Quick Picks
-    /// after upgrading -- having deliberately deleted the presets -- gets all thirty back. See #666.
+    /// The marker used to be a per-browser localStorage flag and became a site setting in #662, so an
+    /// installation seeded before that has no row and would seed again on the next admin visit.
+    /// <para>
+    /// This covers installations that still hold at least one global pick, which is the common case. It
+    /// deliberately does NOT cover an admin who had already deleted every preset before upgrading: they
+    /// have no global picks, so there is nothing here to infer from, and the old marker lived in their
+    /// browser where the server cannot see it. That admin gets one reseed. Said plainly because the
+    /// first version of this comment claimed to cover it and did not. See #666, #672.
+    /// </para>
     /// </remarks>
     private async Task BackfillQuickPickSeedMarkerAsync()
     {


### PR DESCRIPTION
Closes #671
Closes #672

Third run of the regression lens. **Two findings, both low severity, no regressions of consequence and no missed siblings** — the curve across the three passes is 8 → 5 → 2.

**#671** — the `sameType` gate added for #669 cleared *every* stored key on a type change, not just the departing type's filters. `clean` is read by `quick-pick-apply-dialog` as its base bitmask and is exposed by no form, so changing a pick's type silently reset its auto-delete, edit-in-place and summary bits. That is the preservation #654 added, undone two commits later by the fix for #669 — a three-link chain, which is why the lens has to keep running until a pass comes back empty. Type-agnostic keys now survive; `clean` is the only one, confirmed by grepping every `filters['…']` read.

**#672** — a documentation correction, and worth making explicitly. My `BackfillQuickPickSeedMarkerAsync` docstring claimed it spares an admin who had deliberately deleted the presets before upgrading. It does not: that admin has zero global picks, so there is nothing for the backfill to infer from, and the old marker lived in their browser where the server cannot see it. They get one reseed. The inline comment inside the method said so honestly while the docstring above it and the commit message overclaimed. The code is right; only the documentation changes.

## Verification

- 1832 backend, 960 frontend tests (2 new). The `clean` test was **confirmed red** against the wholesale clear and green after; its sibling asserts the departing type's filters are still dropped, so #669 is not undone in the other direction.