### PR TITLE
docs: remove PoracleJS references from all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [Quick Start guide](https://pgan-dev.github.io/PoracleWeb.NET/getting-st
 - **Gym Picker** — Search and target specific gyms for team change, raid, and egg alarms
 - **Bulk Operations** — Multi-select with bulk delete and distance update
 - **Alert Defaults** — Choose whether new alerts default to Areas or a Distance radius, with a configurable default distance
-- **Custom Geofences** — Draw polygons, auto-served to PoracleJS via unified feed
+- **Custom Geofences** — Draw polygons, auto-served to the Poracle bot via unified feed
 - **Geofence Admin Review** — Approve/reject with Discord forum integration
 - **Quick Picks** — One-click alarm templates
 - **Profile Switching** — Multiple alarm profiles per user
@@ -149,7 +149,7 @@ Cutting a release means merging `develop` into `main` and publishing a GitHub re
 
 PoracleWeb.NET stands on the shoulders of these projects and their authors:
 
-- **[PoracleJS](https://github.com/KartulUdus/PoracleJS)** by KartulUdus — the original Poracle bot that this UI manages
+- **[PoracleJS](https://github.com/KartulUdus/PoracleJS)** by KartulUdus — the original Poracle bot (alarm management in this app uses PoracleNG's REST API)
 - **[PoracleNG](https://github.com/jfberry/PoracleNG)** by jfberry — next-generation fork whose REST API powers all alarm tracking
 - **[PoracleWeb (PHP)](https://github.com/bbdoc/PoracleWeb)** by bbdoc — the original PHP web interface that inspired this .NET rewrite
 - **[Kōji](https://github.com/TurtIeSocks/Koji)** by TurtIeSocks — geofence management platform used for admin areas, region detection, and public geofence promotion

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -35,7 +35,7 @@ The `active_hours` column stores a JSON array defining when alarm delivery is ac
 - `hours` / `mins` — stored as **strings** (zero-padded, e.g. `"09"`, `"00"`)
 
 !!! info "Managed by PoracleNG"
-    The `active_hours` column is part of Poracle's own schema (managed by PoracleJS/PoracleNG) — no PoracleWeb.NET migration is needed. PoracleWeb.NET reads and writes this field through the `IPoracleHumanProxy` API, not via direct DB access.
+    The `active_hours` column is part of Poracle's own schema (managed by PoracleNG) — no PoracleWeb.NET migration is needed. PoracleWeb.NET reads and writes this field through the `IPoracleHumanProxy` API, not via direct DB access.
 
 ### PoracleWebContext
 

--- a/docs/features/custom-geofences/admin-operations.md
+++ b/docs/features/custom-geofences/admin-operations.md
@@ -79,7 +79,7 @@ The colour bar tracks state: **amber** while pending, **green** approved, **red*
 If Discord is unreachable or the channel isn't set, the submission still works — the geofence still moves to `pending_review`/`approved`/`rejected`. The forum post is a convenience, never a blocker. The same applies to the individual pieces: a failed map download falls back to linking it, a failed card rewrite still posts the outcome reply, and a Koji outage just omits the "Already covered by" line.
 
 !!! note "Bot token and tags"
-    PoracleWeb.NET uses the Discord bot token from your PoracleJS/PoracleNG server's Discord bot configuration. The forum tags (`Geofence - Pending` / `Approved` / `Rejected`) are created automatically the first time they're needed. If you rename those tags in Discord, restart PoracleWeb.NET so it re-reads them.
+    PoracleWeb.NET uses the Discord bot token from your PoracleNG server's Discord bot configuration. The forum tags (`Geofence - Pending` / `Approved` / `Rejected`) are created automatically the first time they're needed. If you rename those tags in Discord, restart PoracleWeb.NET so it re-reads them.
 
 ## Limits that protect your deployment
 

--- a/docs/features/custom-geofences/index.md
+++ b/docs/features/custom-geofences/index.md
@@ -16,7 +16,7 @@ flowchart TD
     C -->|Reject| E[Stays private,<br/>with a note back to the user]
 ```
 
-## How PoracleJS/PoracleNG gets its geofences (and why not straight from Koji)
+## How PoracleNG gets its geofences (and why not straight from Koji)
 
 Your bot does **not** read geofences from Koji. It reads them from **one PoracleWeb.NET URL** — `/api/geofence-feed` — which serves a single combined list: the public areas (from Koji) **plus** the private user-drawn areas (from PoracleWeb.NET's own database).
 
@@ -24,12 +24,12 @@ Your bot does **not** read geofences from Koji. It reads them from **one Poracle
 flowchart LR
     Koji[(Koji<br/>public areas)] -->|cached 5 min| Feed
     DB[(PoracleWeb.NET DB<br/>private user geofences)] --> Feed
-    Feed["PoracleWeb.NET<br/>/api/geofence-feed"] -->|single URL| Bot[PoracleJS / PoracleNG]
+    Feed["PoracleWeb.NET<br/>/api/geofence-feed"] -->|single URL| Bot[PoracleNG]
 ```
 
 Why it's set up this way:
 
-- **One source, not two.** The bot needs a single geofence source. PoracleWeb.NET does the Koji round-trip for you and merges in the private areas, so a stock PoracleJS/PoracleNG works with one config line — no custom code in the bot or in Koji.
+- **One source, not two.** The bot needs a single geofence source. PoracleWeb.NET does the Koji round-trip for you and merges in the private areas, so a stock PoracleNG install works with one config line — no custom code in the bot or in Koji.
 - **Privacy.** Private user geofences must stay hidden from the bot's `!area` picker and from notification DMs. PoracleWeb.NET serves them with the right "hidden" flags. Pushing them into Koji wouldn't reliably hide them (Koji's hide-from-matches property isn't honored by every notification formatter), so PoracleWeb.NET keeps them in its own database and serves them itself.
 - **Resilience.** If Koji is briefly unreachable, PoracleWeb.NET still serves the private user geofences and the last-known public ones, so notifications keep flowing. The bot also keeps its own local cache as a further safety net.
 

--- a/docs/features/custom-geofences/key-concepts.md
+++ b/docs/features/custom-geofences/key-concepts.md
@@ -66,7 +66,7 @@ PoracleWeb.NET users can have multiple **profiles** (e.g. "Home", "Work"). A geo
 
 ## A note on capitalization (it matters)
 
-PoracleJS/PoracleNG matches area names **exactly, including case**. PoracleWeb.NET stores every geofence name in **lowercase** to avoid surprises — `Downtown` and `downtown` are *not* the same to PoracleJS/PoracleNG, and a mismatch means no notifications, silently.
+PoracleNG matches area names **exactly, including case**. PoracleWeb.NET stores every geofence name in **lowercase** to avoid surprises — `Downtown` and `downtown` are *not* the same to PoracleNG, and a mismatch means no notifications, silently.
 
 !!! warning "If you edit the database by hand"
     You don't normally need to do anything — PoracleWeb.NET handles lowercasing. But if you ever edit area names directly in `humans.area`, `profiles.area`, or a geofence name, keep them **lowercase**.

--- a/docs/features/custom-geofences/koji-and-regions.md
+++ b/docs/features/custom-geofences/koji-and-regions.md
@@ -12,8 +12,8 @@ This page covers two operator jobs: **connecting PoracleWeb.NET to Koji**, and *
 
 Private user geofences never touch Koji — they live inside PoracleWeb.NET until (and unless) an admin promotes them.
 
-!!! info "PoracleJS/PoracleNG never talks to Koji directly"
-    PoracleWeb.NET is the only thing that talks to Koji. PoracleWeb.NET merges Koji's public areas with the private user areas and serves them as **one combined feed**. PoracleJS/PoracleNG reads that single URL. See [Troubleshooting → How the combined feed works](troubleshooting.md#how-the-combined-feed-works-background).
+!!! info "PoracleNG never talks to Koji directly"
+    PoracleWeb.NET is the only thing that talks to Koji. PoracleWeb.NET merges Koji's public areas with the private user areas and serves them as **one combined feed**. PoracleNG reads that single URL. See [Troubleshooting → How the combined feed works](troubleshooting.md#how-the-combined-feed-works-background).
 
 ## Connecting PoracleWeb.NET to Koji
 
@@ -29,10 +29,10 @@ Set these in your `.env` file:
 !!! warning "The token is read at startup"
     `KOJI_BEARER_TOKEN` is read **once when PoracleWeb.NET starts**. If you change it, **restart PoracleWeb.NET** for it to take effect.
 
-Then point your **PoracleJS/PoracleNG** bot at PoracleWeb.NET's combined feed (a single URL, not Koji) via its geofence-source setting:
+Then point your **PoracleNG** bot at PoracleWeb.NET's combined feed (a single URL, not Koji) via its geofence-source setting:
 
 ```jsonc
-// PoracleJS/PoracleNG bot — geofence source
+// PoracleNG bot — geofence source
 "geofence": {
   "path": "http://poracleweb:8082/api/geofence-feed"
 }
@@ -131,8 +131,8 @@ There are two groups. The `__`-prefixed keys are **Koji structural directives** 
 |---|---|---|
 | `name` | the user-facing display name | The friendly label shown in PoracleWeb.NET's region/area lists. Read back from Koji to label regions. |
 | `group` | the region/category label | The folder a public area is shown under in the bot's area picker. For admin geofences this is resolved from the parent chain. |
-| `parent` | the same region/category label | A duplicate of `group` that some PoracleJS/PoracleNG format serializers read instead of `group`. (This is the *custom* `parent` property — a text label — and is separate from the structural `__parent` id above.) |
-| `userSelectable` | `true` when public, `false` when private | **The visibility switch.** `true` = the area appears in the bot's `!area` picker. `false` = hidden. PoracleJS/PoracleNG also refuses to let a non-admin subscribe to a `userSelectable=false` area through its `setAreas` call, which is why private user geofences are managed entirely inside PoracleWeb.NET. |
+| `parent` | the same region/category label | A duplicate of `group` that some PoracleNG format serializers read instead of `group`. (This is the *custom* `parent` property — a text label — and is separate from the structural `__parent` id above.) |
+| `userSelectable` | `true` when public, `false` when private | **The visibility switch.** `true` = the area appears in the bot's `!area` picker. `false` = hidden. PoracleNG also refuses to let a non-admin subscribe to a `userSelectable=false` area through its `setAreas` call, which is why private user geofences are managed entirely inside PoracleWeb.NET. |
 | `displayInMatches` | `true` when public, `false` when private | Whether the **area name appears in notification DM text**. `false` keeps private geofence names out of messages. |
 
 For a **private** user geofence, PoracleWeb.NET never writes any of this to Koji — it serves the geofence from its own feed with `userSelectable=false` and `displayInMatches=false`. For an **approved (public)** geofence, both flags are set to `true` and the geofence is written into Koji as a normal public area.

--- a/docs/features/custom-geofences/private-and-promotion.md
+++ b/docs/features/custom-geofences/private-and-promotion.md
@@ -8,7 +8,7 @@ When a user draws a shape and names it, it becomes a **private geofence** straig
 
 - It works **immediately** — notifications start firing inside the shape for that user.
 - **Only that user** can see or use it. Other users have no idea it exists.
-- Its name is **hidden** from the PoracleJS/PoracleNG bot — it won't appear in the bot's `!area` picker, and the area name won't show in notification messages.
+- Its name is **hidden** from the PoracleNG bot — it won't appear in the bot's `!area` picker, and the area name won't show in notification messages.
 - It's stored **inside PoracleWeb.NET**, not in Koji.
 
 ## Staying private is a complete, valid choice

--- a/docs/features/custom-geofences/troubleshooting.md
+++ b/docs/features/custom-geofences/troubleshooting.md
@@ -18,8 +18,8 @@ Common problems operators hit, what causes them, and how to fix them. Each entry
 Work down this list:
 
 1. **Is it switched on for the right profile?** A geofence is on/off **per profile**. If the user switched profiles, it may be off on the new one. Have them check the toggle on the Geofences page for the active profile.
-2. **Is PoracleJS/PoracleNG pointed at PoracleWeb.NET's feed?** The bot's geofence-source setting must be the combined feed URL (`http://poracleweb:8082/api/geofence-feed`), **not** Koji. If it points at Koji, private geofences will be missing entirely.
-3. **Did PoracleJS/PoracleNG reload its geofences?** PoracleWeb.NET tells PoracleJS/PoracleNG to reload after changes, but if the bot was down at that moment, trigger a reload (or it'll pick it up on its next refresh).
+2. **Is PoracleNG pointed at PoracleWeb.NET's feed?** The bot's geofence-source setting must be the combined feed URL (`http://poracleweb:8082/api/geofence-feed`), **not** Koji. If it points at Koji, private geofences will be missing entirely.
+3. **Did PoracleNG reload its geofences?** PoracleWeb.NET tells PoracleNG to reload after changes, but if the bot was down at that moment, trigger a reload (or it'll pick it up on its next refresh).
 4. **Polygon too small or odd?** A shape needs at least 3 points and must be a real area. Degenerate shapes are dropped from the feed.
 
 ## Public (approved) geofences aren't showing up
@@ -38,7 +38,7 @@ flowchart TD
     F --> N[Notifications keep working;<br/>new public-area changes wait until Koji is back]
 ```
 
-PoracleJS/PoracleNG also keeps its own local cache as a second safety net.
+PoracleNG also keeps its own local cache as a second safety net.
 
 !!! warning "You can't approve while Koji is down"
     Approving a submission writes to Koji, so approvals will error until Koji is reachable again. Everything else keeps working.
@@ -59,11 +59,11 @@ Two flags control visibility, and PoracleWeb.NET sets them for you:
 | Appears in the bot's `!area` picker | No | Yes |
 | Name shown in notification DMs | No | Yes |
 
-If a **private** geofence's name is leaking into the bot picker or DMs, something is serving it as public — check that PoracleJS/PoracleNG reads PoracleWeb.NET's feed (not Koji directly), and that the geofence wasn't accidentally promoted.
+If a **private** geofence's name is leaking into the bot picker or DMs, something is serving it as public — check that PoracleNG reads PoracleWeb.NET's feed (not Koji directly), and that the geofence wasn't accidentally promoted.
 
 ## Capitalization / name-match issues
 
-PoracleJS/PoracleNG matches area names **case-sensitively**. PoracleWeb.NET always stores names in **lowercase**, so this normally just works. If you've hand-edited `humans.area`, `profiles.area`, or a geofence name in the database, make sure everything is lowercase — a single capital letter means a silent mismatch and no notifications.
+PoracleNG matches area names **case-sensitively**. PoracleWeb.NET always stores names in **lowercase**, so this normally just works. If you've hand-edited `humans.area`, `profiles.area`, or a geofence name in the database, make sure everything is lowercase — a single capital letter means a silent mismatch and no notifications.
 
 ## Removing a geofence from Koji completely
 
@@ -71,13 +71,13 @@ Deleting an approved geofence in PoracleWeb.NET removes it from the **project** 
 
 ## How the combined feed works (background)
 
-So you understand why the bot only needs one URL: PoracleWeb.NET exposes **`/api/geofence-feed`**, which merges two sources into one list for PoracleJS/PoracleNG.
+So you understand why the bot only needs one URL: PoracleWeb.NET exposes **`/api/geofence-feed`**, which merges two sources into one list for PoracleNG.
 
 ```mermaid
 flowchart LR
     Koji[(Koji<br/>public areas)] -->|cached 5 min| Feed
     DB[(PoracleWeb.NET DB<br/>private user geofences)] --> Feed
-    Feed["/api/geofence-feed<br/>combined list"] -->|single URL| PJS[PoracleJS / PoracleNG]
+    Feed["/api/geofence-feed<br/>combined list"] -->|single URL| PJS[PoracleNG]
 ```
 
 - **Public** entries come from Koji, marked visible/selectable.
@@ -85,4 +85,4 @@ flowchart LR
 - Region/parent geofences are filtered out (they're folders, not areas).
 
 !!! warning "Keep the feed on a private network"
-    The feed endpoint is open (no login) so PoracleJS/PoracleNG can read it on your internal network. Don't expose it to the internet.
+    The feed endpoint is open (no login) so PoracleNG can read it on your internal network. Don't expose it to the internet.

--- a/docs/getting-started/standalone-setup.md
+++ b/docs/getting-started/standalone-setup.md
@@ -187,7 +187,7 @@ journalctl -u poracleweb -f
 
 Place your `.env` file in `/opt/poracleweb/` (the `WorkingDirectory`) and the app will pick it up automatically.
 
-### pm2 (if you're already using it for PoracleJS)
+### pm2
 
 ```bash
 cd /opt/poracleweb


### PR DESCRIPTION
Closes #726

Full sweep across 9 files. Every \PoracleJS/PoracleNG\ and standalone \PoracleJS\ reference replaced with \PoracleNG\.

Two intentional occurrences remain:
- The \PoracleNG is required\ warning in README.md (which links to PoracleJS to say it is *not* supported)
- The credits attribution in README.md

**Files changed:** README.md, docs/architecture/database.md, docs/getting-started/standalone-setup.md, docs/features/custom-geofences/admin-operations.md, docs/features/custom-geofences/index.md, docs/features/custom-geofences/key-concepts.md, docs/features/custom-geofences/koji-and-regions.md, docs/features/custom-geofences/private-and-promotion.md, docs/features/custom-geofences/troubleshooting.md