### PR TITLE
release: promote develop for v2.15.1

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Pgan.PoracleWebNet.Api.csproj
+++ b/Applications/Pgan.PoracleWebNet.Api/Pgan.PoracleWebNet.Api.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <!--
       Direct pin to clear NU1903 (GHSA-v5pm-xwqc-g5wc, high): a circular schema reference can
       terminate OpenAPI parsing. Microsoft.OpenApi is vulnerable at >= 2.0.0-preview.11 and
@@ -23,8 +23,8 @@
       the same 2.0.0. This direct reference is the only way to raise it, and can be dropped once
       Microsoft.AspNetCore.OpenApi ships a patched floor of its own.
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Expired OIDC refresh sessions are actually deleted now.** The background cleanup had never once completed on MariaDB: EF Core's `ExecuteDeleteAsync` emits ``DELETE FROM `oidc_sessions` AS `o` ``, and MariaDB rejects an aliased single-table delete outright, so every pass since the feature shipped threw a 1064 and logged a warning while the table only grew. The delete is now raw SQL with no alias. Nothing needs doing on upgrade — the first pass after startup clears the backlog. The eight sibling deletes in `HumanRepository` would have failed the same way and are gone; they had been dead code since alarm deletion moved to the PoracleNG proxy ([#707](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/707)).
 - Dependabot no longer proposes `Microsoft.OpenApi` 3.x every week. The 3.0 object model made `IOpenApiMediaType.Example` read-only, and `Microsoft.AspNetCore.OpenApi` 10.0.10 still generates code that assigns it, so the bump cannot build and no edit in this repository can reach the failure. Minor and patch updates inside 2.x still come through, so a later advisory is not masked ([#702](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/702)).
 
+### Dependencies
+
+- Bump the dotnet group with 12 updates ([#711](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/711))
+- Bump `@types/leaflet` in /Applications/Pgan.PoracleWebNet.App/ClientApp ([#705](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/705))
+- Bump the angular group in /Applications/Pgan.PoracleWebNet.App/ClientApp ([#701](https://github.com/PGAN-Dev/PoracleWeb.NET/pull/701))
+
 ## [2.15.0] - 2026-08-10
 
 ### Added

--- a/Core/Pgan.PoracleWebNet.Core.Services/Pgan.PoracleWebNet.Core.Services.csproj
+++ b/Core/Pgan.PoracleWebNet.Core.Services/Pgan.PoracleWebNet.Core.Services.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/Pgan.PoracleWebNet.Data.Scanner/Pgan.PoracleWebNet.Data.Scanner.csproj
+++ b/Data/Pgan.PoracleWebNet.Data.Scanner/Pgan.PoracleWebNet.Data.Scanner.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.9" />
   </ItemGroup>
 

--- a/Data/Pgan.PoracleWebNet.Data/Pgan.PoracleWebNet.Data.csproj
+++ b/Data/Pgan.PoracleWebNet.Data/Pgan.PoracleWebNet.Data.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.9" />
   </ItemGroup>
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Pgan.PoracleWebNet.Tests.csproj
+++ b/Tests/Pgan.PoracleWebNet.Tests/Pgan.PoracleWebNet.Tests.csproj
@@ -9,14 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <!-- EFCore.Sqlite 10.0.10 still pulls SQLitePCLRaw 2.1.11, which carries GHSA-2m69-gcr7-jv3q.
          Pinned forward so the build stops reporting a high-severity advisory. Test-only. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Promotes `develop` to `main` for the v2.15.1 release.

The 2.15.0 release merge (#710) landed on `main` but no release was ever published, so the two fixes below have been sitting on released code without shipping — no tag, no `:latest` build, nothing for watchtower to pull. This promotion picks up the outstanding dependency work as well, and the release is published straight after.

**Fixes**
- Inspecting a blocked user no longer signs the admin out (#706, via #709)
- Expired OIDC refresh sessions are actually deleted on MariaDB (#707, via #708)
- Dependabot no longer proposes `Microsoft.OpenApi` 3.x every week (#702)

**Dependencies**
- The dotnet group, 12 updates (#711)
- `@types/leaflet` (#705)
- The angular group (#701)

Also records those three bumps in `CHANGELOG.md` — all of them had landed on `develop` without an entry, so the 2.15.1 notes would have omitted them.

https://claude.ai/code/session_01CYyjpx2HzaZxMnYamkyoXX
