### PR TITLE
docs: clarify PoracleNG is required; PoracleJS not tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PoracleWeb.NET
 
-A web application for managing Pokemon GO notification alarms through the Poracle bot system. Compatible with both [PoracleJS](https://github.com/KartulUdus/PoracleJS) and [PoracleNG](https://github.com/jfberry/PoracleNG). Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+A web application for managing Pokemon GO notification alarms through the [PoracleNG](https://github.com/jfberry/PoracleNG) bot. Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+
+> **PoracleNG is required.** All alarm management, profile handling, and user operations are proxied through PoracleNG's REST API. [PoracleJS](https://github.com/KartulUdus/PoracleJS) is not a tested or supported configuration — some operations that rely on PoracleNG-specific endpoints will not work.
 
 **[Documentation](https://pgan-dev.github.io/PoracleWeb.NET/)** | **[Changelog](CHANGELOG.md)**
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -89,7 +89,7 @@ All alarm tracking writes (create, update, delete) and single-user human/profile
 PoracleWeb.NET does **not** modify the Poracle DB schema. The Poracle database is managed by PoracleNG. Application-owned data (user geofences, site settings, webhook delegates, quick pick definitions) lives in a separate `poracle_web` database managed by EF Core migrations.
 
 ### Unified geofence feed
-PoracleWeb.NET acts as the single geofence source for PoracleJS. It fetches admin geofences from Koji, merges them with user-drawn geofences, and serves everything via one endpoint (`GET /api/geofence-feed`). No custom code needed in PoracleJS or Koji. User geofences support GeoJSON import/export for interoperability with external mapping tools.
+PoracleWeb.NET acts as the single geofence source for PoracleNG. It fetches admin geofences from Koji, merges them with user-drawn geofences, and serves everything via one endpoint (`GET /api/geofence-feed`). No custom code needed in PoracleNG or Koji. User geofences support GeoJSON import/export for interoperability with external mapping tools.
 
 ### Manual mapping extensions
 Mapping lives in static extension methods under `Core.Mappings/` -- there is no AutoMapper dependency. `AlarmMappingExtensions` provides `To*()` for `*Create` DTOs and `ApplyUpdate()` for `*Update` DTOs; `EntityMappingExtensions` provides `ToModel()`, `ToEntity()`, and `ApplyTo()` for Human, Profile, and the `poracle_web`-owned tables. Update models use nullable properties and `ApplyUpdate` skips nulls, so partial updates don't zero out unset fields. Alarm data itself flows as raw JSON through the PoracleNG API proxy. See [Backend Patterns](backend.md).

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -54,11 +54,11 @@ The `./data` directory persists:
 
 ### Poracle config directory
 
-Mount your PoracleJS `config/` directory as read-only for DTS template preview functionality:
+Mount your PoracleNG `config/` directory as read-only for DTS template preview functionality:
 
 ```yaml
 volumes:
-  - /path/to/PoracleJS/config:/poracle-config:ro
+  - /path/to/PoracleNG/config:/poracle-config:ro
 ```
 
 ## Building locally

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -83,7 +83,7 @@ CORS_ORIGIN=http://localhost:8082
 
 ```env
 # Poracle config directory — mount for DTS template previews
-PORACLE_CONFIG_DIR=/path/to/PoracleJS/config
+PORACLE_CONFIG_DIR=/path/to/PoracleNG/config
 
 # Koji geofence API (required for custom geofences feature)
 KOJI_API_ADDRESS=http://host.docker.internal:8080

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,10 @@ template: home.html
 
 # PoracleWeb.NET
 
-A web application for managing Pokemon GO notification alarms through the Poracle bot system. Compatible with both [PoracleJS](https://github.com/KartulUdus/PoracleJS) and [PoracleNG](https://github.com/jfberry/PoracleNG). Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+A web application for managing Pokemon GO notification alarms through the [PoracleNG](https://github.com/jfberry/PoracleNG) bot. Users authenticate via Discord OAuth2 or Telegram and configure personalized alert filters (Pokemon, Raids, Quests, Invasions, Lures, Nests, Gyms) through a browser-based UI.
+
+!!! warning "PoracleNG is required"
+    All alarm management, profile handling, and user operations are proxied through PoracleNG's REST API. [PoracleJS](https://github.com/KartulUdus/PoracleJS) is not a tested or supported configuration — some operations that rely on PoracleNG-specific endpoints will not work.
 
 ## Tech Stack
 
@@ -25,7 +28,7 @@ A web application for managing Pokemon GO notification alarms through the Poracl
 - **Alert Defaults** — Choose whether new alerts default to Areas or a Distance radius, with a configurable default distance
 - **Quick Picks** — Admin-defined alarm templates users can apply with one click
 - **Area Management** — Interactive Leaflet map for selecting geofence areas
-- **Custom Geofences** — Draw custom polygon geofences on a map, served to PoracleJS via a built-in feed endpoint. Submit for admin review to promote to public areas.
+- **Custom Geofences** — Draw custom polygon geofences on a map, served to the Poracle bot via a built-in unified feed endpoint. Submit for admin review to promote to public areas.
 - **Geofence Admin Review** — Approve or reject user-submitted geofences with Discord forum integration
 - **Profile Switching** — Multiple alarm profiles per user
 - **Profile Active Hours** — Schedule automatic profile switching by day and time
@@ -51,7 +54,7 @@ A web application for managing Pokemon GO notification alarms through the Poracl
 | Requirement | Version | Purpose |
 |---|---|---|
 | MySQL | 5.7+ or 8.0+ | Poracle database (existing Poracle installation) |
-| Poracle | PoracleJS or PoracleNG | Running instance with REST API enabled. All alarm writes are proxied through the Poracle API. |
+| Poracle | [PoracleNG](https://github.com/jfberry/PoracleNG) | Running instance with REST API enabled. All alarm, profile, and user operations are proxied through PoracleNG's REST API. PoracleJS is not a tested configuration. |
 | Discord App | — | OAuth2 application for user authentication |
 | Koji | — | Geofence management server (required for custom geofences feature) |
 | .NET SDK | 10.0 | Backend development (not needed for Docker) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,10 +243,10 @@ UPDATE gym SET team = 4 WHERE team = 0;
 
 ## Monster filter defaults (size, max_level, etc.) — legacy
 
-!!! note "Legacy issue"
-    This was caused by direct database writes with incorrect C# model defaults. New alarms created through the PoracleNG API proxy have correct defaults. The SQL queries below help diagnose alarms created before the migration.
+!!! note "Legacy issue (PoracleJS only)"
+    This was caused by direct database writes with incorrect C# model defaults in early versions of PoracleWeb.NET. New alarms created through the PoracleNG API proxy have correct defaults applied by PoracleNG itself. The SQL queries below help diagnose alarms created before the migration, on PoracleJS installations.
 
-**Problem**: New monster alarms created via the web UI may silently filter out pokemon if model defaults don't match PoracleJS expectations. For example, `max_size=0` causes all pokemon with size data to be rejected, and `size=0` instead of `size=-1` shows incorrectly in the old PHP UI as "-XXL".
+**Problem**: On PoracleJS, monster alarms created by old versions of PoracleWeb.NET may silently filter out pokemon if model defaults don't match PoracleJS expectations. For example, `max_size=0` causes all pokemon with size data to be rejected, and `size=0` instead of `size=-1` shows incorrectly in the old PHP UI as "-XXL". This does not apply to PoracleNG, which applies its own defaults on every write.
 
 **Solution**: All Create model defaults are aligned with the PHP PoracleWeb.NET `include/defaults.php`. Key values:
 


### PR DESCRIPTION
Closes #722

## What changed

Six files updated to reflect that PoracleNG is the required and tested bot backend. PoracleJS is no longer a supported configuration.

### README.md / docs/index.md
- Replaced "Compatible with both PoracleJS and PoracleNG" with a clear statement that PoracleNG is required
- Added a prominent warning admonition in the docs site intro
- Updated the Prerequisites table to list PoracleNG explicitly with a note that PoracleJS is untested
- Updated the Custom Geofences feature bullet to say "Poracle bot" instead of "PoracleJS"

### docs/getting-started/quick-start.md
- `PORACLE_CONFIG_DIR` comment path updated from `/path/to/PoracleJS/config` to `/path/to/PoracleNG/config`

### docs/configuration/docker.md
- Volume mount example and description updated from "PoracleJS config/" to "PoracleNG config/"

### docs/architecture/overview.md
- "single geofence source for PoracleJS" → "for PoracleNG"

### docs/troubleshooting.md
- Legacy monster filter defaults section: callout now explicitly says "PoracleJS only" and the problem description clarifies this does not apply to PoracleNG

## Why

PoracleWeb.NET's proxy layer (`IPoracleTrackingProxy`, `IPoracleHumanProxy`) is built entirely against PoracleNG's REST API. Alarm CRUD, profile management, area updates, and human operations all use PoracleNG endpoints that do not exist in PoracleJS. The "compatible with both" claim was inaccurate and led to user confusion when PoracleJS-specific issues were reported as PoracleWeb.NET bugs.

The geofence feed (`/api/geofence-feed`) is bot-agnostic — any bot that accepts a URL geofence source can read it — so references in the geofence feature docs that say "PoracleJS/PoracleNG" remain unchanged.
