### PR TITLE
docs: say where the OAuth callback URL comes from in the setup guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`PUBLIC_URL` sets the sign-in callback address directly.** OAuth callback URLs were only ever derived from the incoming request, so the sole way to influence them was to declare your reverse proxy — an indirect lever for something you would rather just state. Setting `PUBLIC_URL=https://poracle.example.com` names the origin outright for both Discord and OIDC. Optional: leave it unset and behaviour is unchanged, which stays correct for a directly-exposed instance, for a declared proxy, and for anyone reaching the instance on several hostnames. An unusable value stops the app at startup instead of producing a callback the provider silently refuses ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
 - A sign-in that is about to fail this way now says so in the log, naming both fixes, rather than leaving the provider's "invalid redirect_uri" as the only symptom ([#689](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/689)).
+- The Discord OAuth2 and external SSO setup guides now say where the callback URL comes from and when to pin it with `PUBLIC_URL`, instead of describing it as always derived from the request.
 
 ### Removed
 

--- a/docs/configuration/external-sso.md
+++ b/docs/configuration/external-sso.md
@@ -55,7 +55,9 @@ sequenceDiagram
 - **PKCE**: when `OIDC_USE_PKCE=true` (default), a code verifier is stored in an `HttpOnly`
   cookie and only the S256 challenge is sent to the provider.
 - **Redirect URI**: PoracleWeb always uses `{your-host}/api/auth/oidc/callback`. Register exactly
-  this URI at your provider.
+  this URI at your provider. `{your-host}` comes from the incoming request unless `PUBLIC_URL` is
+  set, in which case it is that value — worth setting behind a reverse proxy, where the app
+  otherwise sees plain HTTP and sends an `http://` redirect URI the provider will refuse.
 - **Identity resolution**: the configured identity claim (falling back to `sub`) is looked up
   against the Poracle `human` table. The provider authenticates; Poracle authorizes.
 - **JWT type claim**: successful logins mint PoracleWeb's internal JWT with the `type` claim set

--- a/docs/getting-started/discord-oauth.md
+++ b/docs/getting-started/discord-oauth.md
@@ -14,10 +14,18 @@ PoracleWeb.NET uses Discord OAuth2 for user authentication. This page walks thro
     | Development | `http://localhost:4200/api/auth/discord/callback` |
 
     The redirect URI must match the origin **the browser is on**, because `AuthController` builds the
-    callback from the incoming `Host` header. In production the API and the SPA share an origin, so this
+    callback from the incoming request. In production the API and the SPA share an origin, so this
     is simply your domain. In development the browser is on the Angular dev server (4200) and
     `proxy.conf.json` sets `changeOrigin: false`, so the `Host` stays `localhost:4200` — register that,
     not the API's 5048. If you serve the dev app on another port, register that port instead.
+
+    !!! tip "Behind a reverse proxy, set `PUBLIC_URL`"
+        Deriving the callback from the request goes wrong when TLS is terminated in front of the app:
+        it sees plain HTTP and builds an `http://` callback that Discord rejects as unregistered.
+        Setting `PUBLIC_URL=https://poracle.example.com` in `.env` pins the callback to exactly what
+        you registered here, whatever the request looks like. Declaring the proxy with
+        `PROXY_KNOWN_PROXIES` / `PROXY_KNOWN_NETWORKS` fixes the same thing at source and additionally
+        keeps rate limits per-user — see [Behind a reverse proxy](standalone-setup.md#reverse-proxy-optional).
 
 4. Copy the **Client ID** and **Client Secret**
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -216,4 +216,4 @@ The app will now be available at `http://your-server:9090`. Remember to update y
 : `PORACLE_API_ADDRESS` must be reachable from inside the container. If Poracle runs on the host, use `http://host.docker.internal:3030`. If it's on another machine, use that machine's IP.
 
 **Discord login fails**
-: The redirect URI in your Discord app must match exactly: `http://your-server:PORT/api/auth/discord/callback`. Check both the port and the hostname/IP.
+: The redirect URI in your Discord app must match exactly: `http://your-server:PORT/api/auth/discord/callback`. Check both the port and the hostname/IP. If you serve the site over HTTPS through a reverse proxy and Discord reports the callback as `http://`, set `PUBLIC_URL` — see [the troubleshooting entry](../troubleshooting.md#sign-in-fails-with-invalid-oauth2-redirect_uri).


### PR DESCRIPTION
Pre-release docs pass for the `PUBLIC_URL` change.

`docs/getting-started/discord-oauth.md` and `docs/configuration/external-sso.md` are where you register the redirect URI with the provider, and both described it as always derived from the incoming request. That is now only true when `PUBLIC_URL` is unset, and the request-derived case is exactly what breaks behind a TLS-terminating proxy.

- **discord-oauth.md** — admonition on the redirect-URI step: pin it with `PUBLIC_URL`, or declare the proxy, with a link to the reverse-proxy section.
- **external-sso.md** — the Redirect URI bullet now says where `{your-host}` comes from.
- **quick-start.md** — the "Discord login fails" entry points at the new troubleshooting section.

Anchors verified against the target headings.