### PR TITLE
fix: the nightly prune was deleting released images, including :latest

### DIFF
--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -61,11 +61,58 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Keep only last 10 develop-<sha> images
-        uses: actions/delete-package-versions@v5
+      # Deliberately github-script rather than actions/delete-package-versions.
+      #
+      # That action's `ignore-versions` matches a package version's NAME, and for container packages the
+      # name is the digest -- never the tag. So the ignore list protected nothing, and
+      # `min-versions-to-keep: 10` deleted every version older than the ten most recent pushes whatever
+      # it was tagged. Twenty merges to develop after a release was enough to take `latest` and the
+      # version tags with it: on 2026-08-09 the registry held `beta` and 28 `develop-<sha>` tags and
+      # nothing else, so every documented `docker compose up` failed to pull for anyone not already
+      # running an image. The v2.13.0 tags had published successfully and were then pruned away.
+      #
+      # A version is deleted only when EVERY tag on it looks like develop-<sha>. A develop push tags one
+      # digest both `beta` and `develop-<sha>`, and a release tags one digest `latest`, `X.Y.Z`, `X.Y`
+      # and `<sha>` -- checking every tag is what keeps those safe.
+      - name: Keep only the last 10 develop-<sha> images
+        uses: actions/github-script@v9
+        env:
+          ORG: ${{ env.ORG }}
+          PACKAGE: ${{ env.PACKAGE }}
+          KEEP: '10'
         with:
-          package-name: poracleweb.net
-          package-type: container
-          owner: pgan-dev
-          min-versions-to-keep: 10
-          ignore-versions: '^(latest|beta|v\\d+\\.\\d+.*|pr-.*)$'
+          script: |
+            const { ORG, PACKAGE } = process.env;
+            const keep = Number(process.env.KEEP);
+
+            const versions = await github.paginate(
+              github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg,
+              { package_type: 'container', package_name: PACKAGE, org: ORG, per_page: 100 },
+            );
+
+            const isDevelopSha = t => /^develop-[0-9a-f]+$/i.test(t);
+            const prunable = versions.filter(v => {
+              const tags = v.metadata?.container?.tags ?? [];
+              return tags.length > 0 && tags.every(isDevelopSha);
+            });
+
+            // Sorted explicitly rather than trusting the API's order. Which images get deleted depends
+            // entirely on this, and an undocumented ordering is not something to bet the registry on.
+            prunable.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const surplus = prunable.slice(keep);
+            console.log(`${versions.length} versions, ${prunable.length} develop-only, deleting ${surplus.length}`);
+
+            for (const v of surplus) {
+              const tags = (v.metadata?.container?.tags ?? []).join(',');
+              try {
+                await github.rest.packages.deletePackageVersionForOrg({
+                  package_type: 'container',
+                  package_name: PACKAGE,
+                  org: ORG,
+                  package_version_id: v.id,
+                });
+                console.log(`Deleted ${tags}`);
+              } catch (e) {
+                console.log(`Skipping ${tags}: ${e.message}`);
+              }
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The nightly image prune no longer deletes released Docker images. `ignore-versions` matches a container version's digest rather than its tags, so it protected nothing and `:latest` and the version tags were swept away a few days after each release — leaving every documented `docker compose up` unable to pull (#677)
 - Changing a quick pick's alarm type no longer drops its ping target, template or distance either (#674)
 - Changing a quick pick's alarm type no longer resets its auto-delete, edit-in-place and summary bits (#671)
 - Creating a profile validates the location and area list before the profile is created, instead of leaving an orphan profile behind a 400 (#665)


### PR DESCRIPTION
**This blocks the release.** I found it while auditing the docs for the release cut: every install instruction points at `ghcr.io/pgan-dev/poracleweb.net:latest`, and that tag does not exist.

Probing GHCR anonymously right now returns 29 tags: `beta` and 28 `develop-<sha>`. No `latest`, no `2.13.0`, no `2.13`. `docker-publish.yml` **did** run successfully on the v2.13.0 release and pushed them; the nightly prune deleted them afterwards. So the documented happy path is broken today for every new installer.

## Cause

`actions/delete-package-versions` matches `ignore-versions` against a package version's **name**, and for container packages the name is the digest — never the tag. The ignore list therefore protected nothing, and `min-versions-to-keep: 10` deleted every version older than the ten most recent pushes regardless of tag. This session alone merged ~20 PRs to `develop`, which is more than enough to have swept the v2.13.0 images away.

The pattern was doubly wrong: it expected `v`-prefixed semver (`v\d+\.\d+`) while `docker/metadata-action`'s `{{version}}` strips the `v`, so `2.13.0` would not have matched even if `ignore-versions` worked on tags.

## Fix

Rewritten as `github-script`, mirroring the `prune-pr-images` job directly above it, which reads `metadata.container.tags` and has always been correct. A version is deleted only when **every** tag on it matches `develop-<sha>`:

- a develop push tags one digest both `beta` and `develop-<sha>` → protected
- a release tags one digest `latest`, `X.Y.Z`, `X.Y` and `<sha>` → protected

Ordering is sorted explicitly on `created_at` rather than assumed from the API, because which images get deleted depends entirely on it.

## Verification

- YAML validates; the filter logic was smoke-tested in node against a synthetic version set containing a `beta` digest, a release digest and 15 develop digests: both protected, 5 surplus develop images selected.
- I could not dry-run against the live versions API — the local `gh` token lacks `read:packages` — so the tag-list evidence above is from an anonymous registry probe. The workflow's own `GITHUB_TOKEN` has `packages: write`.
- The v2.13.0 images are already gone and cannot be recovered; publishing the next release republishes `latest` and the version tags, and this change keeps them.