### PR TITLE
ci: point Dependabot at develop instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   # .NET (backend)
   - package-ecosystem: nuget
     directory: /
+    # main only moves when a release is merged (see CLAUDE.md), so bumps land on
+    # develop first and reach released code with the release that carries them.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -46,6 +49,9 @@ updates:
   # Angular frontend
   - package-ecosystem: npm
     directory: /Applications/Pgan.PoracleWebNet.App/ClientApp
+    # main only moves when a release is merged (see CLAUDE.md), so bumps land on
+    # develop first and reach released code with the release that carries them.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -101,6 +107,9 @@ updates:
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /
+    # main only moves when a release is merged (see CLAUDE.md), so bumps land on
+    # develop first and reach released code with the release that carries them.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -116,6 +125,9 @@ updates:
   # Dockerfile base images
   - package-ecosystem: docker
     directory: /
+    # main only moves when a release is merged (see CLAUDE.md), so bumps land on
+    # develop first and reach released code with the release that carries them.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dependabot now opens its pull requests against `develop` rather than `main`. With no `target-branch` set it defaulted to the repository's default branch, so dependency bumps landed directly on released code without ever being built as `:beta` or running on the dev instance — contradicting the documented rule that `main` only moves when a release is merged. It also put every bump through the merge queue that exists only on `main`.
 - **Upgrading to 2.14.0 could break sign-in behind a reverse proxy.** The proxy-trust fix in that release ([#583](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/583)) stopped believing `X-Forwarded-Proto` from undeclared proxies, so instances that had not set `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` began building OAuth callback URLs as `http://` and Discord rejected the sign-in with an invalid `redirect_uri`. Both variables are now documented in `.env.example`, the configuration reference, the reverse-proxy setup guide, and troubleshooting. If you are affected, declare your proxy and recreate the container ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
 
 ## [2.14.0] - 2026-08-09


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` sets no `target-branch` on any of its four ecosystems (nuget, npm, github-actions, docker), so all of them fall back to the repository's default branch — `main`.

That contradicts the branching model in CLAUDE.md:

> `main` — Released code. Only moves when a release is merged.

Every dependency bump has been landing directly on released code without being built as `:beta`, without running on the dev instance, and without appearing in `develop` first.

It has already drifted: `7366906` (jsdom) is on `main` and not on `develop`.

There is a second effect. The merge queue (ruleset 20426419) exists only on `main`; `develop` has none. So every Dependabot PR is routed through a queue it does not need — which is where #683 and #686 are stuck right now, both approved with all required checks green and neither ever entering the queue.

## Change

`target-branch: develop` on all four ecosystems, with a comment recording why.

## Follow-up (not in this PR)

- #683–#686 to be closed so Dependabot reopens them against `develop` on its next run.
- `main` merged back into `develop` to recover the jsdom bump.