### PR TITLE
fix(ui): spacing and overflow, verified in a browser

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-add-dialog.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-add-dialog.component.scss
@@ -17,6 +17,10 @@ mat-dialog-content {
 .form-row {
   display: flex;
   gap: 12px;
+  // Room for the next field's floating label. Where a row's fields carry a mat-hint, the hint fills
+  // the row to its bottom edge and the following field's label, which floats above its own border,
+  // lands on top of it. Measured: the row ended at exactly the y the next field started.
+  margin-bottom: 12px;
 }
 .form-row mat-form-field {
   flex: 1;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-edit-dialog.component.scss
@@ -47,6 +47,9 @@ mat-dialog-content {
 .form-row {
   display: flex;
   gap: 16px;
+  // Room for the next field's floating label, which otherwise lands on the hint above it. Same
+  // measurement as the add dialog.
+  margin-bottom: 12px;
 }
 .form-row mat-form-field {
   flex: 1;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/location-dialog/location-dialog.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/location-dialog/location-dialog.component.scss
@@ -43,6 +43,9 @@ mat-dialog-content {
   margin-top: 1px;
 }
 .mini-map {
+  // width:100% plus a 1px border made it 2px wider than every sibling, which is what was left of the
+  // dialog's horizontal scrollbar after the width fix. Measured at 514px against 512.
+  box-sizing: border-box;
   width: 100%;
   height: 200px;
   border-radius: 8px;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/scope-picker/scope-picker.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/scope-picker/scope-picker.component.scss
@@ -37,13 +37,25 @@
 
 // The pin being unset is the difference between an alarm that works and one that silently never
 // fires, so it is a warning rather than a hint.
+// Wraps rather than squeezes. At phone width the icon was being crushed to a sliver and the action
+// squashed into three lines against the right edge; measured at 390px.
 .scope-warning {
-  align-items: center;
+  align-items: flex-start;
   color: var(--mat-sys-error, #d32f2f);
   display: flex;
+  flex-wrap: wrap;
   font-size: 0.78rem;
   gap: 0.35rem;
   margin: 0.5rem 0 0 2.25rem;
+}
+
+.scope-warning span {
+  flex: 1 1 12rem;
+}
+
+.scope-warning mat-icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
 }
 
 .scope-warning mat-icon {
@@ -70,7 +82,18 @@
 .scope-warning-action {
   --mdc-text-button-label-text-color: var(--mat-sys-error, #d32f2f);
 
+  flex: 0 0 auto;
   font-size: 0.78rem;
   min-width: 0;
   padding: 0 6px;
+}
+
+// The 2.25rem indent lines options up with the radio labels, which is right on a wide dialog and
+// wasteful on a phone, where it costs a fifth of the usable width.
+@media (max-width: 599px) {
+  .scope-option-body,
+  .scope-option-detail,
+  .scope-warning {
+    margin-left: 1.25rem;
+  }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Overalt i mine områder",
     "PIN_NOTE": "Standarden for enhver besked uden eget mål.",
     "PIN_TITLE": "Min position",
-    "PLACES_EMPTY": "Ingen steder endnu. Tilføj et for at få beskeder et andet sted end ved din position: arbejdet, fitnesscentret, hos dine forældre.",
+    "PLACES_EMPTY": "Tilføj et for at få beskeder et andet sted end ved din position: arbejdet, fitnesscentret, hos dine forældre.",
     "PLACES_TITLE": "Steder",
     "PLACE_DELETED": "{{place}} slettet.",
     "PLACE_DELETE_CONFIRM": "Beskeder rettet mod {{place}} falder tilbage til din position.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Überall in meinen Gebieten",
     "PIN_NOTE": "Der Rückfallwert für jede Meldung ohne eigenes Ziel.",
     "PIN_TITLE": "Mein Standort",
-    "PLACES_EMPTY": "Noch keine Orte. Füge einen hinzu, um Meldungen woanders als an deinem Standort zu erhalten: Arbeit, Fitnessstudio, bei den Eltern.",
+    "PLACES_EMPTY": "Füge einen hinzu, um Meldungen woandershin als an deinen Standort zu schicken: Arbeit, Fitnessstudio, bei den Eltern.",
     "PLACES_TITLE": "Orte",
     "PLACE_DELETED": "{{place}} gelöscht.",
     "PLACE_DELETE_CONFIRM": "Meldungen für {{place}} nutzen künftig wieder deinen Standort.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1740,7 +1740,7 @@
     "NAME_PLACE_TITLE": "Name this place",
     "PIN_NOTE": "The fallback for every alert that is not aimed somewhere else.",
     "PIN_TITLE": "My pin",
-    "PLACES_EMPTY": "No places yet. Add one to send alerts somewhere other than your pin: work, the gym, your parents' house.",
+    "PLACES_EMPTY": "Add one to send alerts somewhere other than your pin: work, the gym, your parents' house.",
     "PLACES_TITLE": "Places",
     "PLACE_DELETED": "Deleted {{place}}.",
     "PLACE_DELETE_CONFIRM": "Alerts aimed at {{place}} will fall back to your pin.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "En cualquier parte de mis áreas",
     "PIN_NOTE": "El valor por defecto para toda alerta sin destino propio.",
     "PIN_TITLE": "Mi ubicación",
-    "PLACES_EMPTY": "Todavía no hay lugares. Añade uno para recibir alertas fuera de tu ubicación: el trabajo, el gimnasio, casa de tus padres.",
+    "PLACES_EMPTY": "Añade uno para recibir alertas fuera de tu ubicación: el trabajo, el gimnasio, casa de tus padres.",
     "PLACES_TITLE": "Lugares",
     "PLACE_DELETED": "{{place}} eliminado.",
     "PLACE_DELETE_CONFIRM": "Las alertas dirigidas a {{place}} volverán a usar tu ubicación.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Partout dans mes zones",
     "PIN_NOTE": "La valeur par défaut de toute alerte sans destination propre.",
     "PIN_TITLE": "Ma position",
-    "PLACES_EMPTY": "Aucun lieu pour l'instant. Ajoutez-en un pour recevoir des alertes ailleurs qu'à votre position : le travail, la salle de sport, chez vos parents.",
+    "PLACES_EMPTY": "Ajoutez-en un pour recevoir des alertes ailleurs qu'à votre position : le travail, la salle de sport, chez vos parents.",
     "PLACES_TITLE": "Lieux",
     "PLACE_DELETED": "{{place}} supprimé.",
     "PLACE_DELETE_CONFIRM": "Les alertes visant {{place}} reviendront à votre position.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Ovunque nelle mie aree",
     "PIN_NOTE": "Il valore predefinito per ogni avviso senza una destinazione propria.",
     "PIN_TITLE": "La mia posizione",
-    "PLACES_EMPTY": "Nessun luogo per ora. Aggiungine uno per ricevere avvisi altrove: il lavoro, la palestra, casa dei tuoi.",
+    "PLACES_EMPTY": "Aggiungine uno per ricevere avvisi altrove: il lavoro, la palestra, casa dei tuoi.",
     "PLACES_TITLE": "Luoghi",
     "PLACE_DELETED": "{{place}} eliminato.",
     "PLACE_DELETE_CONFIRM": "Gli avvisi diretti a {{place}} torneranno alla tua posizione.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Overal in mijn gebieden",
     "PIN_NOTE": "De terugval voor elke melding zonder eigen bestemming.",
     "PIN_TITLE": "Mijn locatie",
-    "PLACES_EMPTY": "Nog geen plaatsen. Voeg er een toe om meldingen ergens anders dan bij je locatie te krijgen: werk, de sportschool, bij je ouders.",
+    "PLACES_EMPTY": "Voeg er een toe om meldingen ergens anders dan bij je locatie te krijgen: werk, de sportschool, bij je ouders.",
     "PLACES_TITLE": "Plaatsen",
     "PLACE_DELETED": "{{place}} verwijderd.",
     "PLACE_DELETE_CONFIRM": "Meldingen gericht op {{place}} vallen terug op je locatie.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Wszędzie w moich obszarach",
     "PIN_NOTE": "Ustawienie zapasowe dla każdego alertu bez własnego celu.",
     "PIN_TITLE": "Moja lokalizacja",
-    "PLACES_EMPTY": "Brak miejsc. Dodaj jedno, aby dostawać alerty poza swoją lokalizacją: praca, siłownia, dom rodziców.",
+    "PLACES_EMPTY": "Dodaj jedno, aby dostawać alerty poza swoją lokalizacją: praca, siłownia, dom rodziców.",
     "PLACES_TITLE": "Miejsca",
     "PLACE_DELETED": "Usunięto {{place}}.",
     "PLACE_DELETE_CONFIRM": "Alerty wskazujące {{place}} wrócą do twojej lokalizacji.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Em qualquer parte das minhas áreas",
     "PIN_NOTE": "O padrão para todo alerta sem destino próprio.",
     "PIN_TITLE": "Minha localização",
-    "PLACES_EMPTY": "Nenhum local ainda. Adicione um para receber alertas fora da sua localização: o trabalho, a academia, a casa dos seus pais.",
+    "PLACES_EMPTY": "Adicione um para receber alertas fora da sua localização: o trabalho, a academia, a casa dos seus pais.",
     "PLACES_TITLE": "Locais",
     "PLACE_DELETED": "{{place}} excluído.",
     "PLACE_DELETE_CONFIRM": "Os alertas voltados para {{place}} voltarão à sua localização.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Em qualquer parte das minhas áreas",
     "PIN_NOTE": "O recurso para qualquer alerta sem destino próprio.",
     "PIN_TITLE": "A minha localização",
-    "PLACES_EMPTY": "Ainda sem locais. Adiciona um para receberes alertas fora da tua localização: o trabalho, o ginásio, a casa dos teus pais.",
+    "PLACES_EMPTY": "Adiciona um para receberes alertas fora da tua localização: o trabalho, o ginásio, a casa dos teus pais.",
     "PLACES_TITLE": "Locais",
     "PLACE_DELETED": "{{place}} eliminado.",
     "PLACE_DELETE_CONFIRM": "Os alertas dirigidos a {{place}} voltam à tua localização.",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -1747,7 +1747,7 @@
     "OPTION_PROFILE": "Var som helst i mina områden",
     "PIN_NOTE": "Reservvalet för varje avisering utan eget mål.",
     "PIN_TITLE": "Min position",
-    "PLACES_EMPTY": "Inga platser än. Lägg till en för att få aviseringar någon annanstans än vid din position: jobbet, gymmet, hos föräldrarna.",
+    "PLACES_EMPTY": "Lägg till en för att få aviseringar någon annanstans än vid din position: jobbet, gymmet, hos föräldrarna.",
     "PLACES_TITLE": "Platser",
     "PLACE_DELETED": "{{place}} borttagen.",
     "PLACE_DELETE_CONFIRM": "Aviseringar som pekar på {{place}} återgår till din position.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Layout problems found by actually looking at the running app.** The PVP tab's rank hints collided with the field below them; the scope picker's missing-pin warning crushed its icon and squeezed its action into three lines on a phone; the Set Location dialog kept a 2px horizontal scrollbar because its map's border sat outside its width. The Places empty state also stopped repeating its own title ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
+
 - **The PVP tab's mega evolution control no longer collides with the rank fields.** Its fieldset was given a class that had no styles, so it drew the browser's default border and reserved no space beneath itself. It uses the same classes as the PVP cap control right above it, which already handled this ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
 - **The Set Location dialog no longer scrolls sideways.** Giving the component itself a width made it wider than the padded surface it sits in. The size lives on the dialog's content now, the way the app's other dialogs do it ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).


### PR DESCRIPTION
I drove Playwright against dev for this one instead of reasoning from the CSS. Everything below was measured in the running app, and the fixes were trialled by injecting the style and re-screenshotting before writing any code.

## PVP tab

Your screenshot. Two separate causes:

1. The mega fieldset had a class with no styles, so it drew the browser's default border. Fixed in #745 by reusing `.pvp-cap-fieldset`.
2. **Still broken after that**, which I only saw once I looked: the rank fields carry a `mat-hint` that fills the row to its bottom edge, and the next field's floating label renders above its own border into that band. Measured — the row ended at exactly the y the next field started. `.form-row` now leaves 12px, in both pokemon dialogs.

## Scope picker on a phone

At 390px the warning's icon was crushed to a sliver and "Set your pin" was squeezed into three lines against the right edge. It wraps now. The 2.25rem indent that aligns options with the radio labels also drops to 1.25rem on small screens, where it was costing a fifth of the usable width.

## Set Location dialog

The surface stopped scrolling with #744, but 2px of overflow remained — enough to keep drawing a scrollbar. The Leaflet container is `width: 100%` with a 1px border and no `box-sizing`, so it measured 514px against its siblings' 512. That was the whole thing.

## Copy

The Places empty state had a title of "No places yet" and a subtitle opening with "No places yet."

## What I checked

At 1400px and 390px: Areas & Places, the alarm dialog's four tabs, the scope picker in all three modes, and the Set Location dialog. The map on Areas & Places measures 1296×702, matching My Geofences, and the page has no horizontal overflow.

Build clean, 1037 tests passing.