### PR TITLE
fix: quest summary schedules are read-and-delete when quests are off

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/SummaryScheduleController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/SummaryScheduleController.cs
@@ -11,11 +11,16 @@ namespace Pgan.PoracleWebNet.Api.Controllers;
 /// Per-user quest summary delivery schedules. The schedule is an <c>active_hours</c> array keyed by the
 /// authenticated user + <c>quest</c> — there is NO id/userId route segment or body field anywhere
 /// (the JWT's userId is the sole id source; <c>summary_schedules</c> is keyed per-user with no profile_no,
-/// so any forwarded request-supplied id would be a full read/write/delete/trigger IDOR). The whole
-/// controller is gated by <c>disable_quests</c>; admins are intentionally NOT exempt (see #236).
+/// so any forwarded request-supplied id would be a full read/write/delete/trigger IDOR).
 /// </summary>
+/// <remarks>
+/// Gated per-action on <c>disable_quests</c>, matching the alarm types: setting a schedule and firing
+/// one on demand are refused while quests are off; reading or deleting the schedule you already have
+/// is not. A schedule for a disabled type delivers nothing, so removing it is the one useful thing
+/// left - and when quests are disabled in Poracle rather than here, its bot refuses the command too.
+/// Admins are intentionally NOT exempt from the gate (see #236).
+/// </remarks>
 [Route("api/summary-schedules")]
-[RequireFeatureEnabled(DisableFeatureKeys.Quests)]
 public class SummaryScheduleController(
     IPoracleSummaryProxy summaryProxy,
     ISummaryCapabilityService capability) : BaseApiController
