### PR TITLE
fix(pokemon): the PVP rank range was white on white in dark mode

### DIFF
--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.scss
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pokemon-list.component.scss
@@ -347,6 +347,9 @@
   background: #e3f2fd;
   color: #1565c0;
 }
+// The band keeps its fixed light background in both themes, so every colour on it is
+// fixed too. A theme variable here (--text-muted is white at 50% under .dark-theme)
+// paints white on #f5f5f5 and the rank range vanishes. See #800.
 .pvp-row {
   display: flex;
   align-items: center;
@@ -362,7 +365,8 @@
   gap: 4px;
   font-size: 12px;
   font-weight: 500;
-  color: #f57f17;
+  // #f57f17 reads at 2.4:1 on this band; #e65100 (the cp-pill orange) clears 4.5:1.
+  color: #e65100;
 }
 .pvp-badge mat-icon {
   font-size: 16px;
@@ -371,7 +375,7 @@
 }
 .pvp-rank {
   font-size: 12px;
-  color: var(--text-muted, rgba(0, 0, 0, 0.64));
+  color: rgba(0, 0, 0, 0.64);
 }
 .ping-info {
   display: flex;

--- a/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pvp-band-contrast.spec.ts
+++ b/Applications/Pgan.PoracleWebNet.App/ClientApp/src/app/modules/pokemon/pvp-band-contrast.spec.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The PVP band on a Pokemon alarm card keeps a fixed light background (`#f5f5f5`) in both themes,
+ * so every colour painted on it must be fixed too.
+ *
+ * `.pvp-rank` used `var(--text-muted)`, which `styles.scss` sets to `rgba(255, 255, 255, 0.5)` under
+ * `body.dark-theme`. That put the rank range at roughly 1.1:1 on the band: rendered, present in the
+ * DOM, and invisible. Users read it as the ranks they had set having been dropped. See #800.
+ *
+ * Asserted against the stylesheet because that is where the defect lives — jsdom resolves neither
+ * custom properties nor contrast, so a rendered-component test could not tell the two colours apart.
+ */
+describe('PVP band colours', () => {
+  const scss = readFileSync(join(__dirname, 'pokemon-list.component.scss'), 'utf8');
+
+  /** The declarations of a top-level rule, e.g. `.pvp-rank`. */
+  function ruleBody(selector: string): string {
+    const start = scss.indexOf(`\n${selector} {`);
+    expect(start).toBeGreaterThan(-1);
+    const end = scss.indexOf('\n}', start);
+    return scss.slice(start, end);
+  }
+
+  it('paints the band itself with a fixed background', () => {
+    // If this ever becomes theme-driven, the rules below can go back to theme variables.
+    expect(ruleBody('.pvp-row')).toContain('background: #f5f5f5;');
+  });
+
+  it.each(['.pvp-rank', '.pvp-badge'])('gives %s a literal colour, not a theme variable', selector => {
+    const body = ruleBody(selector);
+    expect(body).toMatch(/color: (#|rgba?\()/);
+    expect(body).not.toContain('var(--');
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The PVP rank range is readable again on a dark-themed alarm card.** The band under a PVP alarm showed its league and nothing else, so the ranks you had set looked like they had been dropped. They were being drawn, in white, on a band that stays light in both themes. The league name gained some contrast on the way past ([#800](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/800)).
 - **A delegate configured in Poracle's own config can see their webhooks again.** Poracle reports a delegated webhook by the name the operator wrote in `webhook_admins`, and this site matched those strings against the webhook's URL, so a name matched nothing: the *My Webhooks* item appeared in the sidebar, the page it led to was empty, and the button on it would have been refused. Grants are now resolved to the webhook they name, whether the config names it by name or by URL, and a grant that names no webhook at all no longer puts an item in the sidebar ([#797](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/797)).
 - **Impersonating a delegate shows what the delegate sees.** *My Webhooks* was hidden inside an impersonation session -- the one place an admin looks to find out why someone is complaining -- while the page and its actions would both have answered. Impersonating a second account from inside that session is refused, since only one token can be held for the way back out ([#797](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/797)).
 


### PR DESCRIPTION
Closes #800.

## What was wrong

A PVP alarm's card showed the amber league band and nothing beside it, so the ranks the user had set read as having been dropped.

They were being drawn. `.pvp-rank` took its colour from `var(--text-muted)`, which `styles.scss` sets to `rgba(255, 255, 255, 0.5)` under `body.dark-theme`, while the band's own background is a hardcoded `#f5f5f5` in both themes. About 1.1:1 contrast. Light mode is unaffected, which is why this went unnoticed.

## The fix

The band pairs its fixed background with fixed foregrounds now, the way every filter pill on the same card already does. The league name moves from `#f57f17` to the cp-pill `#e65100` while it is in reach — legible before, but only 2.4:1.

## Siblings

`.pvp-row` is the only place in the codebase mixing a fixed background with a theme-driven colour. The pill rules in `pokemon-list` and `profile-overview` hardcode both halves, and the remaining `var(--text-*)` rules in this file sit on the themed card background where they belong.

## Testing

`pvp-band-contrast.spec.ts` asserts the band keeps its fixed background and that both colours on it are literals. It was watched failing against the old stylesheet before the fix went in. jsdom resolves neither custom properties nor contrast, so the stylesheet is what it reads.

`npm run build`, the pokemon suite (29 tests), eslint and prettier all pass.
