### PR TITLE
fix(webhooks): resolve delegate grants to the webhook they name

### DIFF
--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AdminController.cs
@@ -89,6 +89,10 @@ public partial class AdminController(
         // poracle_web.webhook_delegates only meant a delegate configured in PoracleJS -- the
         // delegateAdministration mechanism -- saw the nav item, got an empty page here, and a 403 from
         // impersonate. See #626.
+        // Grants arrive canonicalised to humans.id -- PoracleNG hands back whatever key the operator wrote
+        // in [[discord.webhook_admins]], and upstream that key is the webhook's NAME. Matched case-
+        // insensitively for the same reason the resolver's set is: nothing guarantees an operator typed the
+        // URL in the case the humans row stores it. See #797.
         var managed = (await this._roleResolver.ResolveAsync(this.UserId)).ManagedWebhooks ?? [];
         if (managed.Length == 0)
         {
@@ -98,7 +102,7 @@ public partial class AdminController(
         var humans = await this._humanService.GetAllAsync();
 
         var webhooks = humans
-            .Where(h => managed.Contains(h.Id, StringComparer.Ordinal))
+            .Where(h => managed.Contains(h.Id, StringComparer.OrdinalIgnoreCase))
             .Select(h => new
             {
                 h.Id,
@@ -632,9 +636,19 @@ public partial class AdminController(
         // impersonating the webhook until they next signed in. See #601.
         // Same union as the claim and as my-webhooks, so a PoracleJS-configured delegate is not refused
         // by an endpoint the nav item just offered them. See #626.
+        // No hop from inside an impersonation session. The SPA stashes the caller's own token in a single
+        // poracle_admin_token slot, so a second hop overwrites it with the first impersonated one and
+        // strands whoever started with no way back to their own account. Nothing legitimate chained before:
+        // the nav item that reaches this endpoint was hidden under impersonation, and the admin user list
+        // refuses it anyway because the impersonation token carries isAdmin = false. See #797.
+        if (this.IsImpersonating)
+        {
+            return this.Forbid();
+        }
+
         var isDelegate = !this.IsAdmin
             && ((await this._roleResolver.ResolveAsync(this.UserId)).ManagedWebhooks ?? [])
-                .Contains(request.UserId, StringComparer.Ordinal);
+                .Contains(request.UserId, StringComparer.OrdinalIgnoreCase);
         if (!this.IsAdmin && !isDelegate)
         {
             return this.Forbid();

--- a/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Controllers/AuthController.cs
@@ -937,11 +937,19 @@ public partial class AuthController(
     /// the last consumer of the claim and the one that decided whether the others were reachable.
     /// </para>
     /// <para>
-    /// Two cases keep the claim instead. An impersonation session, where resolving the impersonated
-    /// account's own delegations answers a different question entirely — the same trap #663 fixed for
-    /// admin status. And a degraded resolve, where an unreachable PoracleNG or a <c>poracle_web</c> blip
-    /// would otherwise strip a legitimate delegate's nav item mid-session (#656, #667); there the two
-    /// sets are unioned, since a partial answer may have found a new grant while missing an old one.
+    /// One case keeps the claim: a degraded resolve, where an unreachable PoracleNG or a
+    /// <c>poracle_web</c> blip would otherwise strip a legitimate delegate's nav item mid-session (#656,
+    /// #667); there the two sets are unioned, since a partial answer may have found a new grant while
+    /// missing an old one.
+    /// </para>
+    /// <para>
+    /// An impersonation session resolves live like any other. <c>this.UserId</c> names the impersonated
+    /// account, which is exactly what <c>GET /api/admin/my-webhooks</c> and <c>POST /api/admin/impersonate</c>
+    /// already answer for, so short-circuiting to a claim the impersonation token never carries hid a nav
+    /// item whose page would have worked. This is not the #663 trap: that one re-elevated ADMIN rights the
+    /// impersonation token deliberately drops, and <c>isAdmin</c> still comes from the claim. Chaining a
+    /// second impersonation off the list is refused server-side, since the SPA has one slot to stash the
+    /// caller's own token in. See #797.
     /// </para>
     /// <para>
     /// Nothing authorises off the claim any more — it is a cold fallback for the degraded path only.
@@ -951,11 +959,6 @@ public partial class AuthController(
     private async Task<string[]?> ResolveManagedWebhooksAsync()
     {
         var claimed = this.ManagedWebhooks;
-
-        if (this.IsImpersonating)
-        {
-            return claimed.Length > 0 ? claimed : null;
-        }
 
         var roles = await this._roleResolver.ResolveAsync(this.UserId);
         var resolved = roles.ManagedWebhooks ?? [];

--- a/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Services/UserRoleResolver.cs
@@ -47,6 +47,7 @@ public interface IUserRoleResolver
 public sealed partial class UserRoleResolver(
     IPoracleApiProxy poracleApiProxy,
     IWebhookDelegateService webhookDelegateService,
+    IHumanService humanService,
     IOptions<PoracleSettings> poracleSettings,
     IMemoryCache cache,
     ILogger<UserRoleResolver> logger) : IUserRoleResolver
@@ -58,6 +59,7 @@ public sealed partial class UserRoleResolver(
     private readonly IPoracleApiProxy _poracleApiProxy = poracleApiProxy;
     private readonly PoracleSettings _poracleSettings = poracleSettings.Value;
     private readonly IWebhookDelegateService _webhookDelegateService = webhookDelegateService;
+    private readonly IHumanService _humanService = humanService;
 
     public async Task<UserRoles> ResolveAsync(string userId)
     {
@@ -185,7 +187,71 @@ public sealed partial class UserRoleResolver(
             delegatesReadable = false;
         }
 
-        return new UserRoles(false, managed.Count > 0 ? [.. managed] : null, configReadable && rolesReadable && delegatesReadable);
+        if (managed.Count == 0)
+        {
+            return new UserRoles(false, null, configReadable && rolesReadable && delegatesReadable);
+        }
+
+        var (canonical, humansReadable) = await this.CanonicaliseAsync(managed);
+
+        return new UserRoles(false, canonical.Length > 0 ? canonical : null,
+            configReadable && rolesReadable && delegatesReadable && humansReadable);
+    }
+
+    /// <summary>
+    /// Rewrites each grant to the <c>humans.id</c> it names, dropping the ones that name nothing.
+    /// </summary>
+    /// <remarks>
+    /// PoracleNG hands back whatever key the operator wrote in <c>[[discord.webhook_admins]] target</c>,
+    /// and upstream that key is the webhook's NAME -- the bot resolves it with <c>LookupWebhookByName</c>
+    /// and authorises with <c>CanAdminWebhook(cfg, userID, nameOverride)</c>. Both consumers here compare
+    /// the strings to <c>humans.id</c>, a webhook URL, so a name-keyed delegate got a nav item off a
+    /// non-empty list, an empty My Webhooks table, and a 403 from impersonate. See #797.
+    /// <para>
+    /// A grant naming no webhook at all is dropped rather than carried. It could never match a human row
+    /// downstream, and carrying it renders a nav item onto a page that has nothing to show. When the
+    /// lookup itself fails the raw set is kept and the answer is marked unresolved, so a database blip
+    /// does not strip a legitimate delegate for the cache TTL (#667).
+    /// </para>
+    /// </remarks>
+    private async Task<(string[] Canonical, bool Readable)> CanonicaliseAsync(HashSet<string> managed)
+    {
+        IEnumerable<Core.Models.Human> webhooks;
+        try
+        {
+            webhooks = await this._humanService.GetWebhooksAsync();
+        }
+        catch (Exception ex)
+        {
+            LogWebhookLookupFailed(this._logger, ex);
+            return ([.. managed], false);
+        }
+
+        var byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var byId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var webhook in webhooks)
+        {
+            byId[webhook.Id] = webhook.Id;
+            if (!string.IsNullOrWhiteSpace(webhook.Name))
+            {
+                byName.TryAdd(webhook.Name, webhook.Id);
+            }
+        }
+
+        var canonical = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var grant in managed)
+        {
+            if (byId.TryGetValue(grant, out var id) || byName.TryGetValue(grant, out id))
+            {
+                canonical.Add(id);
+            }
+            else
+            {
+                LogUnresolvedWebhookGrant(this._logger, grant);
+            }
+        }
+
+        return ([.. canonical], true);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch Poracle config for admin check for {UserId}.")]
@@ -196,4 +262,11 @@ public sealed partial class UserRoleResolver(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch webhook delegates for {UserId}.")]
     private static partial void LogPwebDelegatesFetchFailed(ILogger logger, Exception ex, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to look up webhooks while resolving delegated grants.")]
+    private static partial void LogWebhookLookupFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Delegated webhook grant {Grant} names neither a webhook id nor a webhook name; ignoring it.")]
+    private static partial void LogUnresolvedWebhookGrant(ILogger logger, string grant);
 }

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.html
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.html
@@ -49,7 +49,12 @@
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef>{{ 'ADMIN.COLUMN_ACTIONS' | translate }}</th>
           <td mat-cell *matCellDef="let wh">
-            <button mat-raised-button color="primary" (click)="manageAlarms(wh)" [matTooltip]="'ADMIN.MANAGE_ALARMS_TOOLTIP' | translate">
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="isImpersonating()"
+              (click)="manageAlarms(wh)"
+              [matTooltip]="(isImpersonating() ? 'ADMIN.MANAGE_ALARMS_IMPERSONATING' : 'ADMIN.MANAGE_ALARMS_TOOLTIP') | translate">
               <mat-icon>tune</mat-icon> {{ 'ADMIN.MANAGE_ALARMS' | translate }}
             </button>
           </td>

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.spec.ts
@@ -1,0 +1,75 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { MyWebhooksComponent } from './my-webhooks.component';
+import { AdminUser } from '../../core/models';
+import { AdminService } from '../../core/services/admin.service';
+import { AuthService } from '../../core/services/auth.service';
+
+describe('MyWebhooksComponent', () => {
+  const rows: AdminUser[] = [
+    { id: 'http://wh.example/a', name: 'teamharmonyrares', adminDisable: 0, currentProfileNo: 1, enabled: 1, type: 'webhook' },
+  ] as AdminUser[];
+
+  function setup(options: { impersonating?: boolean; managedWebhooks?: string[]; webhooks?: AdminUser[] } = {}) {
+    const adminService = { getManagedWebhooks: jest.fn(() => of(options.webhooks ?? rows)), impersonateById: jest.fn() };
+    const auth = {
+      impersonate: jest.fn(),
+      isImpersonating: signal(options.impersonating ?? false),
+      managedWebhooks: signal(options.managedWebhooks ?? []),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        { provide: AdminService, useValue: adminService },
+        { provide: AuthService, useValue: auth },
+        { provide: MatSnackBar, useValue: { open: jest.fn() } },
+      ],
+      imports: [MyWebhooksComponent, NoopAnimationsModule],
+    });
+
+    const fixture = TestBed.createComponent(MyWebhooksComponent);
+    fixture.detectChanges();
+    return { adminService, auth, component: fixture.componentInstance, fixture };
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  /**
+   * The rows used to be intersected with the client's own copy of the grant list, so any disagreement
+   * between the two produced an empty table and no error. That is what #797 looked like from the user's
+   * side: a nav item, a page, and nothing on it. The server already scopes the rows to the caller.
+   */
+  it('renders the rows the server returned without re-filtering them', () => {
+    const { component } = setup({ managedWebhooks: ['teamharmonyrares'] });
+
+    expect(component.webhooks()).toEqual(rows);
+  });
+
+  it('asks for the rows even when the client has no copy of the grant list', () => {
+    const { adminService } = setup({ managedWebhooks: [] });
+
+    expect(adminService.getManagedWebhooks).toHaveBeenCalled();
+  });
+
+  /**
+   * One localStorage slot holds the pre-impersonation token, so a second hop overwrites it and strands
+   * the caller. The API refuses it too; this keeps the button from offering what the server will reject.
+   */
+  it('offers Manage Alarms outside an impersonation session', () => {
+    expect(setup().component.isImpersonating()).toBe(false);
+  });
+
+  it('withdraws Manage Alarms inside an impersonation session', () => {
+    expect(setup({ impersonating: true }).component.isImpersonating()).toBe(true);
+  });
+});

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/admin/my-webhooks.component.ts
@@ -39,6 +39,8 @@ export class MyWebhooksComponent implements OnInit {
   private readonly snackBar = inject(MatSnackBar);
 
   readonly columns = ['name', 'url', 'status', 'actions'];
+  /** One slot holds the pre-impersonation token, so a second hop would strand the caller. See #797. */
+  readonly isImpersonating = this.auth.isImpersonating;
   readonly loading = signal(true);
   readonly webhooks = signal<AdminUser[]>([]);
 
@@ -53,13 +55,15 @@ export class MyWebhooksComponent implements OnInit {
       });
   }
 
+  /**
+   * The rows come back scoped to the caller, so they are rendered as they arrive.
+   *
+   * They used to be intersected with `auth.managedWebhooks()` first, which turned any disagreement
+   * between the two lists into an empty table with no error -- the shape of #797, where the server
+   * resolved a name-keyed grant to a webhook the client's copy of the list still named by name.
+   * The second filter could only ever subtract from an already-authorised set.
+   */
   ngOnInit(): void {
-    const managedIds = this.auth.managedWebhooks();
-    if (managedIds.length === 0) {
-      this.loading.set(false);
-      return;
-    }
-
     this.adminService
       .getManagedWebhooks()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -69,7 +73,7 @@ export class MyWebhooksComponent implements OnInit {
           this.snackBar.open(this.i18n.instant('ADMIN.SNACK_FAILED_LOAD_WEBHOOKS'), this.i18n.instant('TOAST.OK'), { duration: 3000 });
         },
         next: users => {
-          this.webhooks.set(users.filter(u => managedIds.includes(u.id)));
+          this.webhooks.set(users);
           this.loading.set(false);
         },
       });

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/da.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Bloker webhook",
     "UNBLOCK_WEBHOOK": "Fjern blokering af webhook",
     "MANAGE_ALARMS": "Administrer alarmer",
+    "MANAGE_ALARMS_IMPERSONATING": "Stop efterligning først for at administrere denne webhook",
     "MANAGE_ALARMS_TOOLTIP": "Administrer alarmer for denne webhook",
     "MANAGE_DELEGATES": "Administrer delegerede",
     "DELETE_WEBHOOK": "Slet webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/de.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Webhook sperren",
     "UNBLOCK_WEBHOOK": "Webhook entsperren",
     "MANAGE_ALARMS": "Alarme verwalten",
+    "MANAGE_ALARMS_IMPERSONATING": "Beende zuerst die Identitätsübernahme, um diesen Webhook zu verwalten",
     "MANAGE_ALARMS_TOOLTIP": "Alarme für diesen Webhook verwalten",
     "MANAGE_DELEGATES": "Delegierte verwalten",
     "DELETE_WEBHOOK": "Webhook löschen",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/en.json
@@ -1322,6 +1322,7 @@
     "BLOCK_WEBHOOK": "Block webhook",
     "UNBLOCK_WEBHOOK": "Unblock webhook",
     "MANAGE_ALARMS": "Manage Alarms",
+    "MANAGE_ALARMS_IMPERSONATING": "Stop impersonating first to manage this webhook",
     "MANAGE_ALARMS_TOOLTIP": "Manage alarms for this webhook",
     "MANAGE_DELEGATES": "Manage delegates",
     "DELETE_WEBHOOK": "Delete webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/es.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Bloquear webhook",
     "UNBLOCK_WEBHOOK": "Desbloquear webhook",
     "MANAGE_ALARMS": "Gestionar alarmas",
+    "MANAGE_ALARMS_IMPERSONATING": "Deja de suplantar primero para gestionar este webhook",
     "MANAGE_ALARMS_TOOLTIP": "Gestionar alarmas de este webhook",
     "MANAGE_DELEGATES": "Gestionar delegados",
     "DELETE_WEBHOOK": "Eliminar webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/fr.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Bloquer le webhook",
     "UNBLOCK_WEBHOOK": "Débloquer le webhook",
     "MANAGE_ALARMS": "Gérer les alarmes",
+    "MANAGE_ALARMS_IMPERSONATING": "Arrêtez d'abord l'usurpation d'identité pour gérer ce webhook",
     "MANAGE_ALARMS_TOOLTIP": "Gérer les alarmes pour ce webhook",
     "MANAGE_DELEGATES": "Gérer les délégués",
     "DELETE_WEBHOOK": "Supprimer le webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/it.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Blocca webhook",
     "UNBLOCK_WEBHOOK": "Sblocca webhook",
     "MANAGE_ALARMS": "Gestisci allarmi",
+    "MANAGE_ALARMS_IMPERSONATING": "Interrompi prima l'impersonificazione per gestire questo webhook",
     "MANAGE_ALARMS_TOOLTIP": "Gestisci allarmi per questo webhook",
     "MANAGE_DELEGATES": "Gestisci delegati",
     "DELETE_WEBHOOK": "Elimina webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/nl.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Webhook blokkeren",
     "UNBLOCK_WEBHOOK": "Webhook deblokkeren",
     "MANAGE_ALARMS": "Alarmen Beheren",
+    "MANAGE_ALARMS_IMPERSONATING": "Stop eerst met imiteren om deze webhook te beheren",
     "MANAGE_ALARMS_TOOLTIP": "Alarmen beheren voor deze webhook",
     "MANAGE_DELEGATES": "Gedelegeerden beheren",
     "DELETE_WEBHOOK": "Webhook verwijderen",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pl.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Zablokuj webhook",
     "UNBLOCK_WEBHOOK": "Odblokuj webhook",
     "MANAGE_ALARMS": "Zarządzaj alarmami",
+    "MANAGE_ALARMS_IMPERSONATING": "Najpierw zakończ podszywanie się, aby zarządzać tym webhookiem",
     "MANAGE_ALARMS_TOOLTIP": "Zarządzaj alarmami dla tego webhooka",
     "MANAGE_DELEGATES": "Zarządzaj delegatami",
     "DELETE_WEBHOOK": "Usuń webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt-BR.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Bloquear webhook",
     "UNBLOCK_WEBHOOK": "Desbloquear webhook",
     "MANAGE_ALARMS": "Gerenciar Alarmes",
+    "MANAGE_ALARMS_IMPERSONATING": "Pare a personificação primeiro para gerenciar este webhook",
     "MANAGE_ALARMS_TOOLTIP": "Gerenciar alarmes deste webhook",
     "MANAGE_DELEGATES": "Gerenciar delegados",
     "DELETE_WEBHOOK": "Excluir webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/pt.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Bloquear webhook",
     "UNBLOCK_WEBHOOK": "Desbloquear webhook",
     "MANAGE_ALARMS": "Gerir Alarmes",
+    "MANAGE_ALARMS_IMPERSONATING": "Pare primeiro a personificação para gerir este webhook",
     "MANAGE_ALARMS_TOOLTIP": "Gerir alarmes para este webhook",
     "MANAGE_DELEGATES": "Gerir delegados",
     "DELETE_WEBHOOK": "Eliminar webhook",

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/assets/i18n/sv.json
@@ -1321,6 +1321,7 @@
     "BLOCK_WEBHOOK": "Blockera webhook",
     "UNBLOCK_WEBHOOK": "Avblockera webhook",
     "MANAGE_ALARMS": "Hantera larm",
+    "MANAGE_ALARMS_IMPERSONATING": "Avsluta imitationen först för att hantera denna webhook",
     "MANAGE_ALARMS_TOOLTIP": "Hantera larm för denna webhook",
     "MANAGE_DELEGATES": "Hantera delegater",
     "DELETE_WEBHOOK": "Radera webhook",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A delegate configured in Poracle's own config can see their webhooks again.** Poracle reports a delegated webhook by the name the operator wrote in `webhook_admins`, and this site matched those strings against the webhook's URL, so a name matched nothing: the *My Webhooks* item appeared in the sidebar, the page it led to was empty, and the button on it would have been refused. Grants are now resolved to the webhook they name, whether the config names it by name or by URL, and a grant that names no webhook at all no longer puts an item in the sidebar ([#797](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/797)).
+- **Impersonating a delegate shows what the delegate sees.** *My Webhooks* was hidden inside an impersonation session -- the one place an admin looks to find out why someone is complaining -- while the page and its actions would both have answered. Impersonating a second account from inside that session is refused, since only one token can be held for the way back out ([#797](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/797)).
+
 ## [2.17.1] - 2026-08-21
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,20 @@ each time because one surface disagreed with another:
 | #601 | reading the claim let a revoked delegate keep access for 24 hours |
 | #626 | resolving from the local table alone refused a PoracleJS-configured delegate the nav item had just offered |
 | #786 | `/api/auth/me` still read the claim, so a *new* delegate could not find a page that would have let them in |
+| #797 | all three agreed on the union and disagreed on what the strings in it *identify* — see below |
+
+**A grant names a webhook; it is not necessarily its id.** PoracleNG returns whatever key the operator
+wrote in `[[discord.webhook_admins]] target`, and upstream that key is the webhook's **name** — the bot
+resolves it with `LookupWebhookByName` and authorises with `CanAdminWebhook(cfg, userID, nameOverride)`.
+The local delegate table stores ids. `UserRoleResolver` therefore canonicalises every grant to a
+`humans.id` (id first, then name, case-insensitively) before returning it, and drops what names neither:
+a grant that matches no row could never match one downstream, and carrying it drew a nav item onto an
+empty page. Consumers may assume `ManagedWebhooks` holds ids. See #797.
+
+An impersonation session resolves `managedWebhooks` live, like every other surface, because `this.UserId`
+is the account the whole session is acting as — the same account `my-webhooks` and `POST impersonate`
+already answer for. `IsAdmin` is the carve-out, not this. Chaining a second impersonation is refused
+server-side: the SPA holds one `poracle_admin_token`, so a second hop overwrites the way back out.
 
 The `managedWebhooks` JWT claim is now a **cold fallback only**, used when a resolve is degraded so an
 outage does not strip a delegate mid-session. Nothing authorises off it. Do not reintroduce it as a

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
@@ -5,6 +5,9 @@ namespace Pgan.PoracleWebNet.Core.Abstractions.Repositories;
 public interface IHumanRepository
 {
     public Task<IEnumerable<Human>> GetAllAsync();
+
+    /// <summary>The webhook humans, id and name. Used to resolve a delegated webhook named by name.</summary>
+    public Task<IEnumerable<Human>> GetWebhooksAsync();
     public Task<Human?> GetByIdAsync(string id);
     public Task<Human> CreateAsync(Human human);
     public Task<Human> UpdateAsync(Human human);

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IHumanService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IHumanService.cs
@@ -5,6 +5,9 @@ namespace Pgan.PoracleWebNet.Core.Abstractions.Services;
 public interface IHumanService
 {
     public Task<IEnumerable<Human>> GetAllAsync();
+
+    /// <summary>The webhook humans, id and name. Used to resolve a delegated webhook named by name.</summary>
+    public Task<IEnumerable<Human>> GetWebhooksAsync();
     public Task<Human?> GetByIdAsync(string id);
     public Task<Human> CreateAsync(Human human);
     public Task<Human> UpdateAsync(Human human);

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
@@ -22,6 +22,12 @@ public class HumanRepository(PoracleContext context) : IHumanRepository
         return entities.Select(e => e.ToModel());
     }
 
+    public async Task<IEnumerable<Human>> GetWebhooksAsync()
+    {
+        var entities = await this._context.Humans.Where(h => h.Type == "webhook").ToListAsync();
+        return entities.Select(e => e.ToModel());
+    }
+
     public async Task<Human?> GetByIdAsync(string id)
     {
         var entity = await this._context.Humans.FirstOrDefaultAsync(h => h.Id == id);

--- a/Core/Pgan.PoracleWebNet.Core.Services/HumanService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/HumanService.cs
@@ -29,6 +29,8 @@ public class HumanService(
     // See: docs/poracleng-enhancement-requests.md
     public async Task<IEnumerable<Human>> GetAllAsync() => await this._repository.GetAllAsync();
 
+    public async Task<IEnumerable<Human>> GetWebhooksAsync() => await this._repository.GetWebhooksAsync();
+
     public async Task<Human?> GetByIdAsync(string id)
     {
         var json = await this._humanProxy.GetHumanAsync(id);

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AdminControllerTests.cs
@@ -427,6 +427,62 @@ public class AdminControllerTests : ControllerTestBase
         Assert.IsType<NotFoundResult>(await this._sut.ImpersonateById(new AdminController.ImpersonateRequest("u1")));
     }
 
+    /// <summary>
+    /// No second hop from inside an impersonation session. The SPA stashes the caller's own token in a
+    /// single poracle_admin_token slot, so a second hop overwrites it with the first impersonated one and
+    /// strands whoever started with no way back. Reachable only since #797 put the My Webhooks nav item
+    /// back inside impersonation sessions; nothing legitimate chained before it, and nothing does now.
+    /// </summary>
+    [Fact]
+    public async Task ImpersonateByIdRefusesAHopFromInsideAnImpersonationSession()
+    {
+        SetupImpersonatingUser(this._sut, isAdmin: true);
+        this._roleResolver.Setup(r => r.ResolveAsync(It.IsAny<string>()))
+            .ReturnsAsync(new Pgan.PoracleWebNet.Api.Services.UserRoles(false, ["u1"]));
+        this._humanService.Setup(s => s.GetByIdAsync("u1"))
+            .ReturnsAsync(new Human { Id = "u1", Name = "WH", Type = "webhook", Enabled = 1, AdminDisable = 0, CurrentProfileNo = 1 });
+
+        Assert.IsType<ForbidResult>(await this._sut.ImpersonateById(new AdminController.ImpersonateRequest("u1")));
+    }
+
+    // --- GetManagedWebhooks (#797) ---
+
+    /// <summary>
+    /// The grant PoracleNG reports is the webhook's NAME, and this page matches on humans.id. The
+    /// resolver canonicalises it, so what arrives here is an id and the row is found -- the delegate
+    /// used to get the nav item and an empty table. See #797.
+    /// </summary>
+    [Fact]
+    public async Task GetManagedWebhooksListsTheWebhookADelegateWasGrantedByName()
+    {
+        SetupUser(this._sut, isAdmin: false);
+        this._roleResolver.Setup(r => r.ResolveAsync("123456789"))
+            .ReturnsAsync(new Pgan.PoracleWebNet.Api.Services.UserRoles(false, ["http://wh.example/a"]));
+        this._humanService.Setup(s => s.GetAllAsync()).ReturnsAsync(
+        [
+            new Human { Id = "http://wh.example/a", Name = "teamharmonyrares", Type = "webhook" },
+            new Human { Id = "http://wh.example/b", Name = "100iv", Type = "webhook" },
+        ]);
+
+        var ok = Assert.IsType<OkObjectResult>(await this._sut.GetManagedWebhooks());
+
+        var rows = Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value);
+        Assert.Single(rows);
+    }
+
+    [Fact]
+    public async Task GetManagedWebhooksReturnsNothingWhenTheCallerHasNoGrants()
+    {
+        SetupUser(this._sut, isAdmin: false);
+        this._roleResolver.Setup(r => r.ResolveAsync("123456789"))
+            .ReturnsAsync(new Pgan.PoracleWebNet.Api.Services.UserRoles(false, null));
+
+        var ok = Assert.IsType<OkObjectResult>(await this._sut.GetManagedWebhooks());
+
+        Assert.Empty(Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value));
+        this._humanService.Verify(s => s.GetAllAsync(), Times.Never);
+    }
+
     // --- WebhookDelegates ---
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/AuthControllerMeTests.cs
@@ -298,11 +298,19 @@ public class AuthControllerMeTests : ControllerTestBase
     }
 
     /// <summary>
-    /// While impersonating, this.UserId is the impersonated account, so resolving its delegations answers
-    /// a different question than "what may this session manage" — the trap #663 fixed for admin status.
+    /// This asserted the opposite until #797: the carve-out returned the JWT claim, which an impersonation
+    /// token never carries, so the answer was always "manages nothing" and the My Webhooks nav item could
+    /// not render inside an impersonation session — while GET /api/admin/my-webhooks and
+    /// POST /api/admin/impersonate, both resolving off the same this.UserId, would have let it through.
+    /// An admin could not see the page the delegate they were inspecting sees.
+    /// <para>
+    /// Not the #663 trap. That one re-elevated ADMIN rights the impersonation token deliberately drops;
+    /// isAdmin still comes from the claim. This asks what the effective account manages, which is what
+    /// every other surface already answers.
+    /// </para>
     /// </summary>
     [Fact]
-    public async Task MeDoesNotResolveDelegationsForAnImpersonatedAccount()
+    public async Task MeResolvesDelegationsForTheImpersonatedAccount()
     {
         SetupUser(this._sut, profileNo: 1);
         this._sut.ControllerContext.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
@@ -314,12 +322,12 @@ public class AuthControllerMeTests : ControllerTestBase
                 new Claim("impersonatedBy", "admin-1"),
             ], "TestAuth"));
         this.SetupHuman(profileNo: 1);
-        this.Resolves(["http://webhook.example/not-mine"]);
+        this.Resolves(["http://webhook.example/delegated"]);
 
         var ok = Assert.IsType<OkObjectResult>(await this._sut.Me());
 
-        Assert.Null(Assert.IsType<UserInfo>(ok.Value).ManagedWebhooks);
-        this._roleResolver.Verify(r => r.ResolveAsync(It.IsAny<string>()), Times.Never);
+        Assert.Equal(["http://webhook.example/delegated"], Assert.IsType<UserInfo>(ok.Value).ManagedWebhooks);
+        this._roleResolver.Verify(r => r.ResolveAsync("123456789"), Times.Once);
     }
 
     private void Resolves(string[] webhooks) =>

--- a/Tests/Pgan.PoracleWebNet.Tests/Controllers/ControllerTestBase.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Controllers/ControllerTestBase.cs
@@ -6,7 +6,7 @@ namespace Pgan.PoracleWebNet.Tests.Controllers;
 
 public abstract class ControllerTestBase
 {
-    protected static void SetupUser(ControllerBase controller, string userId = "123456789", int profileNo = 1, bool isAdmin = false, string username = "TestUser", string[]? managedWebhooks = null)
+    protected static void SetupUser(ControllerBase controller, string userId = "123456789", int profileNo = 1, bool isAdmin = false, string username = "TestUser", string[]? managedWebhooks = null, string? impersonatedBy = null)
     {
         var claims = new List<Claim>
         {
@@ -21,6 +21,11 @@ public abstract class ControllerTestBase
             claims.Add(new Claim("managedWebhooks", string.Join(',', managedWebhooks)));
         }
 
+        if (impersonatedBy is not null)
+        {
+            claims.Add(new Claim("impersonatedBy", impersonatedBy));
+        }
+
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
 
@@ -29,4 +34,9 @@ public abstract class ControllerTestBase
             HttpContext = new DefaultHttpContext { User = principal }
         };
     }
+
+    /// <summary>A session inspecting somebody else's account: <c>userId</c> names the account being looked at.</summary>
+    protected static void SetupImpersonatingUser(ControllerBase controller, string userId = "123456789", int profileNo = 1,
+        bool isAdmin = false, string impersonatedBy = "admin-1") =>
+        SetupUser(controller, userId, profileNo, isAdmin, impersonatedBy: impersonatedBy);
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserRoleResolverTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserRoleResolverTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -18,10 +19,14 @@ public class UserRoleResolverTests
 {
     private readonly Mock<IPoracleApiProxy> _poracleApiProxy = new();
     private readonly Mock<IWebhookDelegateService> _webhookDelegateService = new();
+    private readonly Mock<IHumanService> _humanService = new();
+
+    private const string TeamHarmonyRares = "https://discordapp.com/api/webhooks/863186716952100874/token";
 
     private UserRoleResolver CreateSut(string adminIds = "") => new(
         this._poracleApiProxy.Object,
         this._webhookDelegateService.Object,
+        this._humanService.Object,
         Options.Create(new PoracleSettings { AdminIds = adminIds }),
         new MemoryCache(new MemoryCacheOptions()),
         NullLogger<UserRoleResolver>.Instance);
@@ -80,5 +85,98 @@ public class UserRoleResolverTests
         Assert.False(roles.IsAdmin);
         Assert.True(roles.Resolved);
         this._poracleApiProxy.Verify(p => p.GetAdminRolesAsync("u1"), Times.Once);
+    }
+    /// <summary>
+    /// The defect: PoracleNG returns whatever key the operator wrote in <c>[[discord.webhook_admins]]</c>,
+    /// and upstream that key is the webhook's NAME -- the bot looks it up with <c>LookupWebhookByName</c>.
+    /// Verified against prod 5.1.0, where <c>getAdministrationRoles</c> for a live delegate answers
+    /// <c>{"webhooks":["teamharmonyrares", ...]}</c>. Both consumers compare the strings to
+    /// <c>humans.id</c>, so the delegate got a nav item, an empty table and a 403. See #797.
+    /// </summary>
+    [Fact]
+    public async Task AWebhookNamedByNameResolvesToItsId()
+    {
+        this.ArrangeDelegate(["teamharmonyrares"]);
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.Equal([TeamHarmonyRares], roles.ManagedWebhooks);
+        Assert.True(roles.Resolved);
+    }
+
+    /// <summary>
+    /// The legitimate-case-still-passes half. A grant written as the webhook URL -- what the admin dialog
+    /// stores in <c>poracle_web.webhook_delegates</c>, and what a PoracleJS-style config carries -- must
+    /// survive canonicalisation untouched.
+    /// </summary>
+    [Fact]
+    public async Task AWebhookNamedByIdIsKept()
+    {
+        this.ArrangeDelegate([TeamHarmonyRares]);
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.Equal([TeamHarmonyRares], roles.ManagedWebhooks);
+    }
+
+    [Fact]
+    public async Task TheSameWebhookNamedBothWaysIsListedOnce()
+    {
+        this.ArrangeDelegate(["teamharmonyrares", TeamHarmonyRares]);
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.Equal([TeamHarmonyRares], roles.ManagedWebhooks);
+    }
+
+    /// <summary>
+    /// A grant naming no webhook at all is dropped. It could never match a human row downstream, so
+    /// carrying it rendered the My Webhooks nav item onto a page with nothing on it -- which is exactly
+    /// what a config whose targets were mangled by the JSON-to-TOML conversion produces.
+    /// </summary>
+    [Fact]
+    public async Task AGrantNamingNothingIsDropped()
+    {
+        this.ArrangeDelegate(["https://discordapp.com/api/webhooks/863186716952100874/to_ken"]);
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.Null(roles.ManagedWebhooks);
+        Assert.True(roles.Resolved);
+    }
+
+    /// <summary>
+    /// The lookup is a fourth source, and a blip in it must not strip a legitimate delegate for the cache
+    /// TTL -- the shape of #667. The raw grants are kept and the answer marked unresolved, so the caller
+    /// falls back to the claim rather than to nothing.
+    /// </summary>
+    [Fact]
+    public async Task AFailedWebhookLookupKeepsTheGrantsAndReportsUnresolved()
+    {
+        this.ArrangeDelegate(["teamharmonyrares"]);
+        this._humanService.Setup(h => h.GetWebhooksAsync()).ThrowsAsync(new InvalidOperationException("db down"));
+
+        var roles = await this.CreateSut().ResolveAsync("u1");
+
+        Assert.Equal(["teamharmonyrares"], roles.ManagedWebhooks);
+        Assert.False(roles.Resolved);
+    }
+
+    private void ArrangeDelegate(string[] grants)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            admin = new { discord = new { channels = Array.Empty<string>(), webhooks = grants, users = false } },
+            status = "ok",
+        });
+
+        this._poracleApiProxy.Setup(p => p.GetConfigAsync()).ReturnsAsync((PoracleConfig?)null!);
+        this._poracleApiProxy.Setup(p => p.GetAdminRolesAsync(It.IsAny<string>())).ReturnsAsync(payload);
+        this._webhookDelegateService.Setup(s => s.GetManagedWebhookIdsAsync(It.IsAny<string>())).ReturnsAsync([]);
+        this._humanService.Setup(h => h.GetWebhooksAsync()).ReturnsAsync(
+        [
+            new Human { Id = TeamHarmonyRares, Name = "teamharmonyrares", Type = "webhook" },
+            new Human { Id = "https://discordapp.com/api/webhooks/863186778525925396/other", Name = "100iv", Type = "webhook" },
+        ]);
     }
 }

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -76,6 +76,11 @@ Three sources, unioned on every check:
 3. **Administrators**, from `PORACLE_ADMIN_IDS` or Poracle's `admins` list, who can manage any
    webhook and are never listed as delegates of a particular one.
 
+A Poracle-side grant names its webhook however the operator wrote it in `webhook_admins` — by the
+webhook's name, or by its URL. Either is resolved to the webhook it names before anything is decided,
+so both work. A grant naming a webhook this Poracle has no account for is ignored: it grants access to
+nothing, and counting it would put **My Webhooks** in the sidebar over an empty page.
+
 The answer is cached for a minute per person, so granting or revoking takes effect within about that
 long rather than at their next sign-in. A lookup that cannot reach one of its sources is never
 cached, and falls back to what the session already knew rather than dropping access mid-session.
@@ -87,9 +92,18 @@ webhook. Check the grant exists on the webhook's delegates dialog, and that they
 once before being granted — a grant to an account that never existed is refused, so an absent chip
 means it was never written.
 
+**Impersonating them hides the page.** It does not any more — an impersonation session sees the
+delegate's webhooks, which is the point of looking. Impersonating a second account from inside that
+session is refused; leave the first one before starting another.
+
 **They can see it in Discord but not here, or the reverse.** These are separate grants. The bot side
 is Poracle's config; this side is the delegates dialog. Having one does not imply the other, although
 a Poracle-side grant does also work here.
+
+**My Webhooks is in the sidebar but the page is empty.** The grant names a webhook that does not exist
+here. The usual cause is a `webhook_admins` target that no longer matches any webhook — a URL whose
+token was rewritten when the config was converted from PoracleJS's JSON, for instance. Naming the
+webhook by its name rather than its URL avoids the whole class of problem.
 
 **A revoked delegate still has access.** Give it a minute — the resolution is cached that long.
 Beyond that, check whether they are a global admin or hold a Poracle-side grant, both of which this


### PR DESCRIPTION
Closes #797.

## What was wrong

Two symptoms, verified against prod (PoracleNG 5.1.0) rather than inferred.

**A delegate configured in Poracle's config saw the nav item and an empty page.** PoracleNG returns a
delegated webhook as whatever key the operator wrote in `[[discord.webhook_admins]] target`, and
upstream that key is the webhook's **name** — the bot resolves it with `LookupWebhookByName` and
authorises with `CanAdminWebhook(cfg, userID, nameOverride)` (`processor/internal/bot/target.go:145`):

```
GET /api/humans/293131677008658444/getAdministrationRoles
{"admin":{"discord":{"webhooks":["teamharmonynests","teamharmonytasks","teamharmony100iv",
                                 "teamharmonypvp","teamharmonyrares"],...
```

PoracleWeb.NET compared those to `humans.id`, a webhook URL. `/api/auth/me` reported a non-empty list
so the nav item rendered; `my-webhooks` filtered every row away; `impersonate` answered 403. Same
union on all three surfaces, disagreement about what the strings in it identify — the fifth entry in
that table in CLAUDE.md.

**Impersonating that delegate hid the page entirely.** `ResolveManagedWebhooksAsync` short-circuited
on `IsImpersonating` and returned the JWT claim, which `GenerateImpersonationToken` never sets — so
the answer was always "manages nothing", while the two surfaces behind it, both resolving off the same
`this.UserId`, would have let it through.

## What changed

- `UserRoleResolver` canonicalises every grant to a `humans.id`: exact id first, then webhook name,
  case-insensitively. Consumers may now assume the array holds ids.
- A grant naming neither is dropped. It could never match a row downstream, so carrying it only ever
  drew a nav item over an empty page. A failed lookup keeps the raw grants and marks the answer
  unresolved instead, so a database blip does not strip a delegate for the cache minute (#667's shape).
- `/api/auth/me` resolves live under impersonation. `isAdmin` still comes from the claim — that is the
  #663 carve-out and it is untouched.
- `POST /api/admin/impersonate` refuses a hop from inside an impersonation session. The SPA stashes the
  caller's token in one `poracle_admin_token` slot, so a second hop overwrites the way back out.
  Nothing reached this before: the nav item was hidden, and the admin user list refuses an
  impersonation token anyway.
- The My Webhooks page renders the rows the server returned instead of intersecting them with its own
  copy of the list.

## Tests

`AWebhookNamedByIdIsKept` and `ImpersonateByIdAllowsDelegateWhenManagedWebhookMatches` are the
legitimate-case-still-passes half of the drop rule. 2130 backend, 1164 frontend, lint, prettier and
`npm run build` all clean.

## Not fixed here, needs a config edit on the host

30 of the 35 `[[discord.webhook_admins]]` targets in prod's `config.toml` were snake_cased during the
JSON→TOML conversion:

```
PoracleJS: .../webhooks/863180166905987092/RjrUMWx0EEVRXY0AMP-Hfl-92WfbhVKfhlRfm5r79Ynvk...
PoracleNG: .../webhooks/863180166905987092/rjr_um_wx0_eevrxy0_amp-hfl-92_wfbh_v_kfhl_rfm5r79_ynvk...
```

Those grants are dead in the bot too, so this deliberately does not un-mangle them — that would grant
here what Poracle itself refuses. Rewriting those targets as webhook names fixes both sides at once.

https://claude.ai/code/session_01JWWffXvVcZBTDwUuBFuZZ4
