### PR TITLE
feat: let deployments set the OAuth callback URL with PUBLIC_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,19 @@ KOJI_PROJECT_NAME=YourProjectName
 # CORS_ORIGIN=http://192.168.1.50:8082
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# PUBLIC URL — the address users reach this instance on
+# ═══════════════════════════════════════════════════════════════════════════════
+# Sets the OAuth callback URLs (Discord and OIDC) outright instead of guessing them
+# from each incoming request. Set this if sign-in fails with an invalid redirect_uri,
+# or just set it anyway — it is the one value your identity provider must also have
+# registered, so stating it here keeps the two in step.
+#
+# Origin only: no trailing path, no query. A bad value stops the app at startup.
+# Leave it blank to keep the old behaviour of following the incoming request, which
+# is correct for a direct-exposed instance or one whose proxy is declared below.
+# PUBLIC_URL=https://poracle.example.com
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # REVERSE PROXY — required if anything sits in front of PoracleWeb.NET
 # ═══════════════════════════════════════════════════════════════════════════════
 # Nginx, Caddy, Traefik, Cloudflare Tunnel and friends terminate TLS themselves and
@@ -161,7 +174,8 @@ KOJI_PROJECT_NAME=YourProjectName
 # Leave both blank only if the app is exposed directly. Behind an undeclared proxy the
 # app sees every request as plain HTTP from the proxy's address, which means all users
 # share one rate-limit bucket AND OAuth callback URLs are built as http:// — Discord
-# and OIDC providers then reject the sign-in with "Invalid redirect_uri".
+# and OIDC providers then reject the sign-in with "Invalid redirect_uri". (PUBLIC_URL
+# above fixes the sign-in on its own; only these settings fix the rate-limit bucket.)
 #
 # Comma-separated. Use the address the proxy connects FROM, as the container sees it.
 # PROXY_KNOWN_PROXIES=10.0.3.20

