### PR TITLE
fix(pvp): style the mega evolution fieldset like its sibling

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-add-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-add-dialog.component.html
@@ -234,8 +234,8 @@
             </fieldset>
           }
 
-          <fieldset class="pvp-evolution">
-            <legend>{{ 'POKEMON.PVP_EVOLUTION' | translate }}</legend>
+          <fieldset class="pvp-cap-fieldset">
+            <legend class="pvp-cap-legend">{{ 'POKEMON.PVP_EVOLUTION' | translate }}</legend>
             <mat-button-toggle-group [formControl]="pvpForm.controls.pvpRankingEvolution" class="pvp-cap-toggle">
               <mat-button-toggle [value]="0">{{ 'POKEMON.PVP_EVO_BASE' | translate }}</mat-button-toggle>
               <mat-button-toggle [value]="1">{{ 'POKEMON.PVP_EVO_MEGA' | translate }}</mat-button-toggle>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.html
@@ -203,8 +203,8 @@
                 }
               </mat-button-toggle-group>
 
-              <fieldset class="pvp-evolution">
-                <legend>{{ 'POKEMON.PVP_EVOLUTION' | translate }}</legend>
+              <fieldset class="pvp-cap-fieldset">
+                <legend class="pvp-cap-legend">{{ 'POKEMON.PVP_EVOLUTION' | translate }}</legend>
                 <mat-button-toggle-group [formControl]="form.controls.pvpRankingEvolution" class="pvp-cap-toggle">
                   <mat-button-toggle [value]="0">{{ 'POKEMON.PVP_EVO_BASE' | translate }}</mat-button-toggle>
                   <mat-button-toggle [value]="1">{{ 'POKEMON.PVP_EVO_MEGA' | translate }}</mat-button-toggle>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The PVP tab's mega evolution control no longer collides with the rank fields.** Its fieldset was given a class that had no styles, so it drew the browser's default border and reserved no space beneath itself. It uses the same classes as the PVP cap control right above it, which already handled this ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
+
 - **The Set Location dialog no longer scrolls sideways.** Giving the component itself a width made it wider than the padded surface it sits in. The size lives on the dialog's content now, the way the app's other dialogs do it ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
 - **The scope picker ignored the scope it was given.** It read its input in the constructor, where a signal input is not populated yet, so it took its own default and wrote that straight back — discarding an alarm's real scope when you opened it to edit, and the Alert Defaults preference when creating one. It seeds after the input arrives now ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).


### PR DESCRIPTION
Mine, from the mega-PVP change.

I gave the control a `<fieldset class="pvp-evolution">` and never wrote any CSS for that class. Browsers style a bare fieldset with a border and inset padding, and it reserved no space beneath itself — so it drew a box around itself and the Best/Worst Rank fields ran straight into it, which is the jumble in your screenshot.

The PVP cap control immediately above it already solves this with `.pvp-cap-fieldset` and `.pvp-cap-legend`. Reusing those is the fix. There was never a reason for a second set of classes, and inventing one is what caused it.

Applied to the add and edit dialogs, which carry the same markup.

One caveat worth stating: I cannot see the result. The app needs a Discord login I cannot complete, so I have reasoned from the CSS and the working sibling rather than looking at it. Worth a glance on dev before you trust it — and if the rank hints still crowd the Min CP field below them, that is a separate spacing issue on `.form-row` rather than this fieldset.

Build clean, 13 pokemon tests passing.