### PR TITLE
fix: serve Pokemon names, types and forms in the display language

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/MasterDataController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/MasterDataController.cs
@@ -5,7 +5,7 @@ using Pgan.PoracleWebNet.Core.Abstractions.Services;
 namespace Pgan.PoracleWebNet.Api.Controllers;
 
 [Route("api/masterdata")]
-public class MasterDataController(
+public partial class MasterDataController(
     IMasterDataService masterDataService,
     IPoracleApiProxy poracleApiProxy,
     IRaidLevelService raidLevelService) : BaseApiController
@@ -95,6 +95,73 @@ public class MasterDataController(
         var levels = await this._raidLevelService.GetAllAsync();
         return this.Ok(levels);
     }
+
+    /// <summary>
+    /// Monster master data (names, types, form names, stats, evolutions) keyed
+    /// <c>"{pokemonId}_{formId}"</c>, translated into <paramref name="locale"/>.
+    /// </summary>
+    /// <remarks>
+    /// PoracleNG owns the translations, so this proxies its <c>/api/masterdata/monsters</c> and only
+    /// falls back to the WatWowMap masterfile - which is English-only - when that route is missing or
+    /// unreachable. Before this endpoint existed the SPA fetched the masterfile from GitHub directly,
+    /// so Pokemon names and types stayed English no matter what the display language was set to.
+    /// </remarks>
+    [AllowAnonymous]
+    [HttpGet("monsters")]
+    public async Task<IActionResult> GetMonsters([FromQuery] string? locale)
+    {
+        var requested = NormalizeLocale(locale);
+
+        try
+        {
+            var localized = await this._poracleApiProxy.GetMonstersAsync(requested);
+            if (!string.IsNullOrWhiteSpace(localized))
+            {
+                return this.Content(localized, "application/json");
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // Upstream unreachable or too slow - fall through to the English masterfile rather than
+            // leaving the selector with no names, types or forms at all. A misconfigured
+            // Poracle:ApiAddress throws InvalidOperationException instead and is left to surface.
+        }
+
+        var fallback = await this._masterDataService.GetMonsterDataAsync();
+        if (fallback == null)
+        {
+            await this._masterDataService.RefreshCacheAsync();
+            fallback = await this._masterDataService.GetMonsterDataAsync();
+        }
+
+        if (fallback == null)
+        {
+            return this.NotFound(new
+            {
+                message = "Monster data not available."
+            });
+        }
+
+        return this.Content(fallback, "application/json");
+    }
+
+    /// <summary>
+    /// Constrains the locale to a BCP-47-ish shape before it reaches the upstream query string.
+    /// Anything else becomes <c>en</c>, which is also what PoracleNG defaults to.
+    /// </summary>
+    internal static string NormalizeLocale(string? locale)
+    {
+        if (string.IsNullOrWhiteSpace(locale))
+        {
+            return "en";
+        }
+
+        var trimmed = locale.Trim();
+        return LocalePattern().IsMatch(trimmed) ? trimmed : "en";
+    }
+
+    [System.Text.RegularExpressions.GeneratedRegex("^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})?$")]
+    private static partial System.Text.RegularExpressions.Regex LocalePattern();
 
     [AllowAnonymous]
     [HttpGet("grunts")]

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/icon.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/icon.service.ts
@@ -1,29 +1,9 @@
 import { Injectable, inject, computed } from '@angular/core';
 
 import { SettingsService } from './settings.service';
+import { POKEMON_TYPE_IDS } from '../../shared/utils/pokemon-types';
 
 const DEFAULT_UICONS = 'https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons';
-
-const TYPE_IDS: Record<string, number> = {
-  Bug: 7,
-  Dark: 17,
-  Dragon: 16,
-  Electric: 13,
-  Fairy: 18,
-  Fighting: 2,
-  Fire: 10,
-  Flying: 3,
-  Ghost: 8,
-  Grass: 12,
-  Ground: 5,
-  Ice: 15,
-  Normal: 1,
-  Poison: 4,
-  Psychic: 14,
-  Rock: 6,
-  Steel: 9,
-  Water: 11,
-};
 
 @Injectable({ providedIn: 'root' })
 export class IconService {
@@ -83,7 +63,7 @@ export class IconService {
   }
 
   getTypeUrl(typeName: string): string {
-    const id = TYPE_IDS[typeName];
+    const id = POKEMON_TYPE_IDS[typeName];
     return id ? `${this.typeBase()}/${id}.png` : '';
   }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
@@ -1,8 +1,10 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
 
 import { ConfigService } from './config.service';
+import { I18nService } from './i18n.service';
 import { MasterDataService } from './masterdata.service';
 
 describe('MasterDataService', () => {
@@ -13,7 +15,12 @@ describe('MasterDataService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ConfigService, useValue: { apiHost: API } }],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        { provide: ConfigService, useValue: { apiHost: API } },
+      ],
     });
     service = TestBed.inject(MasterDataService);
     httpMock = TestBed.inject(HttpTestingController);
@@ -49,6 +56,7 @@ describe('MasterDataService', () => {
         expect(ready).toBe(true);
       });
 
+      const monstersReq = httpMock.expectOne(req => req.url === `${API}/api/masterdata/monsters`);
       const pokemonReq = httpMock.expectOne(`${API}/api/masterdata/pokemon`);
       const itemsReq = httpMock.expectOne(`${API}/api/masterdata/items`);
       const movesReq = httpMock.expectOne(`${API}/api/masterdata/moves`);
@@ -56,10 +64,7 @@ describe('MasterDataService', () => {
       pokemonReq.flush({ '25': 'Pikachu', '150': 'Mewtwo' });
       itemsReq.flush({ '1': 'Poke Ball', '2': 'Great Ball' });
       movesReq.flush({ '13': 'Wrap', '14': 'Hyper Beam' });
-
-      // Also handle the forms request from loadForms()
-      const formsReq = httpMock.expectOne(req => req.url.includes('master-latest-poracle'));
-      formsReq.flush({});
+      monstersReq.flush({});
 
       expect(service.isLoaded()).toBe(true);
       expect(service.getPokemonName(25)).toBe('Pikachu');
@@ -75,7 +80,7 @@ describe('MasterDataService', () => {
       httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/moves`).flush({ '13': 'Wrap' });
-      httpMock.expectOne(req => req.url.includes('master-latest-poracle')).flush({});
+      httpMock.expectOne(req => req.url === `${API}/api/masterdata/monsters`).flush({});
 
       expect(service.getMoveName(13)).toBe('Wrap');
       expect(service.getMoveName(9999)).toBe('Move #9999');
@@ -89,7 +94,7 @@ describe('MasterDataService', () => {
       httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '25': 'Pikachu' });
       httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
-      httpMock.expectOne(req => req.url.includes('master-latest-poracle')).flush({});
+      httpMock.expectOne(req => req.url === `${API}/api/masterdata/monsters`).flush({});
     });
 
     it('should handle API errors gracefully', () => {
@@ -102,6 +107,7 @@ describe('MasterDataService', () => {
       // The items request gets cancelled by forkJoin, so just match and discard it
       httpMock.match(`${API}/api/masterdata/items`);
       httpMock.match(`${API}/api/masterdata/moves`);
+      httpMock.match(req => req.url === `${API}/api/masterdata/monsters`);
 
       expect(service.isLoaded()).toBe(true);
     });
@@ -118,7 +124,7 @@ describe('MasterDataService', () => {
       });
       httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
-      httpMock.expectOne(req => req.url.includes('master-latest-poracle')).flush({});
+      httpMock.expectOne(req => req.url === `${API}/api/masterdata/monsters`).flush({});
 
       const pokemon = service.getAllPokemon();
       expect(pokemon[0]).toEqual({ id: 0, name: 'All Pokemon' });
@@ -150,13 +156,11 @@ describe('MasterDataService', () => {
       httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
       httpMock
-        .expectOne(req => req.url.includes('master-latest-poracle'))
+        .expectOne(req => req.url === `${API}/api/masterdata/monsters`)
         .flush({
-          monsters: {
-            '618_0': { id: 618, name: 'Stunfisk', form: { id: 0, name: '' } },
-            '618_2246': { id: 618, name: 'Stunfisk', form: { id: 2246, name: 'Normal' } },
-            '618_2345': { id: 618, name: 'Stunfisk', form: { id: 2345, name: 'Galarian' } },
-          },
+          '618_0': { id: 618, name: 'Stunfisk', form: { id: 0, name: '' } },
+          '618_2246': { id: 618, name: 'Stunfisk', form: { id: 2246, name: 'Normal' } },
+          '618_2345': { id: 618, name: 'Stunfisk', form: { id: 2345, name: 'Galarian' } },
         });
 
       expect(service.getFormsForPokemon(618)).toEqual([
@@ -172,15 +176,128 @@ describe('MasterDataService', () => {
       httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
       httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
       httpMock
-        .expectOne(req => req.url.includes('master-latest-poracle'))
+        .expectOne(req => req.url === `${API}/api/masterdata/monsters`)
         .flush({
-          monsters: {
-            '1_0': { id: 1, name: 'Bulbasaur', form: { id: 0, name: '' } },
-            '1_123': { id: 1, name: 'Bulbasaur', form: { id: 123, name: 'Normal' } },
-          },
+          '1_0': { id: 1, name: 'Bulbasaur', form: { id: 0, name: '' } },
+          '1_123': { id: 1, name: 'Bulbasaur', form: { id: 123, name: 'Normal' } },
         });
 
       expect(service.getFormsForPokemon(1)).toEqual([]);
+    });
+  });
+  describe('localized monster data', () => {
+    const MONSTERS = `${API}/api/masterdata/monsters`;
+
+    /** Flushes the three English maps, then the monster map, and returns nothing. */
+    function load(monsters: unknown, pokemon: Record<string, string> = {}): void {
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush(pokemon);
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+      httpMock.expectOne(req => req.url === MONSTERS).flush(monsters);
+    }
+
+    it('should request the monster map for the current display language', () => {
+      TestBed.inject(I18nService).use('de');
+      service.loadData().subscribe();
+
+      const req = httpMock.expectOne(r => r.url === MONSTERS);
+      expect(req.request.params.get('locale')).toBe('de');
+
+      req.flush({});
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+    });
+
+    it('should prefer the translated name over the English masterfile name', () => {
+      service.loadData().subscribe();
+      load({ '25_0': { id: 25, name: 'Pikachu', form: { id: 0, name: '' } } }, { '25': 'Pikachu' });
+      expect(service.getPokemonName(25)).toBe('Pikachu');
+
+      // Species with names that actually differ between locales, e.g. #001 in German.
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          provideTranslateService(),
+          { provide: ConfigService, useValue: { apiHost: API } },
+        ],
+      });
+      const german = TestBed.inject(MasterDataService);
+      const germanHttp = TestBed.inject(HttpTestingController);
+      german.loadData().subscribe();
+      germanHttp.expectOne(`${API}/api/masterdata/pokemon`).flush({ '1': 'Bulbasaur' });
+      germanHttp.expectOne(`${API}/api/masterdata/items`).flush({});
+      germanHttp.expectOne(`${API}/api/masterdata/moves`).flush({});
+      germanHttp.expectOne(req => req.url === MONSTERS).flush({ '1_0': { id: 1, name: 'Bisasam', form: { id: 0, name: '' } } });
+
+      expect(german.getPokemonName(1)).toBe('Bisasam');
+      germanHttp.verify();
+    });
+
+    it('should keep English type names as identity and translate only the label', () => {
+      service.loadData().subscribe();
+      load({
+        '25_0': {
+          id: 25,
+          name: 'Pikachu',
+          form: { id: 0, name: '' },
+          types: [{ id: 13, name: 'Elektro' }],
+        },
+      });
+
+      // Icons and the type filter chip both key on the English name, so it has to survive.
+      expect(service.getPokemonTypes(25)).toEqual(['Electric']);
+      expect(service.getAllTypes()).toEqual(['Electric']);
+      expect(service.getTypeLabel('Electric')).toBe('Elektro');
+    });
+
+    it('should fall back to the English name when a translation key comes back untranslated', () => {
+      service.loadData().subscribe();
+      load(
+        {
+          '25_0': {
+            id: 25,
+            name: 'poke_25',
+            form: { id: 0, name: '' },
+            types: [{ id: 13, name: 'poke_type_13' }],
+          },
+        },
+        { '25': 'Pikachu' },
+      );
+
+      expect(service.getPokemonName(25)).toBe('Pikachu');
+      expect(service.getTypeLabel('Electric')).toBe('Electric');
+    });
+
+    it('should keep English names when the monster map is unavailable', () => {
+      service.loadData().subscribe();
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '25': 'Pikachu' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+      httpMock.expectOne(req => req.url === MONSTERS).error(new ProgressEvent('error'), { status: 404, statusText: 'Not Found' });
+
+      expect(service.isLoaded()).toBe(true);
+      expect(service.getPokemonName(25)).toBe('Pikachu');
+    });
+
+    it('should reload and re-emit when the display language changes', () => {
+      const seen: string[] = [];
+      service.getAllPokemon$().subscribe(list => seen.push(list[1]?.name));
+      load({ '25_0': { id: 25, name: 'Pikachu', form: { id: 0, name: '' } } }, { '25': 'Pikachu' });
+
+      TestBed.inject(I18nService).use('fr');
+      TestBed.flushEffects();
+
+      const req = httpMock.expectOne(r => r.url === MONSTERS);
+      expect(req.request.params.get('locale')).toBe('fr');
+      req.flush({ '25_0': { id: 25, name: 'Pikachu (fr)', form: { id: 0, name: '' } } });
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '25': 'Pikachu' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+
+      expect(seen).toEqual(['Pikachu', 'Pikachu (fr)']);
     });
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.spec.ts
@@ -169,6 +169,40 @@ describe('MasterDataService', () => {
       ]);
     });
 
+    it('should drop a lone base form under a translated name (it: "Normale")', () => {
+      service.loadData().subscribe();
+
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '1': 'Bulbasaur' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+      httpMock
+        .expectOne(req => req.url === `${API}/api/masterdata/monsters`)
+        .flush({
+          '1_0': { id: 1, name: 'Bulbasaur', form: { id: 0, name: '' } },
+          '1_123': { id: 1, name: 'Bulbasaur', form: { id: 123, name: 'Normale' } },
+        });
+
+      expect(service.getFormsForPokemon(1)).toEqual([]);
+    });
+
+    // Koraidon and Miraidon are the only two species in live data whose single real form is not
+    // the base one, so the drop rule has to be about the name and not about the count.
+    it('should keep a lone form that is not the base form', () => {
+      service.loadData().subscribe();
+
+      httpMock.expectOne(`${API}/api/masterdata/pokemon`).flush({ '1007': 'Koraidon' });
+      httpMock.expectOne(`${API}/api/masterdata/items`).flush({});
+      httpMock.expectOne(`${API}/api/masterdata/moves`).flush({});
+      httpMock
+        .expectOne(req => req.url === `${API}/api/masterdata/monsters`)
+        .flush({
+          '1007_0': { id: 1007, name: 'Koraidon', form: { id: 0, name: '' } },
+          '1007_3084': { id: 1007, name: 'Koraidon', form: { id: 3084, name: 'Apex Build' } },
+        });
+
+      expect(service.getFormsForPokemon(1007)).toEqual([{ id: 3084, name: 'Apex Build' }]);
+    });
+
     it('should drop a lone "Normal" form covered by "All Forms"', () => {
       service.loadData().subscribe();
 

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
@@ -196,9 +196,15 @@ export class MasterDataService {
     // default, the synthetic "All Forms" option already covers it, so listing it adds
     // noise. Keep "Normal" only when sibling variants (Galarian, Alolan, etc.) exist
     // so users can target the base form on its own.
-    const normalLabel = typeLabelMap.get('Normal');
+    //
+    // The name is matched by prefix because it is now translated. Across the locales this UI
+    // offers, prod serves "Normal" for en/de/fr/es/pl/sv and "Normale" for it; nl, pt, pt-BR and
+    // da have no Poracle translation and fall back to English. Species whose only real form is
+    // something else - Koraidon's "Apex Build", Miraidon's "Ultimate Mode", the two exceptions in
+    // live data - are unaffected. A locale that translates it to something else entirely shows one
+    // redundant chip; it cannot hide a form.
     for (const [pokemonId, forms] of grouped) {
-      if (forms.length === 1 && (forms[0].name === 'Normal' || forms[0].name === normalLabel)) {
+      if (forms.length === 1 && /^normal/i.test(forms[0].name)) {
         grouped.delete(pokemonId);
       }
     }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/core/services/masterdata.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject, signal } from '@angular/core';
-import { Observable, ReplaySubject, forkJoin, map } from 'rxjs';
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { Observable, ReplaySubject, catchError, forkJoin, map, of } from 'rxjs';
 
 import { ConfigService } from './config.service';
+import { I18nService } from './i18n.service';
+import { POKEMON_TYPE_NAMES_BY_ID } from '../../shared/utils/pokemon-types';
 
 export interface PokemonEntry {
   id: number;
@@ -10,22 +12,52 @@ export interface PokemonEntry {
   types?: string[];
 }
 
+/** One entry of the monster map, keyed `"{pokemonId}_{formId}"`. */
+interface MonsterEntry {
+  evolutions?: { evoId: number }[];
+  form?: { id: number; name: string };
+  id: number;
+  name: string;
+  types?: { id: number; name: string }[];
+}
+
+/**
+ * A translation key that came back as itself, e.g. `poke_25`. PoracleNG returns the key when neither
+ * the requested locale nor its English fallback has the string, which happens when its game-data
+ * locale download failed. Showing "poke_25" would be worse than the English name we already have.
+ */
+const UNTRANSLATED_KEY = /^(poke|poke_type|form)_\d+$/;
+
 @Injectable({ providedIn: 'root' })
 export class MasterDataService {
   private readonly config = inject(ConfigService);
   private readonly evoBaseMap = new Map<number, number>();
 
-  private formsLoaded = false;
-  private formsLoadRequested = false;
   private readonly formsMap = signal(new Map<number, { id: number; name: string }[]>());
   private readonly http = inject(HttpClient);
+  private readonly i18n = inject(I18nService);
   private itemMap = new Map<number, string>();
   private loaded = false;
+  /** Locale of the data currently in the maps, so a display-language change can be detected. */
+  private loadedLocale = '';
   private loadRequested = false;
   private moveMap = new Map<number, string>();
   private pokemonMap = new Map<number, string>();
   private readonly ready$ = new ReplaySubject<boolean>(1);
+  private readonly typeLabels = signal(new Map<string, string>());
   private readonly typesMap = signal(new Map<number, string[]>());
+
+  constructor() {
+    // Pokemon, type and form names are all translated server-side, so a display-language change
+    // invalidates every map. Re-emitting on ready$ live-updates anything already subscribed
+    // through getAllPokemon$(), which is how open selectors pick the new names up.
+    effect(() => {
+      const locale = this.i18n.currentLang();
+      if (this.loadRequested && locale !== this.loadedLocale) {
+        this.fetch();
+      }
+    });
+  }
 
   getAllItems(): { id: number; name: string }[] {
     const entries: { id: number; name: string }[] = [];
@@ -91,6 +123,14 @@ export class MasterDataService {
     return this.typesMap().get(id) ?? [];
   }
 
+  /**
+   * The display label for a type. Takes the English name that everything else keys on and returns
+   * the translation for the current display language, falling back to the English name itself.
+   */
+  getTypeLabel(englishName: string): string {
+    return this.typeLabels().get(englishName) ?? englishName;
+  }
+
   isLoaded(): boolean {
     return this.loaded;
   }
@@ -98,149 +138,159 @@ export class MasterDataService {
   loadData(): Observable<boolean> {
     if (!this.loadRequested) {
       this.loadRequested = true;
-
-      forkJoin({
-        items: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/items`),
-        moves: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/moves`),
-        pokemon: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/pokemon`),
-      }).subscribe({
-        error: () => {
-          // Masterdata unavailable - continue without names
-          this.loaded = true;
-          this.loadRequested = false;
-          this.ready$.next(true);
-        },
-        next: ({ items, moves, pokemon }) => {
-          this.pokemonMap.clear();
-          if (pokemon) {
-            Object.entries(pokemon).forEach(([id, name]) => {
-              this.pokemonMap.set(Number(id), name as string);
-            });
-          }
-
-          this.itemMap.clear();
-          if (items) {
-            Object.entries(items).forEach(([id, name]) => {
-              this.itemMap.set(Number(id), name as string);
-            });
-          }
-
-          this.moveMap.clear();
-          if (moves) {
-            Object.entries(moves).forEach(([id, name]) => {
-              this.moveMap.set(Number(id), name as string);
-            });
-          }
-
-          this.loaded = true;
-          this.ready$.next(true);
-          this.loadForms();
-        },
-      });
+      this.fetch();
     }
     return this.ready$.asObservable();
   }
 
-  private loadForms(): void {
-    if (this.formsLoadRequested) return;
-    this.formsLoadRequested = true;
+  /**
+   * Rebuilds the maps from the monster payload: localized names, types, forms and evolution chains.
+   * A null payload (upstream unreachable) leaves the English names from /api/masterdata/pokemon in
+   * place rather than blanking the selector.
+   */
+  private applyMonsters(monsters: null | Record<string, MonsterEntry>): void {
+    if (!monsters) return;
 
-    const url = 'https://raw.githubusercontent.com/WatWowMap/Masterfile-Generator/master/master-latest-poracle.json';
-    this.http.get<Record<string, unknown>>(url).subscribe({
+    const namesById = new Map<number, string>();
+    const grouped = new Map<number, { id: number; name: string }[]>();
+    const typeMap = new Map<number, string[]>();
+    const typeLabelMap = new Map<string, string>();
+
+    for (const [key, entry] of Object.entries(monsters)) {
+      if (!entry || typeof entry.id !== 'number') continue;
+
+      // Form 0 is the species' own name; other forms carry it too, so prefer form 0 when present.
+      if (entry.name && !UNTRANSLATED_KEY.test(entry.name) && (key.endsWith('_0') || !namesById.has(entry.id))) {
+        namesById.set(entry.id, entry.name);
+      }
+
+      // Skip only the synthetic id-0 "any" pseudo-form. Real forms (including the
+      // base "Normal"/regional-default form, e.g. Unova Stunfisk) are kept so they
+      // can be tracked distinctly from regional variants like Galarian.
+      if (entry.form && entry.form.id !== 0 && entry.form.name) {
+        const forms = grouped.get(entry.id) ?? [];
+        if (!forms.some(f => f.id === entry.form!.id)) {
+          forms.push({ id: entry.form.id, name: entry.form.name });
+        }
+        grouped.set(entry.id, forms);
+      }
+
+      // Types come from the base form only; form variants repeat them.
+      if (entry.types?.length && !typeMap.has(entry.id)) {
+        const english: string[] = [];
+        for (const t of entry.types) {
+          // The id is the stable identity - icons and filters key on the English name, so a
+          // localized label is only ever recorded alongside it, never in its place.
+          const name = POKEMON_TYPE_NAMES_BY_ID[t.id] ?? t.name;
+          if (!name) continue;
+          english.push(name);
+          if (t.name && !UNTRANSLATED_KEY.test(t.name)) {
+            typeLabelMap.set(name, t.name);
+          }
+        }
+        if (english.length) typeMap.set(entry.id, english);
+      }
+    }
+
+    // Drop a lone "Normal" form: when a species' only real form is its base/regional
+    // default, the synthetic "All Forms" option already covers it, so listing it adds
+    // noise. Keep "Normal" only when sibling variants (Galarian, Alolan, etc.) exist
+    // so users can target the base form on its own.
+    const normalLabel = typeLabelMap.get('Normal');
+    for (const [pokemonId, forms] of grouped) {
+      if (forms.length === 1 && (forms[0].name === 'Normal' || forms[0].name === normalLabel)) {
+        grouped.delete(pokemonId);
+      }
+    }
+
+    for (const forms of grouped.values()) {
+      forms.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    namesById.forEach((name, id) => this.pokemonMap.set(id, name));
+    this.formsMap.set(grouped);
+    this.typesMap.set(typeMap);
+    this.typeLabels.set(typeLabelMap);
+    this.buildEvolutionMap(monsters);
+  }
+
+  /** Resolves each species to the first stage of its evolution chain. */
+  private buildEvolutionMap(monsters: Record<string, MonsterEntry>): void {
+    const evolvesFrom = new Map<number, number>(); // child -> parent
+    const seen = new Set<number>();
+    for (const entry of Object.values(monsters)) {
+      if (!entry || seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      if (entry.evolutions) {
+        for (const evo of entry.evolutions) {
+          if (!evolvesFrom.has(evo.evoId)) {
+            evolvesFrom.set(evo.evoId, entry.id);
+          }
+        }
+      }
+    }
+    // Resolve chains to find the ultimate base
+    for (const id of [...evolvesFrom.keys(), ...seen]) {
+      let base = id;
+      let safety = 5;
+      while (evolvesFrom.has(base) && safety-- > 0) {
+        base = evolvesFrom.get(base)!;
+      }
+      this.evoBaseMap.set(id, base);
+    }
+  }
+
+  /**
+   * Loads every map for the current display language.
+   *
+   * Monsters come from PoracleNG (via our API) because it owns the translations; items and moves
+   * stay on the English masterfile, which has no translated equivalent upstream. A monster failure
+   * is caught rather than left to cancel the forkJoin, so English names still land.
+   */
+  private fetch(): void {
+    const locale = this.i18n.currentLang();
+    this.loadedLocale = locale;
+
+    forkJoin({
+      items: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/items`),
+      monsters: this.http
+        .get<Record<string, MonsterEntry>>(`${this.config.apiHost}/api/masterdata/monsters`, { params: { locale } })
+        .pipe(catchError(() => of(null))),
+      moves: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/moves`),
+      pokemon: this.http.get<Record<string, string>>(`${this.config.apiHost}/api/masterdata/pokemon`),
+    }).subscribe({
       error: () => {
-        // Forms unavailable - continue without form names
-        this.formsLoaded = true;
-        this.formsLoadRequested = false;
+        // Masterdata unavailable - continue without names
+        this.loaded = true;
+        this.loadRequested = false;
+        this.ready$.next(true);
       },
-      next: data => {
-        const monsters = data['monsters'] as
-          | Record<
-              string,
-              {
-                id: number;
-                name: string;
-                form?: { id: number; name: string };
-                evolutions?: { evoId: number }[];
-                types?: { id: number; name: string }[];
-              }
-            >
-          | undefined;
-        if (!monsters) {
-          this.formsLoaded = true;
-          return;
+      next: ({ items, monsters, moves, pokemon }) => {
+        this.pokemonMap.clear();
+        if (pokemon) {
+          Object.entries(pokemon).forEach(([id, name]) => {
+            this.pokemonMap.set(Number(id), name as string);
+          });
         }
 
-        const grouped = new Map<number, { id: number; name: string }[]>();
-        for (const entry of Object.values(monsters)) {
-          // Skip only the synthetic id-0 "any" pseudo-form. Real forms (including the
-          // base "Normal"/regional-default form, e.g. Unova Stunfisk) are kept so they
-          // can be tracked distinctly from regional variants like Galarian.
-          if (!entry.form || entry.form.id === 0) continue;
-          const pokemonId = entry.id;
-          if (!grouped.has(pokemonId)) {
-            grouped.set(pokemonId, []);
-          }
-          const forms = grouped.get(pokemonId)!;
-          // Avoid duplicates
-          if (!forms.some(f => f.id === entry.form!.id)) {
-            forms.push({ id: entry.form.id, name: entry.form.name });
-          }
+        this.itemMap.clear();
+        if (items) {
+          Object.entries(items).forEach(([id, name]) => {
+            this.itemMap.set(Number(id), name as string);
+          });
         }
 
-        // Drop a lone "Normal" form: when a species' only real form is its base/regional
-        // default, the synthetic "All Forms" option already covers it, so listing it adds
-        // noise. Keep "Normal" only when sibling variants (Galarian, Alolan, etc.) exist
-        // so users can target the base form on its own.
-        for (const [pokemonId, forms] of grouped) {
-          if (forms.length === 1 && forms[0].name === 'Normal') {
-            grouped.delete(pokemonId);
-          }
+        this.moveMap.clear();
+        if (moves) {
+          Object.entries(moves).forEach(([id, name]) => {
+            this.moveMap.set(Number(id), name as string);
+          });
         }
 
-        // Sort forms alphabetically within each Pokemon
-        for (const forms of grouped.values()) {
-          forms.sort((a, b) => a.name.localeCompare(b.name));
-        }
-        this.formsMap.set(grouped);
+        this.applyMonsters(monsters);
 
-        // Build types map: Pokemon ID → type names (use base form only, skip form variants)
-        const typeMap = new Map<number, string[]>();
-        for (const entry of Object.values(monsters)) {
-          if (typeMap.has(entry.id)) continue;
-          if (entry.types?.length) {
-            typeMap.set(
-              entry.id,
-              entry.types.map(t => t.name),
-            );
-          }
-        }
-        this.typesMap.set(typeMap);
-
-        // Build evolution base map: evolved Pokemon → base (first stage) Pokemon ID
-        const evolvesFrom = new Map<number, number>(); // child → parent
-        const seen = new Set<number>();
-        for (const entry of Object.values(monsters)) {
-          if (seen.has(entry.id)) continue;
-          seen.add(entry.id);
-          if (entry.evolutions) {
-            for (const evo of entry.evolutions) {
-              if (!evolvesFrom.has(evo.evoId)) {
-                evolvesFrom.set(evo.evoId, entry.id);
-              }
-            }
-          }
-        }
-        // Resolve chains to find the ultimate base
-        for (const id of [...evolvesFrom.keys(), ...seen]) {
-          let base = id;
-          let safety = 5;
-          while (evolvesFrom.has(base) && safety-- > 0) {
-            base = evolvesFrom.get(base)!;
-          }
-          this.evoBaseMap.set(id, base);
-        }
-
-        this.formsLoaded = true;
+        this.loaded = true;
+        this.ready$.next(true);
       },
     });
   }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/pokemon-selector/pokemon-selector.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/pokemon-selector/pokemon-selector.component.html
@@ -10,7 +10,7 @@
     <span class="gen-label">{{ 'POKEMON_SELECTOR.TYPE' | translate }}</span>
     @for (type of availableTypes(); track type) {
       <button class="gen-chip type-chip" [class.gen-active]="activeType() === type" (click)="toggleType(type)">
-        <img [src]="getTypeIcon(type)" [alt]="type" class="type-icon" (error)="onImageError($event)" />{{ type }}
+        <img [src]="getTypeIcon(type)" [alt]="typeLabel(type)" class="type-icon" (error)="onImageError($event)" />{{ typeLabel(type) }}
       </button>
     }
   </div>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/pokemon-selector/pokemon-selector.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/components/pokemon-selector/pokemon-selector.component.ts
@@ -202,4 +202,12 @@ export class PokemonSelectorComponent implements OnInit {
     this.searchControl.setValue('');
     this.searchText.set('');
   }
+
+  /**
+   * Display text for a type chip. The chip's value stays the English name - the icon lookup and the
+   * filter comparison both key on it - so only the label is translated.
+   */
+  typeLabel(type: string): string {
+    return this.masterData.getTypeLabel(type);
+  }
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/utils/pokemon-types.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/shared/utils/pokemon-types.ts
@@ -1,0 +1,33 @@
+/**
+ * The 18 Pokemon types, keyed by the type ids the game (and PoracleNG's masterdata) use.
+ *
+ * These English names are identity, not display text: uicons files are named after the id, alarm
+ * filters compare by name, and the type filter chips track by name. PoracleNG returns type names
+ * already translated into the requested locale, so the localized string is kept apart from this and
+ * used only for rendering — see `MasterDataService.getTypeLabel`.
+ */
+export const POKEMON_TYPE_NAMES_BY_ID: Record<number, string> = {
+  1: 'Normal',
+  2: 'Fighting',
+  3: 'Flying',
+  4: 'Poison',
+  5: 'Ground',
+  6: 'Rock',
+  7: 'Bug',
+  8: 'Ghost',
+  9: 'Steel',
+  10: 'Fire',
+  11: 'Water',
+  12: 'Grass',
+  13: 'Electric',
+  14: 'Psychic',
+  15: 'Ice',
+  16: 'Dragon',
+  17: 'Dark',
+  18: 'Fairy',
+};
+
+/** The inverse of {@link POKEMON_TYPE_NAMES_BY_ID}: English type name to type id. */
+export const POKEMON_TYPE_IDS: Record<string, number> = Object.fromEntries(
+  Object.entries(POKEMON_TYPE_NAMES_BY_ID).map(([id, name]) => [name, Number(id)]),
+);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pokemon names, types and forms follow the display language.** Setting the site to German left the selector listing Bulbasaur, Blastoise and Butterfree under English type chips, because the names never came from anything translatable: the API cached WatWowMap's English masterfile, and the browser fetched the same file from GitHub a second time for forms and types. PoracleNG already translates all three and serves them at `/api/masterdata/monsters`, which is where they now come from, per display language and re-fetched when you change it. The English masterfile stays as the fallback for a Poracle too old to serve that route, so nothing empties out. Type chips keep their English identity internally, since the uicons file names and the filter comparison both key on it, and only the label is translated. Items and moves stay English -- Poracle has no translated equivalent to call. Reported on Discord.
+
 ## [2.16.0] - 2026-08-20
 
 ### Added

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IMasterDataService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IMasterDataService.cs
@@ -9,6 +9,13 @@ public interface IMasterDataService
 
     /// <summary>Move ID to name map (e.g. <c>{"13":"Wrap"}</c>), sourced from the masterfile.</summary>
     public Task<string?> GetMoveDataAsync();
+
+    /// <summary>
+    /// The raw masterfile monster map keyed <c>"{pokemonId}_{formId}"</c> (names, types, forms,
+    /// stats, evolutions). English only - it is the fallback for when PoracleNG cannot serve its
+    /// localized equivalent.
+    /// </summary>
+    public Task<string?> GetMonsterDataAsync();
     public Task RefreshCacheAsync();
 
     /// <summary>

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleApiProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleApiProxy.cs
@@ -10,6 +10,15 @@ public interface IPoracleApiProxy
     Task<string?> GetTemplatesAsync();
     Task<string?> GetAdminRolesAsync(string userId);
     Task<string?> GetGruntsAsync();
+
+    /// <summary>
+    /// Localized monster master data: names, types and form names in <paramref name="locale"/>.
+    /// PoracleNG translates these from its own i18n bundle, which is why they are fetched from it
+    /// rather than from the English-only WatWowMap masterfile.
+    /// </summary>
+    /// <returns>The raw JSON map keyed <c>"{pokemonId}_{formId}"</c>, or <c>null</c> when upstream
+    /// is unreachable or does not serve it.</returns>
+    Task<string?> GetMonstersAsync(string locale);
     Task<string?> GetGeofenceAsync();
     Task<string?> GetAreasWithGroupsAsync(string userId);
     Task<string?> GetAreaMapUrlAsync(string areaName);

--- a/Core/Pgan.PoracleWebNet.Core.Services/MasterDataService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MasterDataService.cs
@@ -18,6 +18,7 @@ public partial class MasterDataService(
     private const string PokemonCacheKey = "MasterData_Pokemon";
     private const string ItemCacheKey = "MasterData_Items";
     private const string MoveCacheKey = "MasterData_Moves";
+    private const string MonsterCacheKey = "MasterData_Monsters";
     private const string BaseStatsCacheKey = "MasterData_BaseStats";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
 
@@ -44,6 +45,13 @@ public partial class MasterDataService(
     {
         await this.EnsureInitializedAsync();
         this._cache.TryGetValue(MoveCacheKey, out string? data);
+        return data;
+    }
+
+    public async Task<string?> GetMonsterDataAsync()
+    {
+        await this.EnsureInitializedAsync();
+        this._cache.TryGetValue(MonsterCacheKey, out string? data);
         return data;
     }
 
@@ -113,6 +121,13 @@ public partial class MasterDataService(
                     }
                 }
             }
+            // The whole monster map is kept verbatim as the English fallback for
+            // GET /api/masterdata/monsters, which normally serves PoracleNG's localized version.
+            if (monsters.ValueKind == JsonValueKind.Object)
+            {
+                this._cache.Set(MonsterCacheKey, monsters.GetRawText(), CacheDuration);
+            }
+
             this._cache.Set(PokemonCacheKey, JsonSerializer.Serialize(pokemonMap), CacheDuration);
             this._cache.Set(BaseStatsCacheKey, baseStatsMap, CacheDuration);
             LogCachedPokemonEntries(this._logger, pokemonMap.Count);

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleApiProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleApiProxy.cs
@@ -270,6 +270,24 @@ public class PoracleApiProxy(HttpClient httpClient, IConfiguration configuration
         return await response.Content.ReadAsStringAsync();
     }
 
+    /// <summary>
+    /// Localized monster master data from <c>/api/masterdata/monsters</c>. Older PoracleJS builds do
+    /// not serve this route, so a 404 is a normal outcome and yields <c>null</c> rather than throwing.
+    /// </summary>
+    public async Task<string?> GetMonstersAsync(string locale)
+    {
+        var request = this.CreateRequest(HttpMethod.Get,
+            $"{this._apiAddress}/api/masterdata/monsters?locale={Uri.EscapeDataString(locale)}");
+        var response = await this._httpClient.SendAsync(request);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        return await response.Content.ReadAsStringAsync();
+    }
+
     public async Task<string?> GetGeofenceAsync()
     {
         // Use any user ID to get the full area list with groups

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/MasterDataControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/MasterDataControllerTests.cs
@@ -110,4 +110,106 @@ public class MasterDataControllerTests : ControllerTestBase
         this._poracleApiProxy.Setup(p => p.GetGruntsAsync()).ReturnsAsync((string?)null);
         Assert.IsType<NotFoundObjectResult>(await this._sut.GetGrunts());
     }
+
+    // --- GetMonsters ---
+
+    [Fact]
+    public async Task GetMonstersServesPoracleNgTranslationForTheRequestedLocale()
+    {
+        this._poracleApiProxy.Setup(p => p.GetMonstersAsync("de"))
+            .ReturnsAsync(/*lang=json,strict*/ "{\"1_0\":{\"id\":1,\"name\":\"Bisasam\"}}");
+
+        var result = await this._sut.GetMonsters("de");
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Contains("Bisasam", content.Content, StringComparison.Ordinal);
+        this._masterDataService.Verify(s => s.GetMonsterDataAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetMonstersDefaultsToEnglishWhenNoLocaleIsGiven()
+    {
+        this._poracleApiProxy.Setup(p => p.GetMonstersAsync("en"))
+            .ReturnsAsync(/*lang=json,strict*/ "{\"1_0\":{\"id\":1,\"name\":\"Bulbasaur\"}}");
+
+        Assert.IsType<ContentResult>(await this._sut.GetMonsters(null));
+
+        this._poracleApiProxy.Verify(p => p.GetMonstersAsync("en"), Times.Once);
+    }
+
+    /// <summary>
+    /// PoracleJS and older PoracleNG builds do not serve /api/masterdata/monsters. Falling back to
+    /// the English masterfile keeps names, types and forms in the selector instead of emptying it.
+    /// </summary>
+    [Fact]
+    public async Task GetMonstersFallsBackToTheEnglishMasterfileWhenUpstreamHasNoSuchRoute()
+    {
+        this._poracleApiProxy.Setup(p => p.GetMonstersAsync(It.IsAny<string>())).ReturnsAsync((string?)null);
+        this._masterDataService.Setup(s => s.GetMonsterDataAsync())
+            .ReturnsAsync(/*lang=json,strict*/ "{\"1_0\":{\"id\":1,\"name\":\"Bulbasaur\"}}");
+
+        var content = Assert.IsType<ContentResult>(await this._sut.GetMonsters("de"));
+
+        Assert.Contains("Bulbasaur", content.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetMonstersFallsBackWhenUpstreamIsUnreachable()
+    {
+        this._poracleApiProxy.Setup(p => p.GetMonstersAsync(It.IsAny<string>())).ThrowsAsync(new HttpRequestException("down"));
+        this._masterDataService.Setup(s => s.GetMonsterDataAsync())
+            .ReturnsAsync(/*lang=json,strict*/ "{\"1_0\":{\"id\":1,\"name\":\"Bulbasaur\"}}");
+
+        var content = Assert.IsType<ContentResult>(await this._sut.GetMonsters("de"));
+
+        Assert.Contains("Bulbasaur", content.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetMonstersReturnsNotFoundWhenNeitherSourceHasData()
+    {
+        this._poracleApiProxy.Setup(p => p.GetMonstersAsync(It.IsAny<string>())).ReturnsAsync((string?)null);
+        this._masterDataService.Setup(s => s.GetMonsterDataAsync()).ReturnsAsync((string?)null);
+        this._masterDataService.Setup(s => s.RefreshCacheAsync()).Returns(Task.CompletedTask);
+
+        Assert.IsType<NotFoundObjectResult>(await this._sut.GetMonsters("en"));
+
+        this._masterDataService.Verify(s => s.RefreshCacheAsync(), Times.Once);
+    }
+
+    [Theory]
+    // Every locale the UI can be set to has to survive normalization - refusing one would silently
+    // send that user back to English names.
+    [InlineData("en")]
+    [InlineData("de")]
+    [InlineData("fr")]
+    [InlineData("es")]
+    [InlineData("nl")]
+    [InlineData("it")]
+    [InlineData("pt")]
+    [InlineData("pt-BR")]
+    [InlineData("pl")]
+    [InlineData("da")]
+    [InlineData("sv")]
+    // PoracleNG's own locale codes, which an admin can set as the Poracle default.
+    [InlineData("ja")]
+    [InlineData("ru")]
+    [InlineData("zh-cn")]
+    [InlineData("nb-no")]
+    public void NormalizeLocaleKeepsEverySupportedLocale(string locale)
+    {
+        Assert.Equal(locale, MasterDataController.NormalizeLocale(locale));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("de&foo=bar")]
+    [InlineData("../../config")]
+    [InlineData("e")]
+    public void NormalizeLocaleFallsBackToEnglishForAnythingElse(string? locale)
+    {
+        Assert.Equal("en", MasterDataController.NormalizeLocale(locale));
+    }
 }


### PR DESCRIPTION
Reported on Discord: with the site set to German, the Pokemon selector still listed Bulbasaur, Blastoise and Butterfree under English type chips.

## Cause

The names were never translatable. `MasterDataService` cached WatWowMap's English-only masterfile, and the SPA fetched the same file from GitHub a second time for forms, types and evolution chains. Nothing in that path takes a locale.

PoracleNG already translates all three from its own i18n bundle and serves them at `GET /api/masterdata/monsters?locale=xx`, in the same shape as the masterfile's `monsters` map. We call its sibling `/api/masterdata/grunts` and never this one.

## Changes

- `GET /api/masterdata/monsters?locale=xx` proxies PoracleNG, falling back to the cached English masterfile when upstream is unreachable or too old to have the route. The locale is normalised to a BCP-47-ish shape before it reaches the query string.
- `MasterDataService` fetches it in the same `forkJoin` as items/moves/pokemon, and refetches on a display-language change, re-emitting on `ready$` so open selectors update in place rather than needing a reload.
- The browser's second direct fetch to GitHub is gone.
- Items and moves stay English: Poracle serves no translated equivalent.

## Two things this had to avoid breaking

**Type names are identity, not display text.** `IconService.getTypeUrl` keys uicons on `Bug`/`Dark`/…, and the filter chip tracks by the same string, so substituting `Käfer` would have blanked every type icon and broken the filter. The English name, resolved from PoracleNG's stable type id, stays as the value; the translated string is held alongside as a label used only for rendering. The id-to-name table moved to `shared/utils/pokemon-types.ts` rather than being duplicated, and `IconService` now imports its inverse.

**The lone-base-form rule matched on the English literal `'Normal'`.** Verified against prod across every locale this UI offers: en/de/fr/es/pl/sv serve `"Normal"`, it serves `"Normale"`, and nl/pt/pt-BR/da have no Poracle translation so they serve English. It is now a prefix match. The tempting simplification of dropping any species with exactly one form is wrong: 856 species qualify in live data and two of them, Koraidon's "Apex Build" and Miraidon's "Ultimate Mode", are not base forms and would have disappeared.

A name that comes back as its own translation key (`poke_25`) is ignored in favour of the English one, covering a Poracle whose game-locale download failed.

## Verification

Called prod (PoracleNG 5.1.0) directly rather than trusting the source read:

```
GET /api/masterdata/monsters?locale=de   → 2523 entries
  1_0  → Bisasam   ["Gift", "Pflanze"]   (type ids 4, 12)
  9_0  → Turtok    ["Wasser"]
 12_0  → Smettbo   ["Flug", "Käfer"]
 15_0  → Bibor     ["Gift", "Käfer"]
618_2345 form → "Galar"   (English: "Galarian")
```

Those are exactly the names in the reporter's screenshot. Zero entries returned untranslated keys. `locale=nl` returns English, confirming the fallback.

Backend 2030 tests and frontend 1113 pass; `npm run build` and `dotnet build` clean.

## Not in scope

The alert-language menu still lists all eleven languages regardless of `allowed_languages`. Filtering it needs `general.available_languages`, which PoracleNG has in its config struct but exposes on neither config endpoint. See #770, which also covers defaulting new users to Poracle's configured locale.