--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,23 @@ KOJI_PROJECT_NAME=YourProjectName
 # CORS_ORIGIN=http://192.168.1.50:8082
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# REVERSE PROXY — required if anything sits in front of PoracleWeb.NET
+# ═══════════════════════════════════════════════════════════════════════════════
+# Nginx, Caddy, Traefik, Cloudflare Tunnel and friends terminate TLS themselves and
+# announce the original request with X-Forwarded-For and X-Forwarded-Proto. Those
+# headers are only believed from addresses named here — a forgeable header would let
+# any caller hand itself a fresh rate-limit allowance on the sign-in endpoints.
+#
+# Leave both blank only if the app is exposed directly. Behind an undeclared proxy the
+# app sees every request as plain HTTP from the proxy's address, which means all users
+# share one rate-limit bucket AND OAuth callback URLs are built as http:// — Discord
+# and OIDC providers then reject the sign-in with "Invalid redirect_uri".
+#
+# Comma-separated. Use the address the proxy connects FROM, as the container sees it.
+# PROXY_KNOWN_PROXIES=10.0.3.20
+# PROXY_KNOWN_NETWORKS=172.18.0.0/16,10.0.0.0/8
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # PORACLE CONFIG (optional — for DTS template previews)
 # ═══════════════════════════════════════════════════════════════════════════════
 # Mount the PoracleJS config directory so DTS files are auto-loaded

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/DiscordSettings.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/DiscordSettings.cs
@@ -4,7 +4,6 @@ public class DiscordSettings
 {
     public string ClientId { get; set; } = string.Empty;
     public string ClientSecret { get; set; } = string.Empty;
-    public string RedirectUri { get; set; } = string.Empty;
     public string FrontendUrl { get; set; } = "http://localhost:4200";
     public string BotToken { get; set; } = string.Empty;
     public string GuildId { get; set; } = string.Empty;

--- a/Applications/Pgan.PoracleWebNet.Api/Configuration/PublicOrigin.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Configuration/PublicOrigin.cs
@@ -1,0 +1,62 @@
+namespace Pgan.PoracleWebNet.Api.Configuration;
+
+/// <summary>
+/// Normalises the optional <c>PUBLIC_URL</c> setting into a bare origin (<c>scheme://host[:port]</c>).
+///
+/// OAuth providers require the callback URI to be registered in advance and to match byte-for-byte
+/// between the authorize request and the token exchange, so it cannot be safely derived from the
+/// incoming request when the deployment sits behind a proxy that has not been declared -- the scheme
+/// comes back as <c>http</c> and the provider rejects the sign-in. Setting <c>PUBLIC_URL</c> states
+/// the answer outright instead.
+///
+/// Left unset, callers fall back to the request scheme and host, which is the historical behaviour
+/// and remains correct for a directly-exposed instance or one whose proxy is declared via
+/// <c>PROXY_KNOWN_PROXIES</c> / <c>PROXY_KNOWN_NETWORKS</c>.
+/// </summary>
+internal static class PublicOrigin
+{
+    /// <summary>
+    /// Validates a configured public URL. Returns <c>false</c> with a non-null <paramref name="error"/>
+    /// when the value is present but unusable, and <c>false</c> with a null error when simply unset.
+    /// </summary>
+    public static bool TryNormalize(string? configured, out string normalized, out string? error)
+    {
+        normalized = string.Empty;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return false;
+        }
+
+        var trimmed = configured.Trim();
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            error = $"'{trimmed}' is not an absolute URL. Expected something like https://poracle.example.com.";
+            return false;
+        }
+
+        if (uri.Scheme is not ("http" or "https"))
+        {
+            error = $"'{trimmed}' uses the '{uri.Scheme}' scheme. Only http and https are supported.";
+            return false;
+        }
+
+        // A path would silently produce callback URIs like https://host/poracle/api/auth/... which is
+        // never what the app serves, so refuse it rather than emit a URI the provider will reject.
+        if (uri.AbsolutePath.Trim('/').Length > 0 || !string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+        {
+            error = $"'{trimmed}' must be an origin only, with no path, query or fragment " +
+                    $"(e.g. {uri.Scheme}://{uri.Authority}).";
+            return false;
+        }
+
+        normalized = $"{uri.Scheme}://{uri.Authority}";
+        return true;
+    }
+
+    /// <summary>Returns the normalised origin, or null when unset or unusable.</summary>
+    public static string? NormalizeOrNull(string? configured) =>
+        TryNormalize(configured, out var normalized, out _) ? normalized : null;
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -60,7 +60,38 @@ public partial class AuthController(
     private readonly OidcSettings _oidcSettings = oidcSettings.Value;
     private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
     private readonly string[] _allowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+    private readonly string? _publicOrigin = PublicOrigin.NormalizeOrNull(configuration["PublicUrl"]);
     private readonly ILogger<AuthController> _logger = logger;
+
+    /// <summary>
+    /// The origin this instance is reached on. <c>PUBLIC_URL</c> when configured, otherwise the
+    /// request's own scheme and host -- which is only correct when the app is exposed directly or
+    /// its proxy is declared via <c>PROXY_KNOWN_PROXIES</c> / <c>PROXY_KNOWN_NETWORKS</c>.
+    ///
+    /// Every OAuth callback URI is built from this single method so the authorize request and the
+    /// token exchange cannot drift apart -- providers compare the two byte-for-byte.
+    /// </summary>
+    private string SelfOrigin() => this._publicOrigin ?? $"{this.Request.Scheme}://{this.Request.Host}";
+
+    /// <summary>
+    /// Warns when a callback URI is about to go out as http:// while the request carries an
+    /// <c>X-Forwarded-Proto: https</c> that was not trusted. The forwarded-headers middleware strips
+    /// the header once it applies it, so seeing it here means the proxy was not declared -- the
+    /// provider is about to reject the sign-in and this is the only place that can say why.
+    /// </summary>
+    private void WarnIfProxySchemeIgnored(string callbackUri)
+    {
+        if (!callbackUri.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var forwardedProto = this.Request.Headers["X-Forwarded-Proto"].FirstOrDefault();
+        if (string.Equals(forwardedProto, "https", StringComparison.OrdinalIgnoreCase))
+        {
+            LogProxySchemeIgnored(this._logger, callbackUri);
+        }
+    }
 
     [AllowAnonymous]
     [HttpGet("discord/login")]
@@ -85,7 +116,7 @@ public partial class AuthController(
 
         // Save the frontend origin so we know where to redirect after the callback.
         // Validate against configured CORS origins to prevent open redirect token theft.
-        var selfOrigin = $"{this.Request.Scheme}://{this.Request.Host}";
+        var selfOrigin = this.SelfOrigin();
         var origin = selfOrigin;
 
         var referer = this.Request.Headers.Referer.FirstOrDefault();
@@ -103,7 +134,8 @@ public partial class AuthController(
         this.Response.Cookies.Append("oauth_origin", origin, cookieOptions);
 
         // Redirect URI points to the API itself, not the Angular app
-        var callbackUri = $"{this.Request.Scheme}://{this.Request.Host}/api/auth/discord/callback";
+        var callbackUri = $"{selfOrigin}/api/auth/discord/callback";
+        this.WarnIfProxySchemeIgnored(callbackUri);
         var redirectUrl = "https://discordapp.com/api/oauth2/authorize" +
             $"?client_id={this._discordSettings.ClientId}" +
             $"&redirect_uri={Uri.EscapeDataString(callbackUri)}" +
@@ -147,7 +179,8 @@ public partial class AuthController(
             ["client_secret"] = this._discordSettings.ClientSecret,
             ["grant_type"] = "authorization_code",
             ["code"] = code,
-            ["redirect_uri"] = $"{this.Request.Scheme}://{this.Request.Host}/api/auth/discord/callback"
+            // Must match the authorize request byte-for-byte -- both go through SelfOrigin().
+            ["redirect_uri"] = $"{this.SelfOrigin()}/api/auth/discord/callback"
         });
 
         var tokenResponse = await httpClient.PostAsync("https://discordapp.com/api/oauth2/token", tokenRequest);
@@ -263,7 +296,7 @@ public partial class AuthController(
 
         // Save the frontend origin (validated against CORS origins) so the callback knows
         // where to redirect — identical handling to DiscordLogin.
-        var selfOrigin = $"{this.Request.Scheme}://{this.Request.Host}";
+        var selfOrigin = this.SelfOrigin();
         var origin = selfOrigin;
 
         var referer = this.Request.Headers.Referer.FirstOrDefault();
@@ -280,7 +313,8 @@ public partial class AuthController(
 
         this.Response.Cookies.Append("oauth_origin", origin, cookieOptions);
 
-        var callbackUri = $"{this.Request.Scheme}://{this.Request.Host}/api/auth/oidc/callback";
+        var callbackUri = $"{selfOrigin}/api/auth/oidc/callback";
+        this.WarnIfProxySchemeIgnored(callbackUri);
 
         var query = new Dictionary<string, string?>
         {
@@ -311,7 +345,7 @@ public partial class AuthController(
         // OIDC RP-initiated (single) logout: bounce the browser to the provider's end-session
         // endpoint so it can clear its OWN session too, then return to the signed-out landing.
         // The frontend has already discarded the local JWT before calling this.
-        var selfOrigin = $"{this.Request.Scheme}://{this.Request.Host}";
+        var selfOrigin = this.SelfOrigin();
         var origin = selfOrigin;
 
         // Validate the return origin the same way the login flow validates oauth_origin.
@@ -380,7 +414,8 @@ public partial class AuthController(
         }
 
         // Exchange the authorization code for tokens via the generic, provider-agnostic OIDC client.
-        var redirectUri = $"{this.Request.Scheme}://{this.Request.Host}/api/auth/oidc/callback";
+        // Must match the authorize request byte-for-byte -- both go through SelfOrigin().
+        var redirectUri = $"{this.SelfOrigin()}/api/auth/oidc/callback";
         var tokenResult = await this._oidcClient.ExchangeCodeAsync(code, redirectUri, pkceVerifier);
         if (tokenResult is null)
         {
@@ -1050,8 +1085,8 @@ public partial class AuthController(
             return savedOrigin.TrimEnd('/');
         }
 
-        // Fallback: same scheme/host as the request
-        return $"{this.Request.Scheme}://{this.Request.Host}";
+        // Fallback: the configured public origin, or the request's own scheme and host
+        return this.SelfOrigin();
     }
 
     /// <summary>
@@ -1221,6 +1256,15 @@ public partial class AuthController(
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Role check failed for {UserId}, denying access.")]
     private static partial void LogRoleCheckFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "OAuth callback URI was built as '{CallbackUri}', but this request arrived with " +
+                  "X-Forwarded-Proto: https from a proxy that is not declared, so the header was ignored. " +
+                  "The provider will reject this sign-in as an invalid redirect_uri. Fix it by setting " +
+                  "PROXY_KNOWN_PROXIES / PROXY_KNOWN_NETWORKS to your proxy's address, or PUBLIC_URL to " +
+                  "the URL users reach this instance on.")]
+    private static partial void LogProxySchemeIgnored(ILogger logger, string callbackUri);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Discord token exchange failed: {Status} {Body}")]
     private static partial void LogDiscordTokenExchangeFailed(ILogger logger, System.Net.HttpStatusCode status, string body);

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -98,6 +98,7 @@ MapEnvVar("KOJI_PROJECT_NAME", "Koji__ProjectName");
 MapEnvVar("GOLBAT_API_ADDRESS", "Golbat__ApiAddress");
 MapEnvVar("GOLBAT_API_SECRET", "Golbat__ApiSecret");
 MapEnvVar("CORS_ORIGIN", "Cors__AllowedOrigins__0");
+MapEnvVar("PUBLIC_URL", "PublicUrl");
 MapEnvVar("SCANNER_DB_CONNECTION", "ConnectionStrings__ScannerDb");
 
 // Auto-compose MySQL connection strings from short env vars (DB_HOST, DB_PORT, etc.)
@@ -296,6 +297,15 @@ if (allowedOrigins is not { Length: > 0 } && !builder.Environment.IsDevelopment(
     throw new InvalidOperationException(
         "Configuration 'Cors:AllowedOrigins' is required in non-development environments. " +
         "Set it to the origin(s) of your frontend (e.g., [\"https://poracle.example.com\"]).");
+}
+
+// PUBLIC_URL is optional, but a typo in it produces OAuth callback URIs the provider rejects with a
+// message that says nothing about this setting. Fail at startup instead, where the cause is obvious.
+var configuredPublicUrl = builder.Configuration["PublicUrl"];
+if (!Pgan.PoracleWebNet.Api.Configuration.PublicOrigin.TryNormalize(configuredPublicUrl, out _, out var publicUrlError)
+    && publicUrlError is not null)
+{
+    throw new InvalidOperationException($"Configuration 'PUBLIC_URL' is invalid: {publicUrlError}");
 }
 
 builder.Services.AddCors(options => options.AddDefaultPolicy(policy =>

--- a/Applications/Pgan.PoracleWebNet.Api/appsettings.json
+++ b/Applications/Pgan.PoracleWebNet.Api/appsettings.json
@@ -22,7 +22,6 @@
   "Discord": {
     "ClientId": "",
     "ClientSecret": "",
-    "RedirectUri": "",
     "BotToken": "",
     "GuildId": "",
     "GeofenceForumChannelId": ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Upgrading to 2.14.0 could break sign-in behind a reverse proxy.** The proxy-trust fix in that release ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)) stopped believing `X-Forwarded-Proto` from undeclared proxies, so instances that had not set `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` began building OAuth callback URLs as `http://` and Discord rejected the sign-in with an invalid `redirect_uri`. Both variables are now documented in `.env.example`, the configuration reference, the reverse-proxy setup guide, and troubleshooting. No code change — if you are affected, declare your proxy and recreate the container.
+
 ## [2.14.0] - 2026-08-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`PUBLIC_URL` sets the sign-in callback address directly.** OAuth callback URLs were only ever derived from the incoming request, so the sole way to influence them was to declare your reverse proxy — an indirect lever for something you would rather just state. Setting `PUBLIC_URL=https://poracle.example.com` names the origin outright for both Discord and OIDC. Optional: leave it unset and behaviour is unchanged, which stays correct for a directly-exposed instance, for a declared proxy, and for anyone reaching the instance on several hostnames. An unusable value stops the app at startup instead of producing a callback the provider silently refuses.
-- A sign-in that is about to fail this way now says so in the log, naming both fixes, rather than leaving the provider's "invalid redirect_uri" as the only symptom.
+- **`PUBLIC_URL` sets the sign-in callback address directly.** OAuth callback URLs were only ever derived from the incoming request, so the sole way to influence them was to declare your reverse proxy — an indirect lever for something you would rather just state. Setting `PUBLIC_URL=https://poracle.example.com` names the origin outright for both Discord and OIDC. Optional: leave it unset and behaviour is unchanged, which stays correct for a directly-exposed instance, for a declared proxy, and for anyone reaching the instance on several hostnames. An unusable value stops the app at startup instead of producing a callback the provider silently refuses ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
+- A sign-in that is about to fail this way now says so in the log, naming both fixes, rather than leaving the provider's "invalid redirect_uri" as the only symptom ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
 
 ### Removed
 
-- `Discord:RedirectUri` — the setting was read by nothing and had been dead since the callback URL became request-derived. Anyone who had set it was getting silence; `PUBLIC_URL` is the working replacement and covers OIDC too.
+- `Discord:RedirectUri` — the setting was read by nothing and had been dead since the callback URL became request-derived. Anyone who had set it was getting silence; `PUBLIC_URL` is the working replacement and covers OIDC too ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
 
 ### Fixed
 
-- **Upgrading to 2.14.0 could break sign-in behind a reverse proxy.** The proxy-trust fix in that release ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)) stopped believing `X-Forwarded-Proto` from undeclared proxies, so instances that had not set `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` began building OAuth callback URLs as `http://` and Discord rejected the sign-in with an invalid `redirect_uri`. Both variables are now documented in `.env.example`, the configuration reference, the reverse-proxy setup guide, and troubleshooting. No code change — if you are affected, declare your proxy and recreate the container.
+- **Upgrading to 2.14.0 could break sign-in behind a reverse proxy.** The proxy-trust fix in that release ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)) stopped believing `X-Forwarded-Proto` from undeclared proxies, so instances that had not set `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` began building OAuth callback URLs as `http://` and Discord rejected the sign-in with an invalid `redirect_uri`. Both variables are now documented in `.env.example`, the configuration reference, the reverse-proxy setup guide, and troubleshooting. If you are affected, declare your proxy and recreate the container ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
 
 ## [2.14.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`PUBLIC_URL` sets the sign-in callback address directly.** OAuth callback URLs were only ever derived from the incoming request, so the sole way to influence them was to declare your reverse proxy — an indirect lever for something you would rather just state. Setting `PUBLIC_URL=https://poracle.example.com` names the origin outright for both Discord and OIDC. Optional: leave it unset and behaviour is unchanged, which stays correct for a directly-exposed instance, for a declared proxy, and for anyone reaching the instance on several hostnames. An unusable value stops the app at startup instead of producing a callback the provider silently refuses.
+- A sign-in that is about to fail this way now says so in the log, naming both fixes, rather than leaving the provider's "invalid redirect_uri" as the only symptom.
+
+### Removed
+
+- `Discord:RedirectUri` — the setting was read by nothing and had been dead since the callback URL became request-derived. Anyone who had set it was getting silence; `PUBLIC_URL` is the working replacement and covers OIDC too.
+
 ### Fixed
 
 - **Upgrading to 2.14.0 could break sign-in behind a reverse proxy.** The proxy-trust fix in that release ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)) stopped believing `X-Forwarded-Proto` from undeclared proxies, so instances that had not set `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` began building OAuth callback URLs as `http://` and Discord rejected the sign-in with an invalid `redirect_uri`. Both variables are now documented in `.env.example`, the configuration reference, the reverse-proxy setup guide, and troubleshooting. No code change — if you are affected, declare your proxy and recreate the container.

--- a/Tests/Pgan.PoracleWebNet.Tests/Configuration/PublicOriginTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Configuration/PublicOriginTests.cs
@@ -1,0 +1,56 @@
+using Pgan.PoracleWebNet.Api.Configuration;
+
+namespace Pgan.PoracleWebNet.Tests.Configuration;
+
+/// <summary>
+/// PUBLIC_URL is validated at startup so a typo surfaces there rather than as an OAuth provider
+/// rejecting a malformed redirect_uri, which names neither the setting nor the mistake.
+/// </summary>
+public class PublicOriginTests
+{
+    [Theory]
+    [InlineData("https://poracle.example.com", "https://poracle.example.com")]
+    [InlineData("http://192.168.1.50:8082", "http://192.168.1.50:8082")]
+    [InlineData("https://poracle.example.com/", "https://poracle.example.com")]
+    [InlineData("  https://poracle.example.com  ", "https://poracle.example.com")]
+    [InlineData("https://poracle.example.com:8443", "https://poracle.example.com:8443")]
+    public void AcceptsAnOriginAndStripsTheTrailingSlash(string configured, string expected)
+    {
+        Assert.True(PublicOrigin.TryNormalize(configured, out var normalized, out var error));
+        Assert.Equal(expected, normalized);
+        Assert.Null(error);
+    }
+
+    /// <summary>Unset is the documented default, not an error -- callers fall back to the request.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TreatsUnsetAsAbsentRatherThanInvalid(string? configured)
+    {
+        Assert.False(PublicOrigin.TryNormalize(configured, out var normalized, out var error));
+        Assert.Equal(string.Empty, normalized);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("poracle.example.com")]                      // no scheme
+    [InlineData("ftp://poracle.example.com")]                // wrong scheme
+    [InlineData("https://poracle.example.com/poracle")]      // path
+    [InlineData("https://poracle.example.com/?a=b")]         // query
+    [InlineData("https://poracle.example.com/#frag")]        // fragment
+    [InlineData("not a url at all")]
+    public void RejectsValuesThatWouldProduceABrokenCallbackUri(string configured)
+    {
+        Assert.False(PublicOrigin.TryNormalize(configured, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void NormalizeOrNullReturnsNullForBothUnsetAndInvalid()
+    {
+        Assert.Null(PublicOrigin.NormalizeOrNull(null));
+        Assert.Null(PublicOrigin.NormalizeOrNull("https://example.com/with/path"));
+        Assert.Equal("https://example.com", PublicOrigin.NormalizeOrNull("https://example.com"));
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerProvidersTests.cs
@@ -463,4 +463,113 @@ public class AuthControllerProvidersTests : ControllerTestBase
         var doc = JsonDocument.Parse(JsonSerializer.Serialize(ok.Value));
         Assert.False(doc.RootElement.GetProperty("oidc").GetProperty("endSession").GetBoolean());
     }
+
+    // ── PUBLIC_URL and OAuth callback construction ────────────────────────────────────────────
+    //
+    // Behind a proxy that has not been declared via PROXY_KNOWN_*, X-Forwarded-Proto is discarded
+    // and Request.Scheme reads "http" on an HTTPS site, so the callback URI goes out as http:// and
+    // the provider refuses it. PUBLIC_URL states the origin outright. The pairs below cover both
+    // directions: the override works, AND leaving it unset still follows the request.
+
+    private static Microsoft.AspNetCore.Http.DefaultHttpContext ProxiedHttpContext()
+    {
+        // What an undeclared reverse proxy produces: TLS terminated at the edge, plain http here.
+        var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new Microsoft.AspNetCore.Http.HostString("alerts.example.com");
+        return httpContext;
+    }
+
+    [Fact]
+    public async Task DiscordLoginUsesPublicUrlForTheCallbackWhenConfigured()
+    {
+        var controller = this.CreateController(config: ConfigWith("PublicUrl", "https://alerts.example.com"));
+        controller.ControllerContext = new ControllerContext { HttpContext = ProxiedHttpContext() };
+
+        var result = await controller.DiscordLogin();
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains(
+            "redirect_uri=" + Uri.EscapeDataString("https://alerts.example.com/api/auth/discord/callback"),
+            redirect.Url,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DiscordLoginFollowsTheRequestWhenPublicUrlIsUnset()
+    {
+        // The historical behaviour, and still correct for a direct-exposed instance or a declared
+        // proxy. A regression here would break every install that does not set PUBLIC_URL.
+        var controller = this.CreateController();
+        var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new Microsoft.AspNetCore.Http.HostString("direct.example.com:8082");
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var result = await controller.DiscordLogin();
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains(
+            "redirect_uri=" + Uri.EscapeDataString("https://direct.example.com:8082/api/auth/discord/callback"),
+            redirect.Url,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OidcLoginUsesPublicUrlForTheCallbackWhenConfigured()
+    {
+        var controller = this.CreateController(
+            oidc: FullyConfiguredOidc(),
+            config: ConfigWith("PublicUrl", "https://alerts.example.com"));
+        controller.ControllerContext = new ControllerContext { HttpContext = ProxiedHttpContext() };
+
+        var result = controller.OidcLogin();
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains(
+            "redirect_uri=" + Uri.EscapeDataString("https://alerts.example.com/api/auth/oidc/callback"),
+            redirect.Url,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OidcLoginFollowsTheRequestWhenPublicUrlIsUnset()
+    {
+        var controller = this.CreateController(oidc: FullyConfiguredOidc());
+        var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new Microsoft.AspNetCore.Http.HostString("direct.example.com:8082");
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var result = controller.OidcLogin();
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains(
+            "redirect_uri=" + Uri.EscapeDataString("https://direct.example.com:8082/api/auth/oidc/callback"),
+            redirect.Url,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A malformed PUBLIC_URL must not silently fall back to the request -- that would reintroduce
+    /// the exact http:// callback the setting exists to prevent, with no sign anything was wrong.
+    /// Startup rejects it (see PublicOriginTests); the controller ignores it if it ever gets through.
+    /// </summary>
+    [Fact]
+    public async Task DiscordLoginIgnoresAnUnusablePublicUrl()
+    {
+        var controller = this.CreateController(config: ConfigWith("PublicUrl", "not a url"));
+        var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new Microsoft.AspNetCore.Http.HostString("direct.example.com");
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var result = await controller.DiscordLogin();
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains(
+            "redirect_uri=" + Uri.EscapeDataString("https://direct.example.com/api/auth/discord/callback"),
+            redirect.Url,
+            StringComparison.Ordinal);
+    }
 }

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -111,6 +111,12 @@ Required for the custom geofences feature.
 |---|---|---|---|
 | CORS Origin | `CORS_ORIGIN` | `Cors__AllowedOrigins__0` | Allowed CORS origin. Required in production (empty = crash). Not required in development mode. |
 
+### Public URL
+
+| Setting | `.env` name | `.NET` env variable | Description |
+|---|---|---|---|
+| Public URL | `PUBLIC_URL` | `PublicUrl` | The origin users reach this instance on (e.g. `https://poracle.example.com`). Sets the Discord and OIDC callback URLs directly instead of deriving them from each request. Origin only — a path, query or invalid URL stops the app at startup. Optional; unset follows the incoming request. |
+
 ### Reverse proxy
 
 Required if anything terminates TLS in front of PoracleWeb.NET. See [Behind a reverse proxy](../getting-started/standalone-setup.md#reverse-proxy-optional).

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -111,6 +111,15 @@ Required for the custom geofences feature.
 |---|---|---|---|
 | CORS Origin | `CORS_ORIGIN` | `Cors__AllowedOrigins__0` | Allowed CORS origin. Required in production (empty = crash). Not required in development mode. |
 
+### Reverse proxy
+
+Required if anything terminates TLS in front of PoracleWeb.NET. See [Behind a reverse proxy](../getting-started/standalone-setup.md#reverse-proxy-optional).
+
+| Setting | `.env` name | `.NET` env variable | Description |
+|---|---|---|---|
+| Known proxies | `PROXY_KNOWN_PROXIES` | `Proxy__KnownProxies` | Comma-separated proxy addresses whose `X-Forwarded-For` / `X-Forwarded-Proto` are believed |
+| Known networks | `PROXY_KNOWN_NETWORKS` | `Proxy__KnownNetworks` | Comma-separated CIDR ranges, same effect (e.g. `172.18.0.0/16,10.0.0.0/8`) |
+
 ## Configuration sources
 
 | Source | Use case |

--- a/docs/getting-started/standalone-setup.md
+++ b/docs/getting-started/standalone-setup.md
@@ -250,6 +250,16 @@ If you want to put PoracleWeb.NET behind nginx or Caddy (just like you might wit
 
 When using a reverse proxy, set `CORS_ORIGIN=https://poracle.example.com` in your `.env` (replacing any `http://localhost:...` value you already have) and update your Discord OAuth2 redirect URI to match the public URL.
 
+You also have to tell the app which proxy to believe. `X-Forwarded-For` and `X-Forwarded-Proto` are only honoured from declared addresses, because a header believed from anyone lets a caller name a different address on each request and hand itself a fresh rate-limit allowance on the sign-in endpoints:
+
+```bash
+# One or both. Comma-separated. Use the address the proxy connects FROM.
+PROXY_KNOWN_PROXIES=127.0.0.1
+PROXY_KNOWN_NETWORKS=172.18.0.0/16
+```
+
+Leave both unset and the app falls back to the connection address, which is safe but wrong in two visible ways: every user behind the proxy shares one rate-limit bucket, and OAuth callback URLs are built from the scheme the app *received* — `http://` — so Discord and OIDC providers reject the sign-in with an invalid `redirect_uri`.
+
 ## Troubleshooting
 
 **"Configuration 'ConnectionStrings:PoracleDb' is required"**

--- a/docs/getting-started/standalone-setup.md
+++ b/docs/getting-started/standalone-setup.md
@@ -260,6 +260,14 @@ PROXY_KNOWN_NETWORKS=172.18.0.0/16
 
 Leave both unset and the app falls back to the connection address, which is safe but wrong in two visible ways: every user behind the proxy shares one rate-limit bucket, and OAuth callback URLs are built from the scheme the app *received* — `http://` — so Discord and OIDC providers reject the sign-in with an invalid `redirect_uri`.
 
+For the sign-in half of that you can skip the inference entirely and name the URL:
+
+```bash
+PUBLIC_URL=https://poracle.example.com
+```
+
+`PUBLIC_URL` is the origin users type in, and the one you register with Discord or your OIDC provider. It must be an origin only — no trailing path — and an unusable value stops the app at startup rather than producing a callback the provider silently refuses. Set it if you have a single public address; leave it unset if people reach the instance on several hostnames and you want the callback to follow whichever one they used.
+
 ## Troubleshooting
 
 **"Configuration 'ConnectionStrings:PoracleDb' is required"**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,15 @@
 
 **Problem**: Clicking sign in sends you to Discord (or your OIDC provider) and it refuses with an invalid `redirect_uri`. Inspecting the URL shows the callback as `http://your-host/api/auth/discord/callback` even though the site is served over HTTPS.
 
-**Solution**: You are behind a reverse proxy that PoracleWeb.NET has not been told to trust, so its `X-Forwarded-Proto: https` is discarded and the callback URL is built from the plain HTTP request the app actually received. Declare the proxy in `.env`:
+**Solution**: You are behind a reverse proxy that PoracleWeb.NET has not been told to trust, so its `X-Forwarded-Proto: https` is discarded and the callback URL is built from the plain HTTP request the app actually received. The app logs a warning naming this when it happens — check the container logs to confirm.
+
+The direct fix is to state the URL rather than let the app infer it:
+
+```env
+PUBLIC_URL=https://poracle.example.com
+```
+
+Also declare the proxy, which fixes the same problem at the source and additionally stops everyone behind it sharing a single rate-limit bucket:
 
 ```env
 PROXY_KNOWN_NETWORKS=172.18.0.0/16,10.0.0.0/8

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,28 @@
 # Troubleshooting
 
+## Sign-in fails with "Invalid OAuth2 redirect_uri"
+
+**Problem**: Clicking sign in sends you to Discord (or your OIDC provider) and it refuses with an invalid `redirect_uri`. Inspecting the URL shows the callback as `http://your-host/api/auth/discord/callback` even though the site is served over HTTPS.
+
+**Solution**: You are behind a reverse proxy that PoracleWeb.NET has not been told to trust, so its `X-Forwarded-Proto: https` is discarded and the callback URL is built from the plain HTTP request the app actually received. Declare the proxy in `.env`:
+
+```env
+PROXY_KNOWN_NETWORKS=172.18.0.0/16,10.0.0.0/8
+# or, for a single address:
+# PROXY_KNOWN_PROXIES=127.0.0.1
+```
+
+Use the address the proxy connects **from**, as the container sees it. Then recreate the container: `docker compose up -d --force-recreate`.
+
+Two things to check if it still comes back as `http://`:
+
+- Your `docker-compose.yml` must actually pass the variable through. The shipped example uses `env_file: - .env`, which covers everything; a hand-edited file with an explicit `environment:` list needs `PROXY_KNOWN_PROXIES` and `PROXY_KNOWN_NETWORKS` added to it. Confirm with `docker inspect <container> --format '{{range .Config.Env}}{{println .}}{{end}}' | grep PROXY`.
+- Your proxy must send `X-Forwarded-Proto`. Nginx needs `proxy_set_header X-Forwarded-Proto $scheme;` explicitly; Caddy and Cloudflare Tunnel send it by default.
+
+The same misconfiguration also puts every user behind the proxy into a single rate-limit bucket. See [Behind a reverse proxy](getting-started/standalone-setup.md#reverse-proxy-optional).
+
+---
+
 ## Container exits on startup: `Configuration 'Cors:AllowedOrigins' is required`
 
 **Problem**: The container crash-loops on start. Logs show `System.InvalidOperationException: Configuration 'Cors:AllowedOrigins' is required in non-development environments.`


### PR DESCRIPTION
## Problem

Prod could not sign in this morning: Discord refused with `Invalid OAuth2 redirect_uri`, and the authorize URL carried `http://alerts.pogoalerts.net/api/auth/discord/callback` on an HTTPS site.

#583 (in 2.14.0) stopped honouring `X-Forwarded-For`/`X-Forwarded-Proto` from undeclared proxies. Right call for the rate-limit bypass it fixed, but nobody enumerated who depended on the loose rule: `AuthController` builds every OAuth callback from `Request.Scheme`, so behind an undeclared proxy the scheme silently became `http` and sign-in broke outright.

Underneath that is a design gap. There was no way to just *say* what the callback URL is — the only lever was proxy trust, which is an indirect route to a value the identity provider makes you register anyway. `DiscordSettings.RedirectUri` looks like that setting but is read by nothing; it has been dead since the URL became request-derived, so anyone setting it got silence.

## Change

`PUBLIC_URL=https://poracle.example.com` names the origin outright. It feeds a single `SelfOrigin()` helper used by both callback sites per provider, so the authorize request and the token exchange can't drift apart — providers compare them byte-for-byte.

**Unset behaviour is byte-identical to today**, so no existing install can regress.

Also: startup rejects an unusable value (path, wrong scheme, not a URL) instead of emitting a callback the provider refuses without explanation; and `Discord:RedirectUri` is removed from the settings class and `appsettings.json`.

## Two things deliberately not done

**No derivation from `CORS_ORIGIN`.** Tempting — production already requires it and it is normally the public URL. But `environment.ts` sets `apiUrl: ''`, so the SPA calls the API same-origin and CORS never applies in the shipped deployment. `Program.cs` requires the value to be *present*, never checks that it is *right*, and no browser ever exercises it. Deriving the callback from it would turn a currently-invisible misconfiguration into a hard login failure — e.g. a LAN `http://192.168.1.50:8082` plus a public `https://poracle.example.com`, both registered with Discord, works today because the callback follows the request host. That is the same shape as the regression this PR is fixing.

**The cookie `Secure` flag still follows the actual request.** Forcing it from an `https` `PUBLIC_URL` would have the browser drop `oauth_state` for anyone on plain http over a LAN, breaking their login with no clue why. Today's `Secure=false` degrades safely, and proxy trust fixes it properly.

## Making the failure self-explanatory

When a callback is about to go out as `http://` *and* the request carries an `X-Forwarded-Proto: https` that was ignored, the app logs a warning naming both fixes. No false positives — the forwarded-headers middleware strips that header once it trusts it, so its presence here proves the proxy was not declared.

## Docs

`PROXY_KNOWN_PROXIES`/`PROXY_KNOWN_NETWORKS` existed since #596 but appeared in no example file, guide or reference — only a Program.cs comment and one changelog line. Both they and `PUBLIC_URL` are now in `.env.example`, the configuration reference, the reverse-proxy setup section, and a troubleshooting entry titled with the exact Discord error.

## Tests

`PublicOriginTests` covers normalisation and each rejection. In `AuthControllerProvidersTests`, each provider gets a **pair**: the override works, and unset still follows the request. Verified the pairs discriminate — with the controller change stashed, the two override tests fail and the two request-following tests still pass, so the latter are genuinely guarding the old behaviour rather than restating the new code. Full suite: 1852 passing.

## Verification on prod

Declared the proxy network and recreated the container; `GET /api/auth/discord/login` now returns `redirect_uri=https%3A%2F%2Falerts.pogoalerts.net%2F...`. Login restored. Prod's compose predates `env_file: - .env` and uses an explicit `environment:` list, so the variable had to be added there too — the troubleshooting entry calls that case out.

Fixes #689
