### PR TITLE
fix: OIDC session cleanup never ran on MariaDB (#707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Expired OIDC refresh sessions are actually deleted now.** The background cleanup had never once completed on MariaDB: EF Core's `ExecuteDeleteAsync` emits ``DELETE FROM `oidc_sessions` AS `o` ``, and MariaDB rejects an aliased single-table delete outright, so every pass since the feature shipped threw a 1064 and logged a warning while the table only grew. The delete is now raw SQL with no alias. Nothing needs doing on upgrade — the first pass after startup clears the backlog. The eight sibling deletes in `HumanRepository` would have failed the same way and are gone; they had been dead code since alarm deletion moved to the PoracleNG proxy ([#707](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/707)).
 - Dependabot no longer proposes `Microsoft.OpenApi` 3.x every week. The 3.0 object model made `IOpenApiMediaType.Example` read-only, and `Microsoft.AspNetCore.OpenApi` 10.0.10 still generates code that assigns it, so the bump cannot build and no edit in this repository can reach the failure. Minor and patch updates inside 2.x still come through, so a later advisory is not masked ([#702](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/702)).
 
 ## [2.15.0] - 2026-08-10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,13 @@ On first startup after upgrade, the `SettingsMigrationStartupService` automatica
 ### MariaDB GET_LOCK Compatibility
 `MySql.EntityFrameworkCore`'s `MigrateAsync()` uses `GET_LOCK('__EFMigrationsLock', -1)` which returns NULL on MariaDB (infinite timeout not supported), causing `System.InvalidCastException`. The `MariaDbHistoryRepository` class overrides the lock acquisition to use `GET_LOCK(3600)` instead. This is registered via `ReplaceService<IHistoryRepository, MariaDbHistoryRepository>()` on `PoracleWebContext`.
 
+### `ExecuteDeleteAsync` Is Unusable On MariaDB
+`MySql.EntityFrameworkCore` emits the aliased single-table form, ``DELETE FROM `t` AS `x` WHERE …``, and MariaDB answers 1064 — it requires the multi-table ``DELETE x FROM t AS x`` once an alias is present. `ExecuteUpdateAsync` is fine; MariaDB accepts `UPDATE t AS x SET x.c = …`. Verified against MariaDB 10.8.2.
+
+Nothing catches this before production. It compiles, and the repository tests pass because they run on **SQLite**, whose provider emits the same alias and accepts it. The OIDC session cleanup shipped this way and had never once run (#707); `QuickPickAppliedStateRepository` hit it earlier and quietly grew a load-and-`RemoveRange` workaround.
+
+Use raw SQL with **unquoted** identifiers (so the statement also parses on SQLite for the tests), or load and `RemoveRange` when the row count is small. `NoAliasedDeleteTests` fails the build if `.ExecuteDeleteAsync(` reappears anywhere under `Core/`, `Data/` or the API project.
+
 ### Gym ID NULL vs Empty String
 The `gym_id` column in Poracle alarm tables (gym, raid, egg) is a `NOT NULL` string that defaults to `""` (empty string) meaning "any gym". PoracleNG handles the null-to-empty normalization on its side. The `GymPickerComponent` emits `null` when cleared and the gym's `id` string when selected.
 

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
@@ -10,6 +10,5 @@ public interface IHumanRepository
     public Task<Human> UpdateAsync(Human human);
     public Task<IEnumerable<Human>> GetByIdsAsync(IEnumerable<string> ids);
     public Task<bool> ExistsAsync(string id);
-    public Task<int> DeleteAllAlarmsByUserAsync(string userId);
     public Task<bool> DeleteUserAsync(string userId);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IOidcSessionRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IOidcSessionRepository.cs
@@ -4,7 +4,8 @@ namespace Pgan.PoracleWebNet.Core.Abstractions.Repositories;
 
 /// <summary>
 /// Persistence for server-side OIDC refresh sessions (rotation families). All bulk revoke/cleanup
-/// methods commit immediately via EF Core's set-based <c>ExecuteUpdateAsync</c>/<c>ExecuteDeleteAsync</c>.
+/// methods commit immediately: the revokes via EF Core's set-based <c>ExecuteUpdateAsync</c>, the
+/// cleanup via raw SQL because the aliased delete EF generates is invalid on MariaDB (see #707).
 /// </summary>
 public interface IOidcSessionRepository
 {
@@ -28,6 +29,9 @@ public interface IOidcSessionRepository
     /// <summary>Revokes every still-active session for a user (admin disable / logout-everywhere).</summary>
     public Task<int> RevokeAllForUserAsync(string userId, string reason);
 
-    /// <summary>Set-based delete of expired rows and revoked rows older than the retention window.</summary>
+    /// <summary>
+    /// Set-based delete of expired rows and revoked rows older than the retention window.
+    /// Returns the number of rows removed.
+    /// </summary>
     public Task<int> DeleteExpiredAndStaleAsync(TimeSpan revokedRetention);
 }

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
@@ -73,19 +73,10 @@ public class HumanRepository(PoracleContext context) : IHumanRepository
 
     public async Task<bool> ExistsAsync(string id) => await this._context.Humans.AnyAsync(h => h.Id == id);
 
-    public async Task<int> DeleteAllAlarmsByUserAsync(string userId)
-    {
-        var count = 0;
-        count += await this._context.Monsters.Where(m => m.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Raids.Where(r => r.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Eggs.Where(e => e.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Quests.Where(q => q.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Invasions.Where(i => i.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Lures.Where(l => l.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Nests.Where(n => n.Id == userId).ExecuteDeleteAsync();
-        count += await this._context.Gyms.Where(g => g.Id == userId).ExecuteDeleteAsync();
-        return count;
-    }
+    // DeleteAllAlarmsByUserAsync lived here and was dead: HumanService has looped the tracking proxy
+    // since the PoracleNG migration, so nothing reached it. Its eight ExecuteDeleteAsync calls would
+    // each have emitted the aliased DELETE that MariaDB rejects (#707), so it could not have worked
+    // had anything called it. Alarm deletion belongs to PoracleNG, which reloads its own state.
 
     public async Task<bool> DeleteUserAsync(string userId)
     {

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/OidcSessionRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/OidcSessionRepository.cs
@@ -61,9 +61,16 @@ public class OidcSessionRepository(PoracleWebContext context) : IOidcSessionRepo
     {
         DateTime now = DateTime.UtcNow;
         DateTime revokedCutoff = now - revokedRetention;
-        return await this._context.OidcSessions
-            .Where(s => s.ExpiresAt < now || (s.RevokedAt != null && s.RevokedAt < revokedCutoff))
-            .ExecuteDeleteAsync();
+
+        // Raw SQL rather than ExecuteDeleteAsync: MySql.EntityFrameworkCore emits the aliased
+        // single-table form -- DELETE FROM `oidc_sessions` AS `o` WHERE ... -- and MariaDB rejects
+        // that outright (1064; it wants the multi-table `DELETE o FROM ... AS o` when an alias is
+        // present). Every cleanup pass since the feature shipped threw and logged a warning, so the
+        // table only ever grew. Verified against MariaDB 10.8.2. Identifiers are left bare and
+        // unquoted so the same statement parses on MariaDB, MySQL and the SQLite the repository
+        // tests run against. See #707.
+        return await this._context.Database.ExecuteSqlInterpolatedAsync(
+            $"DELETE FROM oidc_sessions WHERE expires_at < {now} OR (revoked_at IS NOT NULL AND revoked_at < {revokedCutoff})");
     }
 
     private static OidcSession ToModel(OidcSessionEntity e) => new()

--- a/Tests/Pgan.PoracleWebNet.Tests/Repositories/NoAliasedDeleteTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Repositories/NoAliasedDeleteTests.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+
+namespace Pgan.PoracleWebNet.Tests.Repositories;
+
+/// <summary>
+/// <c>ExecuteDeleteAsync</c> is unusable against this deployment. MySql.EntityFrameworkCore emits the
+/// aliased single-table form — <c>DELETE FROM `t` AS `x` WHERE …</c> — and MariaDB answers 1064; the
+/// multi-table <c>DELETE x FROM t AS x</c> is required once an alias is present. Verified against
+/// MariaDB 10.8.2.
+///
+/// Nothing catches this at build time and nothing catches it in the test suite either, because the
+/// repository tests run on SQLite, whose provider does not emit the alias. It reaches production green
+/// and fails on every call. That is how the OIDC session cleanup shipped never having run once (#707),
+/// and how <c>QuickPickAppliedStateRepository</c> acquired its load-and-remove workaround before it.
+///
+/// Use raw SQL with unquoted identifiers, or load and <c>RemoveRange</c> when the row count is small.
+/// <c>ExecuteUpdateAsync</c> is fine — MariaDB accepts <c>UPDATE t AS x SET x.c = …</c>.
+/// </summary>
+public sealed class NoAliasedDeleteTests
+{
+    private static readonly string[] ScannedProjects =
+    [
+        "Core",
+        "Data",
+        "Applications/Pgan.PoracleWebNet.Api",
+    ];
+
+    // Matches the call, not prose: the surrounding comments and doc-comments name the method freely.
+    private static readonly Regex CallSite = new(@"\.ExecuteDeleteAsync\s*\(", RegexOptions.Compiled);
+
+    [Fact]
+    public void NoProductionCodeCallsExecuteDeleteAsync()
+    {
+        var root = FindSolutionRoot();
+
+        var offenders = ScannedProjects
+            .Select(p => Path.Combine(root, p.Replace('/', Path.DirectorySeparatorChar)))
+            .Where(Directory.Exists)
+            .SelectMany(dir => Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            .Where(f => !IsBuildOutput(f, root))
+            .SelectMany(f => File.ReadLines(f)
+                .Select((line, i) => (line, number: i + 1))
+                .Where(x => CallSite.IsMatch(x.line))
+                .Select(x => $"{Path.GetRelativePath(root, f)}:{x.number}"))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "ExecuteDeleteAsync is back: " + string.Join(", ", offenders)
+            + ". The provider emits DELETE FROM `t` AS `x`, which MariaDB rejects with a 1064 at runtime "
+            + "while the SQLite-backed tests stay green. Use raw SQL with unquoted identifiers, or load "
+            + "the rows and RemoveRange them. See #707.");
+    }
+
+    private static bool IsBuildOutput(string file, string root)
+    {
+        var relative = Path.GetRelativePath(root, file);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return segments.Any(s => s is "bin" or "obj");
+    }
+
+    private static string FindSolutionRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Pgan.PoracleWebNet.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Repositories/OidcSessionRepositoryTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Repositories/OidcSessionRepositoryTests.cs
@@ -1,5 +1,7 @@
+using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Pgan.PoracleWebNet.Core.Models;
 using Pgan.PoracleWebNet.Core.Repositories;
 using Pgan.PoracleWebNet.Data;
@@ -8,15 +10,16 @@ namespace Pgan.PoracleWebNet.Tests.Repositories;
 
 /// <summary>
 /// Repository tests over a real relational provider (SQLite in-memory) because the rotation guard
-/// and cleanup use <c>ExecuteUpdateAsync</c>/<c>ExecuteDeleteAsync</c>, which the EF InMemory
-/// provider cannot translate. Covers the retention semantics (decoupled revoked-row retention) and
-/// the atomic rotation guard.
+/// uses <c>ExecuteUpdateAsync</c>, which the EF InMemory provider cannot translate. Covers the
+/// retention semantics (decoupled revoked-row retention), the atomic rotation guard, and the shape
+/// of the emitted cleanup statement.
 /// </summary>
 public sealed class OidcSessionRepositoryTests : IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly PoracleWebContext _context;
     private readonly OidcSessionRepository _repo;
+    private readonly CommandCapture _commands = new();
 
     public OidcSessionRepositoryTests()
     {
@@ -24,6 +27,7 @@ public sealed class OidcSessionRepositoryTests : IDisposable
         this._connection.Open();
         var options = new DbContextOptionsBuilder<PoracleWebContext>()
             .UseSqlite(this._connection)
+            .AddInterceptors(this._commands)
             .Options;
         this._context = new PoracleWebContext(options);
         this._context.Database.EnsureCreated();
@@ -132,5 +136,59 @@ public sealed class OidcSessionRepositoryTests : IDisposable
 
         Assert.NotNull(await this._repo.GetByHashAsync("known"));
         Assert.Null(await this._repo.GetByHashAsync("missing"));
+    }
+
+    /// <summary>
+    /// The retention test above passed for the whole time cleanup was broken in production: SQLite
+    /// accepts what EF generated, MariaDB answered 1064 to <c>DELETE FROM `oidc_sessions` AS `o`</c>,
+    /// and no test looked at the statement itself. This one does. See #707.
+    /// </summary>
+    [Fact]
+    public async Task DeleteExpiredAndStale_EmitsUnaliasedDelete_MariaDbCannotParseTheAliasedForm()
+    {
+        await this.SeedAsync("expired", "f1", expiresAt: DateTime.UtcNow.AddMinutes(-1));
+        this._commands.Executed.Clear();
+
+        await this._repo.DeleteExpiredAndStaleAsync(TimeSpan.FromDays(2));
+
+        var delete = Assert.Single(
+            this._commands.Executed,
+            c => c.TrimStart().StartsWith("DELETE", StringComparison.OrdinalIgnoreCase));
+
+        Assert.DoesNotContain(" AS ", delete, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("`", delete, StringComparison.Ordinal);
+    }
+
+    private sealed class CommandCapture : DbCommandInterceptor
+    {
+        public List<string> Executed { get; } = [];
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            this.Executed.Add(command.CommandText);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            this.Executed.Add(command.CommandText);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            this.Executed.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            this.Executed.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
     }
 }

--- a/docs/configuration/oidc-refresh-tokens.md
+++ b/docs/configuration/oidc-refresh-tokens.md
@@ -140,7 +140,7 @@ session and one rotation chain.
                                           (atomic rotate / revoke)   │ FamilyId chain,            │
                                                                      │ EncryptedRefreshToken      │
                                           OidcSessionCleanupService  │ (DataProtection)           │
-                                          (~6h ExecuteDeleteAsync)   └──────────────────────────┘
+                                          (~6h set-based DELETE)     └──────────────────────────┘
 ```
 
 ### Login and refresh-token issuance
@@ -404,8 +404,10 @@ relies solely on `/token` (`grant_type=refresh_token`), `/userinfo`, and `expire
 
 Token hashing uses **SHA-256** over 32 random bytes with a unique index — a full-entropy secret
 correctly uses a fast hash (never bcrypt/PBKDF2) for O(1) indexed lookup. Expired and old-revoked
-session rows are pruned by a background `OidcSessionCleanupService` (~every 6 hours, set-based
-`ExecuteDeleteAsync`).
+session rows are pruned by a background `OidcSessionCleanupService` (~every 6 hours, one set-based
+`DELETE`). That delete is issued as raw SQL rather than EF's `ExecuteDeleteAsync`, which emits an
+aliased `DELETE FROM oidc_sessions AS o` — valid on SQLite and MySQL 8, a 1064 syntax error on
+MariaDB (#707).
 
 ---
 

--- a/docs/poracleng-v2-review.md
+++ b/docs/poracleng-v2-review.md
@@ -50,7 +50,7 @@ Net consequence: **without three explicit asks to jfberry, the keystone deletion
 | 7 | `LocationController.UpdateLanguage` → `HumanService.UpdateAsync` → `HumanRepository.UpdateAsync` | Generic direct-DB human update for language | **YES** | `POST /api/v2/humans/{id}/language` exists — swap now |
 | 8 | `ProfileRepository` (all methods) + `ProfileService.Create/Update/Delete` | Dead code — controllers already use proxy | **YES** | Delete outright; v2 profile endpoints exist |
 | 9 | `HumanRepository.GetByIdAsync`/`ExistsAsync`/`CreateAsync` | Dead — service uses proxy | **YES** | Delete dead methods |
-| 10 | `HumanRepository.DeleteAllAlarmsByUserAsync` | Dead — service loops via proxy | **PARTIAL** | Delete dead method now; one-shot purge endpoint is a nice-to-have (ask #6) |
+| 10 | ~~`HumanRepository.DeleteAllAlarmsByUserAsync`~~ | Dead — service loops via proxy | **DONE** | Deleted in #707 (its `ExecuteDeleteAsync` calls could not run on MariaDB anyway); one-shot purge endpoint is still a nice-to-have (ask #6) |
 | 11 | `DashboardService.GetAllTrackingAsync` (proxy, not direct DB) | Fetches full payloads to count | **YES** | Snapshot/counts — perf win, not DB elimination |
 
 **Verdict:** rows 6–11 close on v2 (some are pure dead-code deletion). Rows 1–5 — the entire reason `PoracleContext` still exists — require **four new PoracleNG capabilities.** Until those land, `HumanRepository` shrinks to ~3 admin methods that still pin `PoracleContext`, and `UserAreaDualWriter` stays in full.
@@ -123,7 +123,7 @@ The three **High** asks (trusted setAreas, admin list, batch resolve) are the ga
 |---|---|---|
 | 0a | Swap `LocationController.UpdateLanguage` to proxy `SetLanguageAsync` (→ `POST /api/v2/humans/{id}/language`). Removes the last live `HumanRepository.UpdateAsync` caller. | S |
 | 0b | Swap `UserGeofenceService:292` display-name read to proxy `GetHumanAsync`. | S |
-| 0c | Delete dead `ProfileRepository`/`IProfileRepository` + `ProfileService` CRUD; dead `HumanRepository` methods (`GetByIdAsync`/`ExistsAsync`/`CreateAsync`/`DeleteAllAlarmsByUserAsync`) + `EnsureNotNullDefaults`. Update test mocks. Keep only `GetAllAsync`/`GetByIdsAsync`/`DeleteUserAsync` until v2 admin endpoints land. | M |
+| 0c | Delete dead `ProfileRepository`/`IProfileRepository` + `ProfileService` CRUD; dead `HumanRepository` methods (`GetByIdAsync`/`ExistsAsync`/`CreateAsync`; `DeleteAllAlarmsByUserAsync` already gone in #707) + `EnsureNotNullDefaults`. Update test mocks. Keep only `GetAllAsync`/`GetByIdsAsync`/`DeleteUserAsync` until v2 admin endpoints land. | M |
 
 **Phase 1 — v2 read path (behind `Poracle:ApiVersion` flag):**
 


### PR DESCRIPTION
Fixes #707.

## What was wrong

`ExecuteDeleteAsync` under `MySql.EntityFrameworkCore` emits the aliased single-table form:

```sql
DELETE FROM `oidc_sessions` AS `o` WHERE ...
```

MariaDB rejects that outright — the multi-table `DELETE o FROM oidc_sessions AS o` is required once an alias is present. So `OidcSessionCleanupService` threw a 1064 on every pass since the feature shipped and the table only ever grew.

Verified against the dev MariaDB (10.8.2):

| Statement | Result |
|---|---|
| ``DELETE FROM `oidc_sessions` AS `o` WHERE 1=0`` | **ERROR 1064** |
| ``DELETE `o` FROM `oidc_sessions` AS `o` WHERE 1=0`` | ok |
| ``UPDATE `oidc_sessions` AS `o` SET ... WHERE 1=0`` | ok |
| `DELETE FROM oidc_sessions WHERE 1=0` | ok |

`ExecuteUpdateAsync` is unaffected, so the rotation guard and the family/user revokes stay as they are.

## The fix

`DeleteExpiredAndStaleAsync` issues the delete as raw parameterized SQL with **unquoted** identifiers, so the one statement parses on MariaDB, MySQL and the SQLite the repository tests run against. Executed against the real dev database inside a rolled-back transaction: it matches the 2 rows sitting there, both expired.

**No manual purge needed on upgrade.** The service runs 240s after startup, so the backlog clears itself on the first deploy.

## Siblings

Per the "fixing one path and leaving its siblings" note in CLAUDE.md, I grepped for the shape. `HumanRepository.DeleteAllAlarmsByUserAsync` held eight more `ExecuteDeleteAsync` calls that would each have failed identically. It has been dead since alarm deletion moved to the PoracleNG proxy — `HumanService` loops the tracking proxy and nothing reaches the repository method — and `docs/poracleng-v2-review.md` already listed it for deletion, so it is removed rather than rewritten. Those are the only two sites; `QuickPickAppliedStateRepository` had already worked around this with load-and-`RemoveRange`.

## Why the tests didn't catch it

`OidcSessionRepositoryTests` runs on SQLite, whose provider emits the *same* alias and accepts it. The retention test passed for the entire time cleanup was broken in production. Two new tests, both watched failing against the unfixed code before the fix went in:

- `DeleteExpiredAndStale_EmitsUnaliasedDelete_...` intercepts the command and asserts the statement's shape, not just its semantics. Against the old code it fails with ``String: ···"FROM "oidc_sessions" AS "o"···``.
- `NoAliasedDeleteTests` fails the build if `.ExecuteDeleteAsync(` reappears under `Core/`, `Data/` or the API project. Against the old code it named all nine call sites.

## Also

- `CLAUDE.md` gains a Common Issues entry, since the trap is invisible at compile time and invisible in the test suite.
- `docs/configuration/oidc-refresh-tokens.md` and `docs/poracleng-v2-review.md` updated to match.

Backend build clean, 1854/1854 backend tests pass. No frontend change.
