### PR TITLE
fix: skip Discord re-authorization prompt for returning users

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -141,6 +141,7 @@ public partial class AuthController(
             $"&redirect_uri={Uri.EscapeDataString(callbackUri)}" +
             "&response_type=code" +
             "&scope=identify" +
+            "&prompt=none" +
             $"&state={Uri.EscapeDataString(state)}";
 
         return this.Redirect(redirectUrl);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Discord login no longer shows the "Authorize" button on every sign-in.** Adding `prompt=none` to the OAuth2 redirect tells Discord to skip the consent screen for users who have already granted the app permission. The screen still appears on first-time authorization ([#719](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/719)).
+
 ## [2.15.1] - 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
Closes #719

## What

Adds `&prompt=none` to the Discord OAuth2 redirect URL in `AuthController.DiscordLogin()`.

## Why

Discord's `prompt=none` parameter tells Discord to skip the consent screen when the user has already granted the requested scopes. Without it, Discord defaults to showing the "Authorize" button on every login — even for returning users who previously approved the app.

**First login**: unchanged — the consent screen appears once as normal.
**All subsequent logins**: Discord detects the existing authorization and redirects straight to the callback with no user interaction required.

This is the same approach used by ReactMap.

## Change

```diff
  var redirectUrl = "https://discordapp.com/api/oauth2/authorize" +
      $"?client_id={this._discordSettings.ClientId}" +
      $"&redirect_uri={Uri.EscapeDataString(callbackUri)}" +
      "&response_type=code" +
      "&scope=identify" +
+     "&prompt=none" +
      $"&state={Uri.EscapeDataString(state)}";
```