@@ -96,6 +101,7 @@ public class SummaryScheduleController(
     /// <c>{alertType}</c> is the sole alert-type source. Validates the active-hours payload via the
     /// shared <see cref="ActiveHoursValidator"/> BEFORE proxying; null/whitespace clears the schedule.
     /// </summary>
+    [RequireFeatureEnabled(DisableFeatureKeys.Quests)]
     [HttpPut("{alertType}")]
     [EnableRateLimiting("auth-read")]
     public async Task<IActionResult> SetSchedule(string alertType, [FromBody] SummaryScheduleRequest request)
@@ -154,6 +160,7 @@ public class SummaryScheduleController(
     /// synchronously, then clears the bucket. Rate-limited (5/60s) and client-cooldown-guarded so a
     /// double-click cannot double-deliver.
     /// </summary>
+    [RequireFeatureEnabled(DisableFeatureKeys.Quests)]
     [HttpPost("{alertType}/trigger")]
     [EnableRateLimiting("test-alert")]
     public async Task<IActionResult> Trigger(string alertType)

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.html
@@ -26,7 +26,9 @@
           }
         </div>
       </section>
-      <p class="send-hint">{{ 'QUESTS.SUMMARY_SCHEDULE_SEND_NOW_HINT' | translate }}</p>
+      @if (!writesDisabled()) {
+        <p class="send-hint">{{ 'QUESTS.SUMMARY_SCHEDULE_SEND_NOW_HINT' | translate }}</p>
+      }
     } @else {
       <section class="state-block empty-block" aria-live="polite">
         <mat-icon class="empty-icon">event_available</mat-icon>
@@ -37,21 +39,23 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button
-    mat-flat-button
-    type="button"
-    class="send-now-btn"
-    [class.is-cooling]="coolingDown()"
-    (click)="sendNow()"
-    [disabled]="!hasSchedule() || triggering() || coolingDown() || saving()"
-    [matTooltip]="'QUESTS.SUMMARY_SCHEDULE_SEND_NOW_HINT' | translate">
-    @if (triggering()) {
-      <mat-spinner [diameter]="18" />
-    } @else {
-      <mat-icon>send</mat-icon>
-    }
-    {{ 'QUESTS.SUMMARY_SCHEDULE_SEND_NOW' | translate }}
-  </button>
+  @if (!writesDisabled()) {
+    <button
+      mat-flat-button
+      type="button"
+      class="send-now-btn"
+      [class.is-cooling]="coolingDown()"
+      (click)="sendNow()"
+      [disabled]="!hasSchedule() || triggering() || coolingDown() || saving()"
+      [matTooltip]="'QUESTS.SUMMARY_SCHEDULE_SEND_NOW_HINT' | translate">
+      @if (triggering()) {
+        <mat-spinner [diameter]="18" />
+      } @else {
+        <mat-icon>send</mat-icon>
+      }
+      {{ 'QUESTS.SUMMARY_SCHEDULE_SEND_NOW' | translate }}
+    </button>
+  }
 
   <span class="spacer"></span>
 
@@ -59,8 +63,10 @@
     {{ 'QUESTS.SUMMARY_SCHEDULE_CLEAR' | translate }}
   </button>
   <button mat-button type="button" (click)="close()">{{ 'COMMON.CLOSE' | translate }}</button>
-  <button mat-flat-button color="primary" type="button" (click)="editSchedule()" [disabled]="saving() || loading()">
-    <mat-icon>edit_calendar</mat-icon>
-    {{ 'QUESTS.SUMMARY_SCHEDULE_EDIT' | translate }}
-  </button>
+  @if (!writesDisabled()) {
+    <button mat-flat-button color="primary" type="button" (click)="editSchedule()" [disabled]="saving() || loading()">
+      <mat-icon>edit_calendar</mat-icon>
+      {{ 'QUESTS.SUMMARY_SCHEDULE_EDIT' | translate }}
+    </button>
+  }
 </mat-dialog-actions>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -9,6 +10,7 @@ import { SummaryScheduleDialogComponent, SummaryScheduleDialogData } from './sum
 import { ActiveHourEntry } from '../../../core/models/active-hours.models';
 import { I18nService } from '../../../core/services/i18n.service';
 import { LocationService } from '../../../core/services/location.service';
+import { SettingsService } from '../../../core/services/settings.service';
 import { SummarySchedule, SummaryScheduleService } from '../../../core/services/summary-schedule.service';
 import { ActiveHoursEditorDialogComponent } from '../../../shared/components/active-hours-editor-dialog/active-hours-editor-dialog.component';
 
@@ -44,6 +46,7 @@ describe('SummaryScheduleDialogComponent', () => {
       schedule?: SummarySchedule | null;
       location?: { latitude: number; longitude: number };
       data?: SummaryScheduleDialogData;
+      questsDisabled?: boolean;
     } = {},
   ) {
     const enabled = overrides.enabled ?? true;
@@ -71,6 +74,14 @@ describe('SummaryScheduleDialogComponent', () => {
         { provide: SummaryScheduleService, useValue: summaryService },
         { provide: MatDialog, useValue: matDialog },
         { provide: LocationService, useValue: locationService },
+        {
+          provide: SettingsService,
+          useValue: {
+            isDisabled: (key: string) => key === 'disable_quests' && (overrides.questsDisabled ?? false),
+            isForcedByPoracle: () => false,
+            siteSettings: signal({}),
+          },
+        },
         { provide: MatSnackBar, useValue: snackBar },
         { provide: I18nService, useValue: { instant: (key: string) => key } },
       ],
@@ -84,6 +95,7 @@ describe('SummaryScheduleDialogComponent', () => {
     const fixture = TestBed.createComponent(SummaryScheduleDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    return fixture;
   }
 
   it('should create', () => {
@@ -255,6 +267,36 @@ describe('SummaryScheduleDialogComponent', () => {
       setup({ location: { latitude: 51.5, longitude: -0.12 }, schedule: QUEST_SCHEDULE });
       expect(component.userLat()).toBe(51.5);
       expect(component.userLon()).toBe(-0.12);
+    });
+  });
+
+  const buttonLabels = (fixture: { nativeElement: HTMLElement }): string[] =>
+    [...fixture.nativeElement.querySelectorAll('button')].map(b => b.textContent ?? '');
+
+  describe('when quests are disabled', () => {
+    /**
+     * A schedule for a disabled type delivers nothing, so clearing it is the one useful action left.
+     * Hiding the dialog, or its Clear button, would strand a schedule its owner cannot see or remove.
+     */
+    it('still offers Clear', () => {
+      const labels = buttonLabels(setup({ questsDisabled: true }));
+
+      expect(labels.some(l => l.includes('CLEAR'))).toBe(true);
+    });
+
+    it('drops Save and Send now', () => {
+      const fixture = setup({ questsDisabled: true });
+      const labels = buttonLabels(fixture);
+
+      expect(labels.some(l => l.includes('SEND_NOW'))).toBe(false);
+      expect(labels.some(l => l.includes('SUMMARY_SCHEDULE_EDIT'))).toBe(false);
+    });
+
+    it('keeps Save and Send now while quests are enabled', () => {
+      const labels = buttonLabels(setup());
+
+      expect(labels.some(l => l.includes('SEND_NOW'))).toBe(true);
+      expect(labels.some(l => l.includes('SUMMARY_SCHEDULE_EDIT'))).toBe(true);
     });
   });
 });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/quests/summary-schedule-dialog/summary-schedule-dialog.component.ts
@@ -11,6 +11,7 @@ import { catchError, finalize, of } from 'rxjs';
 import { ActiveHourEntry, compressDayRange, formatTime12h, groupActiveHours } from '../../../core/models/active-hours.models';
 import { I18nService } from '../../../core/services/i18n.service';
 import { LocationService } from '../../../core/services/location.service';
+import { SettingsService } from '../../../core/services/settings.service';
 import { SummarySchedule, SummaryScheduleService } from '../../../core/services/summary-schedule.service';
 import {
   ActiveHoursEditorDialogComponent,
@@ -45,32 +46,37 @@ export class SummaryScheduleDialogComponent {
   /** Timestamp (ms) when the trigger cooldown expires; 0 = not cooling down. */
   private readonly cooldownUntil = signal(0);
   private readonly dialog = inject(MatDialog);
+
   private readonly dialogRef = inject(MatDialogRef<SummaryScheduleDialogComponent>);
+
   private readonly i18n = inject(I18nService);
   private readonly locationService = inject(LocationService);
+  private readonly settingsService = inject(SettingsService);
   private readonly snackBar = inject(MatSnackBar);
-
   private readonly summaryService = inject(SummaryScheduleService);
 
   readonly coolingDown = computed(() => Date.now() < this.cooldownUntil());
+
   readonly data: SummaryScheduleDialogData = inject(MAT_DIALOG_DATA);
   readonly schedule = signal<SummarySchedule | null>(null);
-
   readonly entries = computed<ActiveHourEntry[]>(() => this.schedule()?.activeHours ?? []);
 
   readonly hasSchedule = computed(() => this.entries().length > 0);
-  readonly loading = signal(true);
 
+  readonly loading = signal(true);
   /** Grouped amber pills mirroring the active-hours-chip idiom. */
   readonly pills = computed(() =>
     groupActiveHours(this.entries()).map(g => ({ label: `${compressDayRange(g.days)} ${formatTime12h(g.hours, g.mins)}` })),
   );
 
   readonly saving = signal(false);
-  readonly triggering = signal(false);
 
+  readonly triggering = signal(false);
   readonly userLat = signal(0);
+
   readonly userLon = signal(0);
+  /** Quests disabled: the schedule can be read and cleared, but not set or fired. */
+  readonly writesDisabled = computed(() => this.settingsService.isDisabled('disable_quests'));
 
   constructor() {
     this.summaryService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Quest summary schedules follow the same rule as the alarm types.** Turning quests off used to take the whole schedule with it -- unreadable and unclearable until someone turned quests back on. Now the schedule you already have can be opened and cleared; setting one, and sending one on demand, are refused. It was the last controller still doing it the old way.
 - **Switching an alarm type off no longer hides the alarms people already have.** It used to take the whole page with it: rules a user had already created became invisible, and unremovable, until someone switched the type back on. That is the wrong way round -- an alarm of a disabled type can never fire, so deleting it is the one thing still worth doing, and when the type is disabled in Poracle rather than here its bot refuses the matching command too, which leaves this page as the only way to clean up. The page now stays reachable and says which side switched it off. Creating, editing, bulk distance changes and test alerts are gone; the list and both delete paths are untouched, and the nav item keeps a padlock so you know before you click.
 ### Documentation
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/SummaryScheduleControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/SummaryScheduleControllerTests.cs
@@ -302,12 +302,43 @@ public class SummaryScheduleControllerTests : ControllerTestBase
         Assert.Equal("api/summary-schedules", route!.Template);
     }
 
-    [Fact]
-    public void ControllerIsGatedByDisableQuestsFeature()
+    /// <summary>
+    /// Setting a schedule and firing one on demand are gated; reading and deleting are not. A schedule
+    /// for a disabled type delivers nothing, so removing it is the one useful thing left, and gating
+    /// the reads would hide a schedule its owner can no longer see or clear.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(SummaryScheduleController.SetSchedule))]
+    [InlineData(nameof(SummaryScheduleController.Trigger))]
+    public void WritesAreGatedByDisableQuests(string action)
     {
         // #236 lesson: the controller filter is the real boundary, not the Angular guard.
-        var attr = typeof(SummaryScheduleController).GetCustomAttribute<RequireFeatureEnabledAttribute>();
+        var attr = typeof(SummaryScheduleController).GetMethod(action)!
+            .GetCustomAttribute<RequireFeatureEnabledAttribute>();
+
         Assert.NotNull(attr);
+        Assert.Equal("disable_quests", (string)attr!.Arguments![0]);
+    }
+
+    [Theory]
+    [InlineData(nameof(SummaryScheduleController.GetSchedules))]
+    [InlineData(nameof(SummaryScheduleController.GetSchedule))]
+    [InlineData(nameof(SummaryScheduleController.GetCapability))]
+    [InlineData(nameof(SummaryScheduleController.DeleteSchedule))]
+    public void ReadsAndDeleteStayOpen(string action)
+    {
+        var attr = typeof(SummaryScheduleController).GetMethod(action)!
+            .GetCustomAttribute<RequireFeatureEnabledAttribute>();
+
+        Assert.Null(attr);
+    }
+
+    [Fact]
+    public void ControllerHasNoClassLevelGate()
+    {
+        var attr = typeof(SummaryScheduleController).GetCustomAttribute<RequireFeatureEnabledAttribute>();
+
+        Assert.True(attr is null, "A class-level gate 403s the reads and the delete too.");
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Filters/FeatureGateCoverageTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Filters/FeatureGateCoverageTests.cs
@@ -192,6 +192,10 @@ public class FeatureGateCoverageTests
         "FortChangeController.DeleteAll",
         "MaxBattleController.Delete",
         "MaxBattleController.DeleteAll",
+
+        // Quest summary schedules follow the alarm types: a schedule for a disabled type delivers
+        // nothing, so clearing it is the one useful thing left.
+        "SummaryScheduleController.DeleteSchedule",
     };
 
     /// <summary>A write, by HTTP verb. Reads are deliberately left open on some gated controllers.</summary>


### PR DESCRIPTION
`SummaryScheduleController` was the last controller still gated at the class level, so turning quests off hid a user's summary schedule entirely and left no way to clear it — the same trap #784 removed everywhere else. Flagged there as out of scope; closing it now.

## Changes

The gate moves from the class to `SetSchedule` and `Trigger`. The three reads and `DeleteSchedule` are open, for the same reason as the alarm types: a schedule for a disabled type delivers nothing, so clearing it is the one useful thing left — and when quests are disabled in Poracle rather than here, its bot refuses the matching command too.

`Trigger` is gated rather than left open despite being a "read-ish" action: it delivers a summary DM on demand, which is making something happen, not cleaning up.

In the dialog, **Save** and **Send now** are hidden — along with the send-now hint paragraph, which would otherwise have described a button that is no longer there. **Clear** and **Close** stay.

The delete exemption is recorded in `FeatureGateCoverageTests.IntentionallyUngatedWrites` beside the twenty alarm deletes, which is what caught the partially-gated shape here too.

## A test that asserted the old contract

`ControllerIsGatedByDisableQuestsFeature` checked for the class-level attribute. That is precisely the thing being removed, so I replaced it with the per-action split asserted in both directions: `SetSchedule` and `Trigger` gated on `disable_quests`, the three reads and the delete ungated, and no class-level attribute. Its `#236` comment — the controller filter is the real boundary, not the Angular guard — carries over intact.

Watched red first on the dialog: neutralising the guard fails the new hidden-controls test.

## Verification

Backend 2142, frontend 1191 across 102 suites. Build, lint and prettier clean.
