### PR TITLE
fix: three more type-agnostic keys survive a quick-pick type change (#674)

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.spec.ts
@@ -93,7 +93,7 @@ describe('QuickPickAdminDialogComponent', () => {
       category: 'PvP',
       description: '',
       enabled: true,
-      filters: { clean: 5, minIv: 0, pvpRankingLeague: 1500 },
+      filters: { clean: 5, minIv: 0, ping: '<@&123>', pvpRankingLeague: 1500, template: 'custom' },
       icon: 'pokeball',
       scope: 'global',
       sortOrder: 1,
@@ -109,15 +109,18 @@ describe('QuickPickAdminDialogComponent', () => {
       expect(savedDefinition().filters['minIv']).toBeUndefined();
     });
 
-    it('keeps clean, which belongs to no type', () => {
-      // quick-pick-apply reads it as the base bitmask, and clearing wholesale reset a pick's
-      // auto-delete, edit and summary bits on a type change. See #671.
+    it('keeps the keys that belong to no type', () => {
+      // All four are properties of every alarm model and are exposed by no form. Clearing wholesale
+      // reset a pick's auto-delete bits (#671) and dropped its ping target and template (#674).
       setup(monsterPick);
       component.mainForm.patchValue({ alarmType: 'lure' });
 
       component.save();
 
-      expect(savedDefinition().filters['clean']).toBe(5);
+      const filters = savedDefinition().filters;
+      expect(filters['clean']).toBe(5);
+      expect(filters['ping']).toBe('<@&123>');
+      expect(filters['template']).toBe('custom');
     });
   });
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quick-picks/quick-pick-admin-dialog.component.ts
@@ -19,10 +19,15 @@ import { QuickPickService } from '../../core/services/quick-pick.service';
 /**
  * Filter keys that belong to no particular alarm type, and so survive a type change.
  *
- * `clean` is the only one: every other key is owned by one alarm type's form, while `clean` is read by
- * the apply dialog as its base bitmask and is exposed by no form at all. See #671.
+ * All four are properties of every one of the ten alarm models, and none is exposed by any of the
+ * per-type forms in `getFilterForm` -- the same test that justified preserving `clean` in #671. The
+ * backend's own `QuickPickService.SafeMonsterFilterKeys` lists them alongside it. `ping` in particular
+ * is never overridden at apply time, because the apply dialog has no ping control at all.
+ *
+ * This said `clean` was the only one, which was wrong -- and wrong in the direction that silently drops
+ * a user's ping target and template on a type change. See #671, #674.
  */
-const TYPE_AGNOSTIC_FILTER_KEYS = new Set(['clean']);
+const TYPE_AGNOSTIC_FILTER_KEYS = new Set(['clean', 'distance', 'ping', 'template']);
 
 @Component({
   imports: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Changing a quick pick's alarm type no longer drops its ping target, template or distance either (#674)
 - Changing a quick pick's alarm type no longer resets its auto-delete, edit-in-place and summary bits (#671)
 - Creating a profile validates the location and area list before the profile is created, instead of leaving an orphan profile behind a 400 (#665)
 - Deleting the last quick pick no longer restores all thirty presets in the same session, and installations seeded before the marker existed are backfilled at startup (#666)


### PR DESCRIPTION
Closes #674

Fourth run of the regression lens. **One finding**, and it is against the *comment* #673 shipped with rather than its logic.

`TYPE_AGNOSTIC_FILTER_KEYS = new Set(['clean'])` asserted that `clean` was the only key belonging to no alarm type. The codebase contradicts that in its own whitelist — `QuickPickService.SafeMonsterFilterKeys` lists `form, gender, clean, template, distance, ping` — and `Ping`, `Template` and `Distance` are properties of **all ten** alarm models. They meet the exact test that justified preserving `clean`: read by a consumer, exposed by no per-type form, meaningful for every type. `request.Ping` does not exist, so `filters['ping']` is never overridden at apply time.

So changing a pick's type dropped its ping target and template, silently.

**Honest severity:** not reachable in production today. All 30 rows in `quick_pick_definitions` are the built-in presets and none carries any of the four keys; reaching it needs a definition created outside the admin dialog, where filters are stored verbatim. I checked the live database before writing this rather than assuming.

The interesting part is the failure mode. #671 fixed a real loss by naming one key and asserting it was the only one — an assertion I did not verify against a whitelist that already existed in this repo. That is the same shape as everything else this loop has found: a locally correct fix carrying a claim wider than the evidence for it.

## Verification

- 960 frontend tests. The widened spec was **confirmed red** against the one-key set and green after; the sibling test still asserts the departing type's filters are dropped, so #669 stays fixed.