### PR TITLE
fix(ui): stop My Geofences and Help overflowing a phone screen

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/geofences/geofence-list.component.scss
@@ -34,6 +34,19 @@
   flex-shrink: 0;
 }
 
+// At phone width the three buttons measured 404px against a 390px viewport, so Draw Geofence was
+// cut off at the edge. Wrapping puts it on its own line rather than off the screen.
+@media (max-width: 599px) {
+  .page-header-actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .page-header-actions .draw-fab {
+    width: 100%;
+  }
+}
+
 .geojson-actions {
   display: flex;
   gap: 8px;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/help/help.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/help/help.component.scss
@@ -332,8 +332,11 @@
   }
 }
 
+// A bare 480px cap beats the base rule's max-width:100%, so on a phone these rendered 482px in a
+// 390px viewport and ran 92px off the screen. min() keeps the intent — never wider than 480 — while
+// still yielding to the viewport. Measured at 390px.
 ::ng-deep .help-screenshot-sm {
-  max-width: 480px;
+  max-width: min(480px, 100%);
 }
 
 // ─── Callout boxes ──────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two pages no longer run off the side of a phone.** Walking all twenty pages at 390px turned up My Geofences, whose three header buttons measured 404px so Draw Geofence sat 30px past the edge, and Help, whose small screenshots carried a bare 480px cap that beat the 100% one on the base class and spilled 92px. The geofence buttons wrap; the screenshots cap to whichever is smaller ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
+
 - **Layout problems found by actually looking at the running app.** The PVP tab's rank hints collided with the field below them; the scope picker's missing-pin warning crushed its icon and squeezed its action into three lines on a phone; the Set Location dialog kept a 2px horizontal scrollbar because its map's border sat outside its width. The Places empty state also stopped repeating its own title ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).
 
 - **The PVP tab's mega evolution control no longer collides with the rank fields.** Its fieldset was given a class that had no styles, so it drew the browser's default border and reserved no space beneath itself. It uses the same classes as the PVP cap control right above it, which already handled this ([#730](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/730)).


### PR DESCRIPTION
Continuing the page-by-page walk at 1400px and 390px. Desktop is clean across all twenty pages. Two overflowed at phone width.

**My Geofences** — `.page-header-actions` measures 404px against a 390px viewport, so "Draw Geofence" is cut off 30px past the edge. Confirmed by screenshot and by measuring the element. The row now wraps below 600px and the FAB takes its own line.

**Help** — `::ng-deep .help-screenshot-sm { max-width: 480px }` overrides the base `.help-screenshot`'s `max-width: 100%`, so three images render at 482px, 92px past the edge. Only visible with the expansion panels open, which is why earlier passes missed it. `min(480px, 100%)` keeps the intended cap.

Not defects, checked and left alone: the admin users and webhooks tables are wider than the viewport but sit in `.table-container` with a working `overflow-x: auto`, and Raids has Material's off-screen inactive tab panel.

Build and both test suites clean.

https://claude.ai/code/session_01Nah4N2sGFs1TU2t7DXfKzJ
