### PR TITLE
fix(where): edit dialogs use the shared picker, and a usable map

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/areas/area-list.component.scss
@@ -290,10 +290,35 @@
 }
 
 // ─── Map View ─────────────────────────────────────────
+// Matches My Geofences: same size, same framing, same margins. The picker was letting the child
+// decide its own height, which left a map too small to pick an area out of.
 .map-container {
-  border-radius: 12px;
   border: 1px solid var(--card-border, rgba(0, 0, 0, 0.12));
-  overflow: visible;
+  border-radius: 12px;
+  height: 70vh;
+  margin: 16px 24px;
+  min-height: 500px;
+  overflow: hidden;
+
+  app-area-map {
+    display: block;
+    height: 100%;
+  }
+
+  ::ng-deep {
+    .map-wrapper {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    .area-map-container {
+      border: none !important;
+      border-radius: 0 !important;
+      flex: 1;
+      height: auto !important;
+    }
+  }
 }
 
 .map-hint {

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.html
@@ -39,55 +39,7 @@
         <span class="tab-label">{{ 'RAIDS.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/fort-changes/fort-change-edit-dialog.component.ts
@@ -17,9 +17,9 @@ import { FortChange, FortChangeUpdate } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { FortChangeService } from '../../core/services/fort-change.service';
 import { I18nService } from '../../core/services/i18n.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 
 @Component({
   imports: [
@@ -37,8 +37,7 @@ import { WhereChipComponent } from '../../shared/components/where-chip/where-chi
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-fort-change-edit-dialog',
   standalone: true,
@@ -52,14 +51,13 @@ export class FortChangeEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<FortChange>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<FortChangeEditDialogComponent>);
+
   form = this.fb.group({
     changeTypeImageUrl: [this.data.changeTypes?.includes('image_url') ?? false],
     changeTypeLocation: [this.data.changeTypes?.includes('location') ?? false],
     changeTypeName: [this.data.changeTypes?.includes('name') ?? false],
     changeTypeNew: [this.data.changeTypes?.includes('new') ?? false],
     changeTypeRemoval: [this.data.changeTypes?.includes('removal') ?? false],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     fortType: [this.data.fortType ?? 'everything'],
     includeEmpty: [this.data.includeEmpty === 1],
     template: [this.data.template ?? ''],
@@ -69,20 +67,13 @@ export class FortChangeEditDialogComponent {
 
   saving = signal(false);
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') this.form.controls.distanceKm.setValue(0);
-    else if (!this.form.controls.distanceKm.value) this.form.controls.distanceKm.setValue(1);
-  }
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
 
   save(): void {
     this.saving.set(true);
     const v = this.form.getRawValue();
-    const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     const changeTypes: string[] = [];
     if (v.changeTypeName) changeTypes.push('name');
     if (v.changeTypeLocation) changeTypes.push('location');
@@ -92,8 +83,10 @@ export class FortChangeEditDialogComponent {
 
     this.fortChangeService
       .update(this.data.uid, {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         changeTypes,
-        distance: dist,
+        distance: scope.distance,
         fortType: v.fortType,
         includeEmpty: v.includeEmpty ? 1 : 0,
         template: v.template || '',

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.html
@@ -31,55 +31,7 @@
         <span class="tab-label">{{ 'POKEMON.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/gyms/gym-edit-dialog.component.ts
@@ -15,10 +15,10 @@ import { Gym, GymUpdate } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { GymService } from '../../core/services/gym.service';
 import { I18nService } from '../../core/services/i18n.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
 import { GymPickerComponent } from '../../shared/components/gym-picker/gym-picker.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -35,9 +35,8 @@ import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-fl
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
     GymPickerComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-gym-edit-dialog',
   standalone: true,
@@ -51,11 +50,10 @@ export class GymEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<Gym>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<GymEditDialogComponent>);
+
   form = this.fb.group({
     battleChanges: [this.data.battleChanges === 1],
     clean: [isAutoDelete(this.data.clean)],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     slotChanges: [this.data.slotChanges === 1],
     template: [this.data.template ?? ''],
   });
@@ -63,6 +61,9 @@ export class GymEditDialogComponent {
   readonly isWebhook = inject(AuthService).isImpersonating();
 
   saving = signal(false);
+
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
   selectedGymId = signal<string | null>(this.data.gymId);
   getGymIcon(): string {
     return `https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/gym/${this.data.team}.png`;
@@ -83,25 +84,17 @@ export class GymEditDialogComponent {
     }
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') this.form.controls.distanceKm.setValue(0);
-    else if (!this.form.controls.distanceKm.value) this.form.controls.distanceKm.setValue(1);
-  }
-
   save(): void {
     this.saving.set(true);
     const v = this.form.getRawValue();
-    const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     this.gymService
       .update(this.data.uid, {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         battleChanges: v.battleChanges ? 1 : 0,
         clean: preserve(this.data.clean, AUTO_DELETE, v.clean ? 1 : 0),
-        distance: dist,
+        distance: scope.distance,
         gymId: this.selectedGymId() ?? '',
         slotChanges: v.slotChanges ? 1 : 0,
         team: this.data.team,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.html
@@ -52,55 +52,7 @@
         <span class="tab-label">{{ 'ALARM.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/invasions/invasion-edit-dialog.component.ts
@@ -18,9 +18,9 @@ import { Invasion, InvasionUpdate } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { InvasionService } from '../../core/services/invasion.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -38,8 +38,7 @@ import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-fl
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-invasion-edit-dialog',
   standalone: true,
@@ -55,18 +54,20 @@ export class InvasionEditDialogComponent {
   readonly data = inject<Invasion>(MAT_DIALOG_DATA);
 
   readonly dialogRef = inject(MatDialogRef<InvasionEditDialogComponent>);
+
   form = this.fb.group({
     clean: [isAutoDelete(this.data.clean)],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     gender: [this.data.gender],
     template: [this.data.template ?? ''],
   });
 
   readonly hideGender = isGenderFixed(this.data.gruntType);
+
   readonly isEvent = isEventType(this.data.gruntType);
   readonly isWebhook = inject(AuthService).isImpersonating();
   saving = signal(false);
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
   readonly selectedGender = toSignal(this.form.controls.gender.valueChanges, { initialValue: this.data.gender });
 
   getDisplayName(): string {
@@ -100,24 +101,16 @@ export class InvasionEditDialogComponent {
     return getGruntIconUrl(this.data.gruntType, this.selectedGender());
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') this.form.controls.distanceKm.setValue(0);
-    else if (!this.form.controls.distanceKm.value) this.form.controls.distanceKm.setValue(1);
-  }
-
   save(): void {
     this.saving.set(true);
     const v = this.form.getRawValue();
-    const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     this.invasionService
       .update(this.data.uid, {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         clean: preserve(this.data.clean, AUTO_DELETE, v.clean ? 1 : 0),
-        distance: dist,
+        distance: scope.distance,
         // Preserve the stored gender when the dropdown is hidden — a Mixed Male alarm
         // (gender=1) must stay at 1 across edits; zeroing it would widen the filter to
         // also match female Mixed grunts.

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.html
@@ -28,55 +28,7 @@
         <span class="tab-label">{{ 'POKEMON.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/lures/lure-edit-dialog.component.ts
@@ -15,9 +15,9 @@ import { Lure, LureUpdate } from '../../core/models';
 import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { LureService } from '../../core/services/lure.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, compose, EDIT, isAutoDelete, isEdit, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -34,8 +34,7 @@ import { AUTO_DELETE, compose, EDIT, isAutoDelete, isEdit, preserve } from '../.
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-lure-edit-dialog',
   standalone: true,
@@ -49,10 +48,9 @@ export class LureEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<Lure>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<LureEditDialogComponent>);
+
   form = this.fb.group({
     clean: [isAutoDelete(this.data.clean)],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     editInPlace: [isEdit(this.data.clean)],
     template: [this.data.template ?? ''],
   });
@@ -60,6 +58,9 @@ export class LureEditDialogComponent {
   readonly isWebhook = inject(AuthService).isImpersonating();
 
   saving = signal(false);
+
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
   getLureIcon(): string {
     return `https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons/reward/item/${this.data.lureId}.png`;
   }
@@ -83,26 +84,18 @@ export class LureEditDialogComponent {
     }
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') this.form.controls.distanceKm.setValue(0);
-    else if (!this.form.controls.distanceKm.value) this.form.controls.distanceKm.setValue(1);
-  }
-
   save(): void {
     this.saving.set(true);
     const v = this.form.getRawValue();
-    const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     this.lureService
       .update(this.data.uid, {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         // Only bits 1 (auto-delete) and 2 (edit-in-place) are user-editable here; preserve
         // any summary bit (4) or future bits the bot may have set on this alarm.
         clean: preserve(this.data.clean, AUTO_DELETE | EDIT, compose(!!v.clean, !!v.editInPlace, false)),
-        distance: dist,
+        distance: scope.distance,
         lureId: this.data.lureId,
         template: v.template || '',
       } as LureUpdate)

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.html
@@ -57,55 +57,7 @@
         <span class="tab-label">{{ 'RAIDS.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.item.distance"
-            [editable]="false"
-            [overrideAreas]="data.item.overrideAreas"
-            [overrideLocationLabel]="data.item.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.spec.ts
@@ -78,8 +78,7 @@ describe('MaxBattleEditDialogComponent — filter preservation (#412)', () => {
 
   it('keeps the move filter when only the distance changes', () => {
     const { component, sent } = setup();
-    component.form.controls.distanceMode.setValue('distance');
-    component.form.controls.distanceKm.setValue(8);
+    component.scope.set({ distanceKm: 8, mode: 'profile' });
 
     component.save();
 
@@ -89,8 +88,7 @@ describe('MaxBattleEditDialogComponent — filter preservation (#412)', () => {
 
   it('keeps the evolution filter when only the distance changes', () => {
     const { component, sent } = setup();
-    component.form.controls.distanceMode.setValue('distance');
-    component.form.controls.distanceKm.setValue(8);
+    component.scope.set({ distanceKm: 8, mode: 'profile' });
 
     component.save();
 
@@ -100,8 +98,7 @@ describe('MaxBattleEditDialogComponent — filter preservation (#412)', () => {
 
   it('still sends the edited distance', () => {
     const { component, sent } = setup();
-    component.form.controls.distanceMode.setValue('distance');
-    component.form.controls.distanceKm.setValue(8);
+    component.scope.set({ distanceKm: 8, mode: 'profile' });
 
     component.save();
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/max-battles/max-battle-edit-dialog.component.ts
@@ -18,9 +18,9 @@ import { I18nService } from '../../core/services/i18n.service';
 import { IconService } from '../../core/services/icon.service';
 import { MasterDataService } from '../../core/services/masterdata.service';
 import { MaxBattleService } from '../../core/services/max-battle.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 export interface MaxBattleEditDialogData {
@@ -60,8 +60,7 @@ const LEVEL_OPTION_KEYS: { gmax: boolean; i18nKey: string; value: number }[] = [
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-max-battle-edit-dialog',
   standalone: true,
@@ -81,14 +80,13 @@ export class MaxBattleEditDialogComponent {
 
   form = this.fb.group({
     clean: [isAutoDelete(this.data.item.clean)],
-    distanceKm: [this.data.item.distance > 0 ? this.data.item.distance / 1000 : 1],
-    distanceMode: [this.data.item.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     gmax: [this.data.item.gmax === 1],
     level: [this.data.item.level],
     template: [this.data.item.template ?? ''],
   });
 
   readonly isLevelBased = this.data.item.pokemonId === 9000;
+
   readonly isWebhook = inject(AuthService).isImpersonating();
   readonly levelOptions: MaxBattleLevelOption[] = LEVEL_OPTION_KEYS.map(k => ({
     gmax: k.gmax,
@@ -97,6 +95,9 @@ export class MaxBattleEditDialogComponent {
   }));
 
   saving = signal(false);
+
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.item.overrideLocationLabel, this.data.item.overrideAreas, this.data.item.distance));
 
   getImage(): string {
     const item = this.data.item;
@@ -121,23 +122,8 @@ export class MaxBattleEditDialogComponent {
     return this.i18n.instant('MAX_BATTLES.ANY_POKEMON');
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.item.overrideAreas?.length ?? 0) > 0;
-  }
-
   isGmax(): boolean {
     return this.data.item.gmax === 1 || this.data.item.level === 7 || this.data.item.level === 8;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') {
-      this.form.controls.distanceKm.setValue(0);
-    } else {
-      if (!this.form.controls.distanceKm.value) {
-        this.form.controls.distanceKm.setValue(1);
-      }
-    }
   }
 
   onImageError(event: Event): void {
@@ -147,7 +133,7 @@ export class MaxBattleEditDialogComponent {
   save(): void {
     this.saving.set(true);
     const values = this.form.getRawValue();
-    const distanceMeters = values.distanceMode === 'areas' ? 0 : Math.round((values.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
 
     const item = this.data.item;
     const levelVal = this.isLevelBased ? (values.level ?? item.level) : 9000;
@@ -157,8 +143,10 @@ export class MaxBattleEditDialogComponent {
     const gmaxVal = this.isLevelBased ? (levelDef?.gmax ? 1 : 0) : values.gmax ? 1 : 0;
 
     const update: MaxBattleUpdate = {
+      overrideAreas: scope.overrideAreas,
+      overrideLocationLabel: scope.overrideLocationLabel,
       clean: preserve(item.clean, AUTO_DELETE, values.clean ? 1 : 0),
-      distance: distanceMeters,
+      distance: scope.distance,
       // Carried through from the existing alarm, not reset to the 9000 "any" sentinel. Neither
       // dialog can set these -- they come from the bot -- so hardcoding 9000 here meant any
       // unrelated edit, a distance change included, silently destroyed the user's filter and

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.html
@@ -30,55 +30,7 @@
         <span class="tab-label">{{ 'POKEMON.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/nests/nest-edit-dialog.component.ts
@@ -17,9 +17,9 @@ import { I18nService } from '../../core/services/i18n.service';
 import { IconService } from '../../core/services/icon.service';
 import { MasterDataService } from '../../core/services/masterdata.service';
 import { NestService } from '../../core/services/nest.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -36,8 +36,7 @@ import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-fl
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-nest-edit-dialog',
   standalone: true,
@@ -53,10 +52,9 @@ export class NestEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<Nest>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<NestEditDialogComponent>);
+
   form = this.fb.group({
     clean: [isAutoDelete(this.data.clean)],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     minSpawnAvg: [this.data.minSpawnAvg],
     template: [this.data.template ?? ''],
   });
@@ -64,19 +62,12 @@ export class NestEditDialogComponent {
   readonly isWebhook = inject(AuthService).isImpersonating();
 
   pokemonName = this.masterData.getPokemonName(this.data.pokemonId);
+
   saving = signal(false);
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
   getPokemonImage(): string {
     return this.iconService.getPokemonUrl(this.data.pokemonId);
-  }
-
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') this.form.controls.distanceKm.setValue(0);
-    else if (!this.form.controls.distanceKm.value) this.form.controls.distanceKm.setValue(1);
   }
 
   onImageError(event: Event): void {
@@ -86,11 +77,13 @@ export class NestEditDialogComponent {
   save(): void {
     this.saving.set(true);
     const v = this.form.getRawValue();
-    const dist = v.distanceMode === 'areas' ? 0 : Math.round((v.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     this.nestService
       .update(this.data.uid, {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         clean: preserve(this.data.clean, AUTO_DELETE, v.clean ? 1 : 0),
-        distance: dist,
+        distance: scope.distance,
         minSpawnAvg: v.minSpawnAvg ?? 0,
         pokemonId: this.data.pokemonId,
         template: v.template || '',

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.html
@@ -239,55 +239,7 @@
         <span class="tab-label">{{ 'POKEMON.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive, so the two-way control below cannot describe
-               this alarm. Showing it would offer a change that silently discards the areas. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.ts
@@ -21,9 +21,9 @@ import { IconService } from '../../core/services/icon.service';
 import { MasterDataService } from '../../core/services/masterdata.service';
 import { MonsterService } from '../../core/services/monster.service';
 import { PoracleConfigService } from '../../core/services/poracle-config.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -42,9 +42,8 @@ import { AUTO_DELETE, isAutoDelete, preserve } from '../../shared/utils/clean-fl
     MatTabsModule,
     MatSnackBarModule,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
     TranslatePipe,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-pokemon-edit-dialog',
   standalone: true,
@@ -70,8 +69,6 @@ export class PokemonEditDialogComponent implements OnInit {
     atk: [this.data.atk],
     clean: [isAutoDelete(this.data.clean)],
     def: [this.data.def],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     form: [this.data.form],
     gender: [this.data.gender],
     maxAtk: [this.data.maxAtk],
@@ -89,7 +86,6 @@ export class PokemonEditDialogComponent implements OnInit {
     // Read-only here on purpose: an alarm's place or areas are changed from the card chip, which is one
     // control in one place. This dialog only has to avoid destroying them, which it does by keeping
     // the stored label and sending the radius against it.
-    placeLabel: [this.data.overrideLocationLabel ?? ''],
     pvpRankingBest: [this.data.pvpRankingBest],
     pvpRankingCap: [this.data.pvpRankingCap ?? 0],
     // 0 base, 1 any mega, 2 Mega X, 3 Mega Y — PoracleNG's pvp_ranking_evolution.
@@ -110,29 +106,17 @@ export class PokemonEditDialogComponent implements OnInit {
 
   saving = signal(false);
 
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
+
   readonly showCapPicker = computed(() => this.pvpCaps().length > 1);
 
   getPokemonImage(): string {
     return this.iconService.getPokemonUrl(this.data.pokemonId, this.data.form);
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
   ngOnInit(): void {
     this.poracleConfig.load().subscribe();
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') {
-      this.form.controls.distanceKm.setValue(0);
-    } else {
-      if (!this.form.controls.distanceKm.value) {
-        this.form.controls.distanceKm.setValue(1);
-      }
-    }
   }
 
   onImageError(event: Event): void {
@@ -149,21 +133,15 @@ export class PokemonEditDialogComponent implements OnInit {
     this.saving.set(true);
     const values = this.form.getRawValue();
 
-    // An alarm confined to areas has no radius, so the two-way control above cannot describe it and
-    // must not overwrite it. Leaving the fields out entirely means the API keeps what is stored: null
-    // reads as "not stated" on the write path, which is exactly what this dialog means. See #730.
-    const keepsAreas = (this.data.overrideAreas?.length ?? 0) > 0;
-    const distanceMeters = keepsAreas
-      ? this.data.distance
-      : values.distanceMode === 'areas'
-        ? 0
-        : Math.round((values.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
 
     const update: MonsterUpdate = {
+      overrideAreas: scope.overrideAreas,
+      overrideLocationLabel: scope.overrideLocationLabel,
       atk: values.atk ?? 0,
       clean: preserve(this.data.clean, AUTO_DELETE, values.clean ? 1 : 0),
       def: values.def ?? 0,
-      distance: distanceMeters,
+      distance: scope.distance,
       form: values.form ?? 0,
       gender: values.gender ?? 0,
       maxAtk: values.maxAtk ?? 15,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.html
@@ -33,55 +33,7 @@
         <span class="tab-label">{{ 'ALARM.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.distance"
-            [editable]="false"
-            [overrideAreas]="data.overrideAreas"
-            [overrideLocationLabel]="data.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/quest-edit-dialog.component.ts
@@ -18,9 +18,9 @@ import { IconService } from '../../core/services/icon.service';
 import { MasterDataService } from '../../core/services/masterdata.service';
 import { QuestService } from '../../core/services/quest.service';
 import { SummaryScheduleService } from '../../core/services/summary-schedule.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, compose, isAutoDelete, isSummary, preserve, SUMMARY } from '../../shared/utils/clean-flags';
 
 @Component({
@@ -37,8 +37,7 @@ import { AUTO_DELETE, compose, isAutoDelete, isSummary, preserve, SUMMARY } from
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-quest-edit-dialog',
   standalone: true,
@@ -57,10 +56,9 @@ export class QuestEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<Quest>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<QuestEditDialogComponent>);
+
   form = this.fb.group({
     clean: [isAutoDelete(this.data.clean)],
-    distanceKm: [this.data.distance > 0 ? this.data.distance / 1000 : 1],
-    distanceMode: [this.data.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     summary: [isSummary(this.data.clean)],
     template: [this.data.template ?? ''],
   });
@@ -68,6 +66,9 @@ export class QuestEditDialogComponent {
   readonly isWebhook = inject(AuthService).isImpersonating();
 
   saving = signal(false);
+
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.overrideLocationLabel, this.data.overrideAreas, this.data.distance));
 
   readonly summaryService = inject(SummaryScheduleService);
 
@@ -131,21 +132,6 @@ export class QuestEditDialogComponent {
     return this.getRewardTypeLabel();
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') {
-      this.form.controls.distanceKm.setValue(0);
-    } else {
-      if (!this.form.controls.distanceKm.value) {
-        this.form.controls.distanceKm.setValue(1);
-      }
-    }
-  }
-
   onImageError(event: Event): void {
     (event.target as HTMLImageElement).style.display = 'none';
   }
@@ -157,11 +143,13 @@ export class QuestEditDialogComponent {
   save(): void {
     this.saving.set(true);
     const values = this.form.getRawValue();
-    const distanceMeters = values.distanceMode === 'areas' ? 0 : Math.round((values.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
 
     const update: QuestUpdate = {
+      overrideAreas: scope.overrideAreas,
+      overrideLocationLabel: scope.overrideLocationLabel,
       clean: preserve(this.data.clean, AUTO_DELETE | SUMMARY, compose(!!values.clean, false, !!values.summary)),
-      distance: distanceMeters,
+      distance: scope.distance,
       pokemonId: this.data.pokemonId,
       reward: this.data.reward,
       rewardType: this.data.rewardType,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.html
@@ -52,55 +52,7 @@
         <span class="tab-label">{{ 'RAIDS.TAB_DELIVERY' | translate }}</span>
       </ng-template>
       <div class="tab-content">
-        <h4>{{ 'ALARM.LOCATION_MODE' | translate }}</h4>
-
-        <p class="scope-current">
-          <app-where-chip
-            [distance]="data.item.distance"
-            [editable]="false"
-            [overrideAreas]="data.item.overrideAreas"
-            [overrideLocationLabel]="data.item.overrideLocationLabel" />
-          <span class="scope-hint">{{ 'WHERE.EDIT_FROM_CARD' | translate }}</span>
-        </p>
-
-        @if (isAreaScoped()) {
-          <!-- Areas and a radius are mutually exclusive upstream, so this control cannot describe an
-               area-confined alarm. Offering it would let a save send both and be refused. -->
-        } @else {
-          <mat-radio-group [formControl]="form.controls.distanceMode" class="distance-radio-group" (change)="onDistanceModeChange()">
-            <mat-radio-button value="areas">
-              <div class="radio-label">
-                <mat-icon>map</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.USE_AREAS' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.USE_AREAS_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-            <mat-radio-button value="distance">
-              <div class="radio-label">
-                <mat-icon>straighten</mat-icon>
-                <div>
-                  <strong>{{ 'ALARM.SET_DISTANCE' | translate }}</strong>
-                  <p class="radio-hint">{{ 'ALARM.SET_DISTANCE_HINT' | translate }}</p>
-                </div>
-              </div>
-            </mat-radio-button>
-          </mat-radio-group>
-
-          @if (form.controls.distanceMode.value === 'distance') {
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'ALARM.DISTANCE_LABEL' | translate }}</mat-label>
-              <input matInput type="number" [formControl]="form.controls.distanceKm" min="0" step="0.1" />
-              <span matSuffix>{{ 'ALARM.DISTANCE_SUFFIX' | translate }}</span>
-            </mat-form-field>
-          }
-
-          <app-delivery-preview
-            [mode]="form.controls.distanceMode.value === 'areas' ? 'areas' : 'distance'"
-            [distanceKm]="form.controls.distanceKm.value ?? 0">
-          </app-delivery-preview>
-        }
+        <app-scope-picker [(scope)]="scope" />
 
         <h4>{{ 'ALARM.MESSAGE_SETTINGS' | translate }}</h4>
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/raids/raid-edit-dialog.component.ts
@@ -18,12 +18,12 @@ import { EggService } from '../../core/services/egg.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { IconService } from '../../core/services/icon.service';
 import { RaidService } from '../../core/services/raid.service';
-import { DeliveryPreviewComponent } from '../../shared/components/delivery-preview/delivery-preview.component';
 import { GymPickerComponent } from '../../shared/components/gym-picker/gym-picker.component';
 import { RsvpToggleComponent } from '../../shared/components/rsvp-toggle/rsvp-toggle.component';
+import { ScopePickerComponent } from '../../shared/components/scope-picker/scope-picker.component';
 import { TemplateSelectorComponent } from '../../shared/components/template-selector/template-selector.component';
-import { WhereChipComponent } from '../../shared/components/where-chip/where-chip.component';
 import { LevelLabelPipe } from '../../shared/pipes/level-label.pipe';
+import { AlarmScope, scopeOf, scopeToFields } from '../../shared/utils/alarm-scope';
 import { AUTO_DELETE, EDIT, isAutoDelete } from '../../shared/utils/clean-flags';
 
 export interface RaidEditDialogData {
@@ -47,11 +47,10 @@ export interface RaidEditDialogData {
     MatSnackBarModule,
     TranslatePipe,
     TemplateSelectorComponent,
-    DeliveryPreviewComponent,
     GymPickerComponent,
     RsvpToggleComponent,
     LevelLabelPipe,
-    WhereChipComponent,
+    ScopePickerComponent,
   ],
   selector: 'app-raid-edit-dialog',
   standalone: true,
@@ -68,10 +67,9 @@ export class RaidEditDialogComponent {
   private readonly snackBar = inject(MatSnackBar);
   readonly data = inject<RaidEditDialogData>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<RaidEditDialogComponent>);
+
   form = this.fb.group({
     clean: [isAutoDelete(this.data.item.clean)],
-    distanceKm: [this.data.item.distance > 0 ? this.data.item.distance / 1000 : 1],
-    distanceMode: [this.data.item.distance === 0 ? 'areas' : ('distance' as 'areas' | 'distance')],
     rsvpChanges: [this.data.item.rsvpChanges],
     team: [this.data.item.team],
     template: [this.data.item.template ?? ''],
@@ -80,6 +78,9 @@ export class RaidEditDialogComponent {
   readonly isWebhook = inject(AuthService).isImpersonating();
 
   saving = signal(false);
+
+  /** The alarm's current scope, read back into the shared picker. */
+  readonly scope = signal<AlarmScope>(scopeOf(this.data.item.overrideLocationLabel, this.data.item.overrideAreas, this.data.item.distance));
   selectedGymId = signal<string | null>(this.data.item.gymId);
 
   getImage(): string {
@@ -104,21 +105,6 @@ export class RaidEditDialogComponent {
     return this.levelLabelPipe.transform(raid.level) + ' ' + this.i18n.instant('RAIDS.RAID_SUFFIX');
   }
 
-  /** True when the alarm is confined to areas, which the areas-or-distance control cannot express. */
-  isAreaScoped(): boolean {
-    return (this.data.item.overrideAreas?.length ?? 0) > 0;
-  }
-
-  onDistanceModeChange(): void {
-    if (this.form.controls.distanceMode.value === 'areas') {
-      this.form.controls.distanceKm.setValue(0);
-    } else {
-      if (!this.form.controls.distanceKm.value) {
-        this.form.controls.distanceKm.setValue(1);
-      }
-    }
-  }
-
   onImageError(event: Event): void {
     (event.target as HTMLImageElement).style.display = 'none';
   }
@@ -126,7 +112,7 @@ export class RaidEditDialogComponent {
   save(): void {
     this.saving.set(true);
     const values = this.form.getRawValue();
-    const distanceMeters = values.distanceMode === 'areas' ? 0 : Math.round((values.distanceKm ?? 1) * 1000);
+    const scope = scopeToFields(this.scope());
     // clean is a PoracleNG bitmask: bit 1 = auto-delete, bit 2 = edit-in-place, bit 4 = summary.
     // RSVP modes (1/2) need the edit bit so count changes edit the alert instead of re-sending.
     // Preserve any other bits (e.g. bot-set summary) the web UI does not surface.
@@ -136,8 +122,10 @@ export class RaidEditDialogComponent {
     if (this.data.type === 'raid') {
       const raid = this.data.item as Raid;
       const update: RaidUpdate = {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         clean,
-        distance: distanceMeters,
+        distance: scope.distance,
         evolution: raid.evolution,
         exclusive: raid.exclusive,
         form: raid.form,
@@ -166,8 +154,10 @@ export class RaidEditDialogComponent {
     } else {
       const egg = this.data.item as Egg;
       const update: EggUpdate = {
+        overrideAreas: scope.overrideAreas,
+        overrideLocationLabel: scope.overrideLocationLabel,
         clean,
-        distance: distanceMeters,
+        distance: scope.distance,
         exclusive: egg.exclusive,
         gymId: this.selectedGymId() ?? '',
         level: egg.level,

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Tilføj et sted",
     "AREAS_LABEL": "Områder",
     "AREA_LIST_MORE": "{{areas}} og {{count}} mere",
-    "EDIT_FROM_CARD": "Ændr det fra kortet.",
     "MEASURED_FROM": "Målt fra",
     "MY_PIN": "Min position",
     "NAME_PLACE_MESSAGE": "Hvad skal stedet hedde?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Ort hinzufügen",
     "AREAS_LABEL": "Gebiete",
     "AREA_LIST_MORE": "{{areas}} und {{count}} weitere",
-    "EDIT_FROM_CARD": "Änderbar über die Karte.",
     "MEASURED_FROM": "Gemessen ab",
     "MY_PIN": "Mein Standort",
     "NAME_PLACE_MESSAGE": "Wie soll dieser Ort heißen?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1727,7 +1727,6 @@
     "PLACES_EMPTY_TITLE": "No places yet",
     "PIN_UNSET": "Not set",
     "PLACES_PAGE_DESC": "Named points your alerts can be aimed at, instead of your pin.",
-    "EDIT_FROM_CARD": "Change this from the card.",
     "MEASURED_FROM": "Measured from",
     "SCOPE_SAVED": "Where updated.",
     "SCOPE_SAVE_ERROR": "Could not update where that alert reaches you.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Añadir un lugar",
     "AREAS_LABEL": "Áreas",
     "AREA_LIST_MORE": "{{areas}} y {{count}} más",
-    "EDIT_FROM_CARD": "Cámbialo desde la tarjeta.",
     "MEASURED_FROM": "Medido desde",
     "MY_PIN": "Mi ubicación",
     "NAME_PLACE_MESSAGE": "¿Cómo quieres llamar a este lugar?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Ajouter un lieu",
     "AREAS_LABEL": "Zones",
     "AREA_LIST_MORE": "{{areas}} et {{count}} autres",
-    "EDIT_FROM_CARD": "Modifiable depuis la carte.",
     "MEASURED_FROM": "Mesuré depuis",
     "MY_PIN": "Ma position",
     "NAME_PLACE_MESSAGE": "Comment nommer ce lieu ?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Aggiungi un luogo",
     "AREAS_LABEL": "Aree",
     "AREA_LIST_MORE": "{{areas}} e altre {{count}}",
-    "EDIT_FROM_CARD": "Modificalo dalla scheda.",
     "MEASURED_FROM": "Misurato da",
     "MY_PIN": "La mia posizione",
     "NAME_PLACE_MESSAGE": "Come vuoi chiamare questo luogo?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Plaats toevoegen",
     "AREAS_LABEL": "Gebieden",
     "AREA_LIST_MORE": "{{areas}} en nog {{count}}",
-    "EDIT_FROM_CARD": "Wijzig dit vanaf de kaart.",
     "MEASURED_FROM": "Gemeten vanaf",
     "MY_PIN": "Mijn locatie",
     "NAME_PLACE_MESSAGE": "Hoe moet deze plaats heten?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Dodaj miejsce",
     "AREAS_LABEL": "Obszary",
     "AREA_LIST_MORE": "{{areas}} i jeszcze {{count}}",
-    "EDIT_FROM_CARD": "Zmienisz to z karty.",
     "MEASURED_FROM": "Mierzone od",
     "MY_PIN": "Moja lokalizacja",
     "NAME_PLACE_MESSAGE": "Jak nazwać to miejsce?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Adicionar um local",
     "AREAS_LABEL": "Áreas",
     "AREA_LIST_MORE": "{{areas}} e mais {{count}}",
-    "EDIT_FROM_CARD": "Altere isso pelo card.",
     "MEASURED_FROM": "Medido a partir de",
     "MY_PIN": "Minha localização",
     "NAME_PLACE_MESSAGE": "Que nome dar a este local?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Adicionar um local",
     "AREAS_LABEL": "Áreas",
     "AREA_LIST_MORE": "{{areas}} e mais {{count}}",
-    "EDIT_FROM_CARD": "Altera isto a partir do cartão.",
     "MEASURED_FROM": "Medido a partir de",
     "MY_PIN": "A minha localização",
     "NAME_PLACE_MESSAGE": "Que nome dar a este local?",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -1730,7 +1730,6 @@
     "ADD_PLACE": "Lägg till en plats",
     "AREAS_LABEL": "Områden",
     "AREA_LIST_MORE": "{{areas}} och {{count}} till",
-    "EDIT_FROM_CARD": "Ändra det från kortet.",
     "MEASURED_FROM": "Mätt från",
     "MY_PIN": "Min position",
     "NAME_PLACE_MESSAGE": "Vad ska platsen heta?",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Editing an alarm uses the same scope control as creating one.** The edit dialogs kept the old two-option version, which could not describe an alarm confined to areas and so showed it read-only. All twenty dialogs now render the one control, so the same three options are available wherever the question is asked ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
+
 - **The Delivery tab and the card's scope picker are the same control.** They were two different shapes of the same question, and the dialog version was missing an option: "only in specific areas" could not be chosen when creating an alarm, only afterwards from the card. Both now render one component, so a new alarm can be confined to areas from the start, and picking your pin when you have not set one says so instead of alerting on nothing ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 - **Alert language shows flag rows, matching display language.** The two menus sit next to each other and now look like siblings, which is the only way the difference between them reads at a glance ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
@@ -29,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New Pokemon alarms can be aimed at a saved place.** The delivery step's radius gains a "measured from" selector: your pin, as before, or any place you have saved. Editing an alarm shows its scope but sends you to the card to change it, so there is one way to do it rather than two that can disagree ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
 ### Fixed
+
+- **The map on Areas & Places is the size it should be.** It let the child component pick its own height and came out too small to find an area in. It now matches My Geofences: same height, framing and margins ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
 - **Clearing your pin no longer comes back as 0,0.** Poracle stores "no pin" as 0,0 rather than null, so the page cleared correctly and then read those coordinates back at face value on the next visit and rendered them. The rule now lives in one helper instead of being rewritten in half a dozen components. The pin's section is also labelled My pin, matching what the rest of the site calls it ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 - **The area map opens on your pin.** It ranked the selected areas above it, and a multi-area selection frames a whole region, so the map opened too far out to click anything. Your own drawn shapes still win on My Geofences, where they are what you came for ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).


### PR DESCRIPTION
The two things I owed you from the last round.

## Edit dialogs

All ten now render `ScopePickerComponent` — the same control the add dialogs and the card sheet use. Twenty dialogs, one control.

They had kept the old two-option version, which is *why* they showed the scope read-only and hid the control entirely for area-confined alarms: that control could not describe those, and offering it would have let a save send areas and a radius together, which PoracleNG refuses. With a control that can express all three states, neither workaround is needed and both are gone.

On method, since I broke this last time: the script verifies every piece is where it expects **before writing anything**, and skips the file otherwise. Five of eight skipped on the first pass because they compute distance differently (`const dist` rather than `const distanceMeters`), and were converted separately rather than guessed at. One still needed a hand-fix afterwards, which is the honest cost of scripting this at all.

`WHERE.EDIT_FROM_CARD` is removed from all eleven locales — it told people to change scope from the card, which is no longer the only place.

## Map

The Areas & Places map container set no height and let the child component decide, which is why it came out too small to find anything in. It now matches My Geofences exactly: 70vh with a 500px floor, same margins, same framing, same overflow handling.

## Verification

Build clean, 1033 tests passing, no locale gaps, eslint and prettier clean.

Three max-battle edit tests drove the removed form controls. They drive the picker's signal now; their assertions are untouched, which is the point — they still assert the filters survive a distance-only edit.