### PR TITLE
ci: stop Dependabot proposing Microsoft.OpenApi 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,23 @@ updates:
       - dependencies
     commit-message:
       prefix: deps
+    ignore:
+      # Microsoft.OpenApi 3.x cannot be used while Microsoft.AspNetCore.OpenApi targets the 2.x
+      # object model. Its source generator assigns IOpenApiMediaType.Example, which became
+      # read-only in 3.0, so the build fails in generated code no edit here can reach:
+      #   OpenApiXmlCommentSupport.generated.cs: error CS0200: Property or indexer
+      #   IOpenApiMediaType.Example cannot be assigned to -- it is read only
+      #
+      # The direct reference exists only to clear GHSA-v5pm-xwqc-g5wc, which
+      # Microsoft.AspNetCore.OpenApi 10.0.10 reintroduces by pinning 2.0.0 transitively (see the
+      # comment in Pgan.PoracleWebNet.Api.csproj). Minor and patch updates inside 2.x still come
+      # through, so a later advisory is not masked.
+      #
+      # Drop this once Microsoft.AspNetCore.OpenApi ships a release built against 3.x -- at which
+      # point the direct reference should go too. See #702.
+      - dependency-name: Microsoft.OpenApi
+        update-types:
+          - version-update:semver-major
     groups:
       # One group for the whole .NET platform. These packages ship as a single versioned set:
       # Microsoft.EntityFrameworkCore 10.0.x transitively requires Microsoft.Extensions.* at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Dependabot no longer proposes `Microsoft.OpenApi` 3.x every week. The 3.0 object model made `IOpenApiMediaType.Example` read-only, and `Microsoft.AspNetCore.OpenApi` 10.0.10 still generates code that assigns it, so the bump cannot build and no edit in this repository can reach the failure. Minor and patch updates inside 2.x still come through, so a later advisory is not masked ([#702](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/702)).
+
 ## [2.15.0] - 2026-08-10
 
 ### Added


### PR DESCRIPTION
#702 bumps `Microsoft.OpenApi` 2.7.5 → 3.9.0 and fails the backend build. It is unfixable here, not merely broken.

## Why it cannot build

3.0 made `IOpenApiMediaType.Example` read-only. `Microsoft.AspNetCore.OpenApi` 10.0.10's XML comment source generator still assigns it:

```
OpenApiXmlCommentSupport.generated.cs(399,41): error CS0200: Property or indexer
'IOpenApiMediaType.Example' cannot be assigned to -- it is read only
```

That file is generated at build time by the ASP.NET Core package. No edit in this repository reaches it, so the only options are to stay on 2.x or drop OpenAPI support.

## Why we cannot just drop the direct reference

The csproj comment names the exit condition: the pin exists solely to clear GHSA-v5pm-xwqc-g5wc, because `Microsoft.AspNetCore.OpenApi` 10.0.10 pins the vulnerable `Microsoft.OpenApi` 2.0.0 transitively. I checked NuGet — 10.0.10 is still the newest release, so no patched floor exists yet and the pin has to stay.

## Change

Ignore **major** updates for `Microsoft.OpenApi` only, matching how the npm ecosystem already ignores Angular, Angular Material and TypeScript majors.

Minor and patch updates inside 2.x still come through, so a later advisory in that line is not masked. 2.11.0 is available and should arrive on the next run.

## Not a silent cap

The ignore carries its reason, the exact compiler error, and the condition for removing it, so whoever sees a 3.x release land does not have to rediscover why it was blocked.

Worth noting the auto-merge workflow behaved correctly here: #702 is a group PR containing a major, and the #344 guard held it for review rather than merging a broken build.

Closes #702.