### PR TITLE
docs: correct how a release actually reaches production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,7 +489,7 @@ JWT token generation is centralized in `IJwtService` / `JwtService` (singleton).
 
 | Branch | Purpose |
 |---|---|
-| `main` | Released code. Only moves when a release is merged. Publishing the release builds `:latest` **and** SSHes to `DEPLOY_HOST` to redeploy prod directly -- not watchtower, and not the merge itself. A plain `git clone` lands here, so self-hosters get released code. |
+| `main` | Released code. Only moves when a release is merged. Publishing the release builds `:latest`, which prod's watchtower auto-deploys within its 60s poll -- the merge itself ships nothing. `docker-publish.yml` also has an SSH deploy step, but it is inert here: it exits early unless `DEPLOY_HOST` and `DEPLOY_SSH_KEY` are set, and this repo has neither. A plain `git clone` lands here, so self-hosters get released code. |
 | `develop` | Integration. **Open pull requests against this.** Publishes `:beta` on every merge, which the dev instance auto-deploys. |
 
 Cutting a release: merge `develop` into `main`, then publish a GitHub release. `release-changelog.yml` opens a PR promoting `[Unreleased]` to the new version section, and `docker-publish.yml` pushes `:latest`.

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -35,13 +35,17 @@ alone ships nothing.
 
 Images go to [`ghcr.io/pgan-dev/poracleweb.net`](https://github.com/PGAN-Dev/PoracleWeb.NET/pkgs/container/poracleweb.net).
 
-!!! warning "Publishing a release also deploys to production"
-    On a `release` event only, the workflow's final step SSHes to the host in the `DEPLOY_HOST` secret and
-    runs `docker compose pull && docker compose up -d --force-recreate`. If `DEPLOY_HOST` or
-    `DEPLOY_SSH_KEY` is unset the step logs and exits 0, so forks are unaffected.
+!!! info "How a release reaches production"
+    Publishing the GitHub release is the moment production changes — merging `develop` into `main` on its
+    own does nothing, because the image build is triggered by the `release` event.
 
-    This is a direct push deploy, not watchtower. Publishing the GitHub release is therefore the moment
-    production changes — merging `develop` into `main` on its own does nothing.
+    Deployment itself is by **watchtower**, which polls `:latest` every 60 seconds. The same applies to
+    the dev instance, which polls `:beta` and therefore updates on every merge to `develop`.
+
+    The workflow does contain an SSH deploy step (`docker compose pull && up -d --force-recreate` against
+    the `DEPLOY_HOST` secret), but it is an **opt-in hook that is inert on this repository**: it exits 0
+    early unless both `DEPLOY_HOST` and `DEPLOY_SSH_KEY` are set, and neither is. Self-hosters who prefer
+    a push deploy to a polling agent can set them.
 
 ## changelog.yml
 


### PR DESCRIPTION
**I got this wrong earlier today and it went into merged docs.**

In #678 I asserted that publishing a release "SSHes to `DEPLOY_HOST` and redeploys production — this is a direct push deploy, not watchtower", and I edited `CLAUDE.md` to contradict its own (correct) note about watchtower.

`gh secret list` returns only `CHANGELOG_APP_ID` and `CHANGELOG_APP_PRIVATE_KEY`. There is no `DEPLOY_HOST` and no `DEPLOY_SSH_KEY`, so that step hits its guard on every release:

```bash
if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_KEY" ]; then
  echo "Deploy secrets not configured, skipping auto-deploy"
  exit 0
fi
```

It has never deployed anything. **Production is deployed by watchtower**, polling `:latest` every 60 seconds — exactly as the note I "corrected" already said.

This is precisely the failure shape documented in `CLAUDE.md` under *Fixing Defects Without Causing Them*: a claim wider than its evidence. I read the workflow, saw an SSH command, and never checked whether the secret it depends on exists. My own memory of this infrastructure said "no `DEPLOY_HOST` secret is configured" and I overrode it with an inference.

## Verified on the hosts

- **prod** — `poraclewebnet-watchtower-1` up and healthy, `WATCHTOWER_SCOPE=poracleweb`, `WATCHTOWER_POLL_INTERVAL=60`, container running `ghcr.io/pgan-dev/poracleweb.net:latest`.
- **dev** — `poracleweb-dev-watchtower` up and healthy, container on `:beta`, `Failed=0` every cycle.

The SSH step is still documented, but as what it is: an opt-in hook, inert here, available to self-hosters who prefer a push deploy over a polling agent.
