### PR TITLE
feat(pokemon): write edits through PoracleNG's /api/v2 surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,11 @@ PORACLE_API_SECRET=your_poracle_api_secret
 # Comma-separated Discord/Telegram user IDs for admin access
 PORACLE_ADMIN_IDS=your_discord_user_id
 
+# Which PoracleNG tracking API pokemon edits are written through: auto, v1 or v2.
+# auto (the default) uses the strict /api/v2 surface on PoracleNG 5.2.0 and later and v1 below that.
+# Set v1 to stay on the old surface, or v2 for a fork that carries the routes without saying so.
+PORACLE_TRACKING_API_VERSION=auto
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # KOJI — Geofence API (required for custom geofences feature)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/Applications/Pgan.PoracleWebNet.Api/Filters/TrackingRuleNotFoundExceptionFilter.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Filters/TrackingRuleNotFoundExceptionFilter.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Api.Filters;
+
+/// <summary>
+/// Turns a write against a rule that is not there into 404 Not Found.
+/// </summary>
+/// <remarks>
+/// Registered globally alongside <see cref="TrackingConflictExceptionFilter"/> and
+/// <see cref="AlarmValidationExceptionFilter"/>. Only the uid-addressed <c>/api/v2</c> PUT can report this
+/// at all, and it means the row went away between the controller reading it and the write landing — a
+/// second tab, the bot, or the active-hours scheduler. 404 tells the SPA to reload the list; a 500 would
+/// tell the user the server broke.
+/// </remarks>
+public sealed class TrackingRuleNotFoundExceptionFilter : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Exception is not TrackingRuleNotFoundException ex)
+        {
+            return;
+        }
+
+        context.Result = new NotFoundObjectResult(new
+        {
+            error = ex.Message,
+            trackingType = ex.TrackingType,
+        });
+        context.ExceptionHandled = true;
+    }
+}

--- a/Applications/Pgan.PoracleWebNet.Api/Program.cs
+++ b/Applications/Pgan.PoracleWebNet.Api/Program.cs
@@ -91,6 +91,7 @@ MapEnvVar("AUTH_FORCE_LOCAL", "Auth__ForceLocal");
 MapEnvVar("PORACLE_API_ADDRESS", "Poracle__ApiAddress");
 MapEnvVar("PORACLE_API_SECRET", "Poracle__ApiSecret");
 MapEnvVar("PORACLE_ADMIN_IDS", "Poracle__AdminIds");
+MapEnvVar("PORACLE_TRACKING_API_VERSION", "Poracle__TrackingApiVersion");
 MapEnvVar("KOJI_API_ADDRESS", "Koji__ApiAddress");
 MapEnvVar("KOJI_BEARER_TOKEN", "Koji__BearerToken");
 MapEnvVar("KOJI_PROJECT_ID", "Koji__ProjectId");
@@ -187,6 +188,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.SummaryBackendUnavailableExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.TrackingConflictExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AlarmValidationExceptionFilter>();
+    options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.TrackingRuleNotFoundExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.AccountGoneExceptionFilter>();
     options.Filters.Add<Pgan.PoracleWebNet.Api.Filters.BlockedAccountFilter>();
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pokemon alarm edits are written through PoracleNG 5.2.1’s strict `/api/v2` surface, where the server can tell an edit apart from a takeover.** Nothing changes on screen. What changes is underneath: an edit now addresses the rule by its id, so Poracle refuses outright if the uid is not yours or if the result would duplicate an alarm you already have, instead of PoracleWeb.NET having to work that out from a success response and undo it afterwards. Poracle also explains a rejected filter field by name now, so the message on the dialog says which one. Anything older than 5.2.0 keeps the surface it has always used, unchanged, and so do the other nine alarm types; an edit carrying anything the new surface cannot express takes the old path rather than failing. Set `PORACLE_TRACKING_API_VERSION` to `v1` or `v2` to pin it ([#805](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/805)).
+
 ### Fixed
 
 - **The PVP rank range is readable again on a dark-themed alarm card.** The band under a PVP alarm showed its league and nothing else, so the ranks you had set looked like they had been dropped. They were being drawn, in white, on a band that stays light in both themes. The league name gained some contrast on the way past ([#800](https://github.com/PGAN-Dev/PoracleWeb.NET/issues/800)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,6 +541,63 @@ When comparing, **a field PoracleWeb does not supply cannot be compared** — Po
 
 See #462, #463, #531, #553, #561.
 
+### The `/api/v2` Pilot: Pokemon Edits Only, And Pokemon Now Rotates Its uid
+
+PoracleNG 5.2.0 added a second tracking surface. `PUT /api/v2/humans/{id}/tracking/pokemon/{uid}` is
+addressed by uid: it 404s when the uid is not that human's and 409s when the replacement would exactly
+duplicate another rule, so the server enforces what `EnsureNoMergeIntoAnotherAlarmAsync` had to
+reconstruct from a 200. **v2 POST still diffs and merges** — the #561 takeover reproduces on it — so
+creates stay on v1 and the reconciler stays.
+
+**Only `MonsterService.UpdateAsync` uses it.** Everything else — every read, `CreateAsync`,
+`BulkCreateAsync`, both distance endpoints, and all nine other types — is unchanged on v1, which 5.2.1
+left frozen. Reads deliberately stay on v1: v2 answers `null` for every field at its wildcard where v1
+answers the sentinel, and both `Monster` (C#) and `Monster` (TS) are built on the sentinels. Rebuilding
+them from nulls means a per-field default table that must match PoracleNG exactly, and one wrong entry
+silently rewrites a filter on the user's next save.
+
+**The v2 PUT is delete-then-insert, so pokemon now rotates its uid on edit like the other nine.** It was
+the one exception, and three places in this file used to say so. `MonsterService` therefore takes
+`ITrackedUidRemapper`, and `TrackedUidRemapperCoverageTests` lists it among the rotating services rather
+than exempting it. Quick-pick applied state is the thing that actually breaks without the remap (#403).
+Note that `EnsureNoMergeIntoAnotherAlarmAsync` already early-returned for pokemon *updates* (#606), so
+moving to v2 removes no guard that was running.
+
+Three shape differences, all handled once at the wire in `TrackingV2Translator`:
+
+| v1 | v2 |
+|---|---|
+| `clean` 3-bit mask | separate `clean` / `edit` / `summary` booleans |
+| `gender` 0-3 | `any` / `male` / `female` / `genderless` |
+| `pvp_ranking_league` any int | enum of `{0, 500, 1500, 2500}` |
+
+Plus `uid`, `id`, `profile_no`, `ping` and `description`, which v2 has no place for and refuses outright:
+`V2PokemonRule` sets `additionalProperties: false`, so one stray property is a 422 and the write fails.
+The v1 shape stays the single internal currency — `TrackingFieldPreserver`, `TrackingUpdateReconciler`,
+`BulkUidRemap` and `QuickPickService` all build and compare it — and the translator is the only exit onto
+v2, which is what stops a v1-shaped row reaching a v2 body.
+
+**The translator never changes what PoracleNG will accept.** A property it does not know, a gender outside
+0-3, a league outside the enum: it answers false and the row goes to v1. Refusing would mean a newer
+PoracleNG broke every pokemon edit; dropping the field would be #730 again.
+
+**A v2 PUT is a full replace** — omitting `min_iv` wipes a stored 90, verified live — so
+`TrackingFieldPreserver` matters more here than it did on v1, not less.
+
+Errors are RFC 9457 problem+json at **422**, not 400, in two shapes: a schema failure carries `errors[]`
+whose `location` is `body.x` on a PUT and `body[0].x` on a POST, and a semantic refusal carries only
+`detail`. `PoracleProblemDetails` reads both, plus v1's `{"message":...}`. PR #811 adds
+`PoracleErrorMessage.cs` doing the same job for the create path; whichever lands second should collapse
+them.
+
+Gating: `PoracleServerProfile.SupportsV2Tracking` is version >= 5.2.0. Not the `/health` capability map —
+5.2.1 advertises nothing about v2. Unreachable answers false, which is the safe direction here even
+though `UpstreamFeatureFlagService` deliberately fails the other way. `Poracle:TrackingApiVersion`
+(`auto` | `v1` | `v2`, env `PORACLE_TRACKING_API_VERSION`) pins it for a fork whose version says the wrong
+thing, and the proxy falls back to v1 for five minutes when the route answers gin's plaintext
+`404 page not found` — that fallback is the only thing standing between a downgraded server and an outage
+window the length of the profile cache.
+
 ### Keep the PoracleNG Checkout Pinned To What Prod Runs
 
 `E:/PGAN/pogogit/PoracleNG` drifts. On 2026-08-08 it was four months behind prod, and its `DiffTracking` lacked the `totalDiffs == 1` clause entirely — reading it produced three wrong fixes in one day.
@@ -761,6 +818,8 @@ dotnet ef migrations script \
 | PoracleTrackingProxy | `Core/Pgan.PoracleWebNet.Core.Services/PoracleTrackingProxy.cs` |
 | PoracleHumanProxy | `Core/Pgan.PoracleWebNet.Core.Services/PoracleHumanProxy.cs` |
 | PoracleJsonHelper | `Core/Pgan.PoracleWebNet.Core.Services/PoracleJsonHelper.cs` |
+| TrackingV2Translator (v1 row -> /api/v2 body) | `Core/Pgan.PoracleWebNet.Core.Services/TrackingV2Translator.cs` |
+| PoracleProblemDetails (RFC 9457 + v1 errors) | `Core/Pgan.PoracleWebNet.Core.Services/PoracleProblemDetails.cs` |
 | Repositories (non-alarm) | `Core/Pgan.PoracleWebNet.Core.Repositories/` |
 | SiteSettingRepository | `Core/Pgan.PoracleWebNet.Core.Repositories/SiteSettingRepository.cs` |
 | WebhookDelegateRepository | `Core/Pgan.PoracleWebNet.Core.Repositories/WebhookDelegateRepository.cs` |

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleTrackingProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/IPoracleTrackingProxy.cs
@@ -24,6 +24,26 @@ public interface IPoracleTrackingProxy
     public Task<TrackingCreateResult> CreateAsync(string type, string userId, JsonElement body);
 
     /// <summary>
+    /// Replaces one existing tracking alarm, addressed by its uid.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="body"/> is a single v1-shaped alarm object — the same shape every alarm service
+    /// already builds, and the same shape <c>TrackingFieldPreserver</c> and <c>TrackingUpdateReconciler</c>
+    /// compare. Which PoracleNG surface it is written through is the proxy's business, not the caller's.
+    /// </para>
+    /// <para>
+    /// On PoracleNG 5.2.0 and later this is <c>PUT /api/v2/humans/{id}/tracking/{type}/{uid}</c>: scoped by
+    /// (human, uid), 404 when the uid is not theirs, 409 when the replacement would duplicate another rule,
+    /// and — because the engine is delete-then-insert — a NEW uid on the way back. On anything older it is
+    /// the v1 create-carrying-a-uid that PoracleWeb has always sent, byte for byte.
+    /// </para>
+    /// </remarks>
+    /// <returns>The uid the rule now lives under, which may differ from <paramref name="uid"/>.</returns>
+    public Task<Pgan.PoracleWebNet.Core.Models.TrackingUpdateResult> UpdateByUidAsync(
+        string type, string userId, int uid, System.Text.Json.JsonElement body);
+
+    /// <summary>
     /// Deletes a single tracking alarm by UID.
     /// Maps to DELETE /api/tracking/{type}/{userId}/byUid/{uid}
     /// </summary>

--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ITrackedUidRemapper.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Services/ITrackedUidRemapper.cs
@@ -5,8 +5,10 @@ namespace Pgan.PoracleWebNet.Core.Abstractions.Services;
 /// </summary>
 /// <remarks>
 /// <para>
-/// PoracleNG implements a tracking edit as delete-and-insert for every type except monsters, so the row
-/// comes back with a new uid. Quick-pick applied state persists the uids captured at apply time, and
+/// PoracleNG implements a tracking edit as delete-and-insert, so the row comes back with a new uid.
+/// Monsters were the one exception -- the v1 surface upserts them in place -- until the v2 pilot: the
+/// full-replace PUT is delete-then-insert like everything else, so pokemon rotates too whenever the
+/// server carries v2 (#805). Quick-pick applied state persists the uids captured at apply time, and
 /// removal deletes by those uids — so after any edit, removal deleted nothing, reported 204, and the
 /// alarm kept firing. Worse, the summary read then saw zero surviving uids, concluded the user had
 /// deleted the alarms by hand, and cleared the applied state, leaving no way to remove it from the UI

--- a/Core/Pgan.PoracleWebNet.Core.Models/PoracleServerProfile.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/PoracleServerProfile.cs
@@ -28,6 +28,9 @@ public sealed class PoracleServerProfile
     /// </remarks>
     public static readonly System.Version MinimumSupported = new(5, 1, 0);
 
+    /// <summary>The first PoracleNG that serves the strict <c>/api/v2</c> tracking surface.</summary>
+    public static readonly System.Version FirstWithV2Tracking = new(5, 2, 0);
+
     /// <summary>Version string as reported, e.g. <c>5.1.0</c>. Null when the server could not be reached.</summary>
     public string? Version
     {
@@ -80,6 +83,30 @@ public sealed class PoracleServerProfile
     /// </remarks>
     [JsonIgnore]
     public bool IsBelowMinimum => this.ParsedVersion is { } v && v < MinimumSupported;
+
+    /// <summary>
+    /// True when this server carries the strict <c>/api/v2</c> tracking surface.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Version, not the capability map. 5.2.1 reports
+    /// <c>{buttons, snapshots, autocreate, tomlDts, buttonResponseObject, derivedDtsTypes}</c> and says
+    /// nothing at all about v2, so there is no key to read. 5.2.0 is where the surface arrives.
+    /// </para>
+    /// <para>
+    /// Unreachable or unparseable answers false, which routes writes at v1. That is the opposite of
+    /// <c>UpstreamFeatureFlagService</c>, which fails open on purpose — but the failure modes are not
+    /// alike. Failing open there disables alarm types nobody asked to disable; failing open here would
+    /// point every pokemon edit at a route that may not exist.
+    /// </para>
+    /// <para>
+    /// A fork that carries v2 while reporting an older number, or reports 5.2.1 without it, is exactly
+    /// what a version probe cannot see. <c>Poracle:TrackingApiVersion</c> pins the answer for those, and
+    /// the proxy falls back to v1 at runtime when the route answers gin's plaintext 404.
+    /// </para>
+    /// </remarks>
+    [JsonIgnore]
+    public bool SupportsV2Tracking => this.ParsedVersion is { } v && v >= FirstWithV2Tracking;
 
     /// <summary>The profile for a server that did not answer: nothing known, nothing assumed.</summary>
     public static PoracleServerProfile Unknown(DateTimeOffset checkedAt) => new()

--- a/Core/Pgan.PoracleWebNet.Core.Models/TrackingRuleNotFoundException.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/TrackingRuleNotFoundException.cs
@@ -1,0 +1,38 @@
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// The rule the write addressed does not exist, or does not belong to this user.
+/// </summary>
+/// <remarks>
+/// Only the uid-addressed <c>/api/v2</c> PUT can tell us this: it is scoped by (human, uid) and answers
+/// 404 rather than quietly creating a row. The v1 surface takes a submitted uid at face value, which is
+/// the whole reason a stale uid used to strand an alarm on a profile nobody could see (#411). Reporting
+/// it as 404 rather than a 500 lets the SPA reload the list instead of telling the user the server broke.
+/// </remarks>
+public sealed class TrackingRuleNotFoundException : Exception
+{
+    public TrackingRuleNotFoundException(string trackingType, string detail)
+        : base(detail)
+    {
+        this.TrackingType = trackingType;
+    }
+
+    public TrackingRuleNotFoundException()
+    {
+    }
+
+    public TrackingRuleNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public TrackingRuleNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public string? TrackingType
+    {
+        get;
+    }
+}

--- a/Core/Pgan.PoracleWebNet.Core.Models/TrackingUpdateResult.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Models/TrackingUpdateResult.cs
@@ -1,0 +1,20 @@
+namespace Pgan.PoracleWebNet.Core.Models;
+
+/// <summary>
+/// Where a tracking rule lives once an update has been applied, and which PoracleNG surface applied it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The uid matters because <c>/api/v2</c>'s full-replace PUT is delete-then-insert: the replacement rule
+/// is handed a NEW uid, returned under <c>updated</c>. Anything holding the old one — quick-pick applied
+/// state above all — has to follow it. On the frozen v1 surface the uid normally stays put, so
+/// <see cref="Uid"/> simply echoes what was submitted.
+/// </para>
+/// <para>
+/// A struct on purpose: a mocked proxy that was never set up answers <c>default</c>, which is uid 0, and
+/// callers already treat a uid of 0 as "PoracleNG named none" rather than dereferencing null.
+/// </para>
+/// </remarks>
+/// <param name="Uid">The uid the rule now lives under, or 0 when PoracleNG named none.</param>
+/// <param name="UsedV2">True when the write went to <c>/api/v2</c> rather than the v1 surface.</param>
+public readonly record struct TrackingUpdateResult(int Uid, bool UsedV2);

--- a/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/MonsterService.cs
@@ -4,11 +4,15 @@ using Pgan.PoracleWebNet.Core.Models;
 
 namespace Pgan.PoracleWebNet.Core.Services;
 
-public class MonsterService(IPoracleTrackingProxy proxy, IFeatureGate featureGate) : IMonsterService
+public class MonsterService(
+    IPoracleTrackingProxy proxy,
+    IFeatureGate featureGate,
+    ITrackedUidRemapper uidRemapper) : IMonsterService
 {
     private const string TrackingType = "pokemon";
     private readonly IPoracleTrackingProxy _proxy = proxy;
     private readonly IFeatureGate _featureGate = featureGate;
+    private readonly ITrackedUidRemapper _uidRemapper = uidRemapper;
 
     // profileNo is kept for interface compatibility only. PoracleNG scopes reads to the user's active
     // profile (humans.current_profile_no), and writes no longer carry profile_no at all — see
@@ -52,21 +56,34 @@ public class MonsterService(IPoracleTrackingProxy proxy, IFeatureGate featureGat
     public async Task<Monster> UpdateAsync(string userId, Monster model)
     {
         await this._featureGate.EnsureEnabledAsync(DisableFeatureKeys.Pokemon);
-        // PoracleNG's POST endpoint handles updates when the body includes a uid field.
         var body = SerializeToElement(model);
 
-        // Carry forward anything the stored row holds that the model does not declare. See #730.
+        // Carry forward anything the stored row holds that the model does not declare. See #730. This
+        // matters MORE on the v2 path than it did on v1: the v2 PUT is a full replace, so a filter left
+        // out of the body is reset to its default rather than left alone -- verified live against 5.2.1,
+        // where omitting min_iv wiped a stored 90.
         body = await TrackingFieldPreserver.PreserveStoredFieldsAsync(
             this._proxy, TrackingType, userId, model.Uid, body);
 
-        // Pokemon is the one type with no collision guard: PoracleNG updates it in place rather than
-        // merging, so an edit onto another alarm's exact settings wrote a byte-identical twin -- two rows
-        // on the page that cannot be told apart and must each be deleted. Creating that state directly is
-        // refused, so the edit path was the only way to reach it. See #537.
+        // Pokemon is the one type with no collision guard on the v1 update path: PoracleNG updates it in
+        // place rather than merging, so this call early-returns for pokemon edits (#606). It stays because
+        // it is the guard for the create path in CreateAsync, and because deleting it here would make the
+        // two paths look different for no reason. On v2 the guard is upstream's: the uid-addressed PUT
+        // answers 409 rather than taking another rule over.
         await TrackingUpdateReconciler.EnsureNoMergeIntoAnotherAlarmAsync(
             this._proxy, TrackingType, userId, model.Uid, body);
 
-        await this._proxy.CreateAsync(TrackingType, userId, body);
+        var result = await this._proxy.UpdateByUidAsync(TrackingType, userId, model.Uid, body);
+
+        // Pokemon used to be the one type whose uid survived an edit. The v2 PUT is delete-then-insert, so
+        // it now rotates like the other nine, and quick-pick applied state has to follow the row or its
+        // "remove" button silently deletes nothing. See #403 and #805.
+        if (result.Uid > 0 && result.Uid != model.Uid)
+        {
+            await this._uidRemapper.RemapAsync(userId, TrackingType, model.Uid, result.Uid);
+            model.Uid = result.Uid;
+        }
+
         return model;
     }
 

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleProblemDetails.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleProblemDetails.cs
@@ -1,0 +1,167 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Pgan.PoracleWebNet.Core.Services;
+
+/// <summary>
+/// Turns whatever PoracleNG returned on a refusal into one sentence a person can act on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PoracleNG now speaks two error dialects and PoracleWeb has to read both. The frozen v1 surface answers
+/// <c>{"message":"...","status":"error"}</c> at 400. <c>/api/v2</c> answers RFC 9457 problem+json at 422,
+/// and in two shapes of its own: a schema failure carries <c>errors[]</c> with a <c>location</c>, while a
+/// semantic refusal such as "override_areas and distance are mutually exclusive" carries only
+/// <c>detail</c>. Confirmed live against 5.2.1.
+/// </para>
+/// <para>
+/// The <c>location</c> is a JSON pointer into the request body, and its shape moves with the route:
+/// <c>body.pokemon_id</c> on the single-object PUT, <c>body[0].pokemon_id</c> on the array-bodied POST.
+/// Both prefixes are trimmed, because a user reading "body[0].pokemon_id: expected integer" learns less
+/// than one reading "pokemon_id: expected integer".
+/// </para>
+/// <para>
+/// NOTE: PR #811 (<c>fix/803-problem-json-errors</c>) introduces <c>PoracleErrorMessage.cs</c>, which reads
+/// the same two shapes for the v1 create path. Whichever lands second should collapse the two into one —
+/// they are the same job, and two of them will drift.
+/// </para>
+/// </remarks>
+internal static class PoracleProblemDetails
+{
+    /// <summary>What to say when PoracleNG refused and explained nothing usable.</summary>
+    public const string Unexplained = "Poracle rejected the alarm.";
+
+    /// <summary>
+    /// Reads an explanation out of a response body. Never throws: an unreadable body still has to produce
+    /// something to show, and the alternative is a 500 for a request PoracleNG already described.
+    /// </summary>
+    public static string Describe(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return Unexplained;
+        }
+
+        JsonElement root;
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            root = document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            // Not JSON. gin's plaintext "404 page not found" lands here, as does an HTML error page from
+            // whatever proxy sits in front. Short bodies are still better than nothing.
+            return body.Length > 300 ? Unexplained : body.Trim();
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return Unexplained;
+        }
+
+        var fieldErrors = FieldErrors(root);
+        if (fieldErrors is not null)
+        {
+            return fieldErrors;
+        }
+
+        // v2 semantic refusal, then v1's own wording, then the problem title as a last resort.
+        foreach (var name in new[] { "detail", "message", "error", "title" })
+        {
+            if (root.TryGetProperty(name, out var value)
+                && value.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(value.GetString()))
+            {
+                return value.GetString()!;
+            }
+        }
+
+        return Unexplained;
+    }
+
+    /// <summary>True when this body is PoracleNG's problem+json rather than the v1 shape.</summary>
+    public static bool IsProblemJson(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            var root = document.RootElement;
+
+            return root.ValueKind == JsonValueKind.Object
+                && root.TryGetProperty("status", out var status)
+                && status.ValueKind == JsonValueKind.Number;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// "pokemon_id: expected integer", or null when this is not a schema failure.
+    /// </summary>
+    private static string? FieldErrors(JsonElement root)
+    {
+        if (!root.TryGetProperty("errors", out var errors) || errors.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var described = new StringBuilder();
+        foreach (var error in errors.EnumerateArray())
+        {
+            if (error.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var message = StringOf(error, "message");
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                continue;
+            }
+
+            var field = TrimBodyPointer(StringOf(error, "location"));
+
+            if (described.Length > 0)
+            {
+                described.Append("; ");
+            }
+
+            described.Append(string.IsNullOrWhiteSpace(field) ? message : $"{field}: {message}");
+        }
+
+        return described.Length > 0 ? described.ToString() : null;
+    }
+
+    /// <summary>Strips the <c>body</c> / <c>body[n]</c> prefix off a huma location pointer.</summary>
+    private static string? TrimBodyPointer(string? location)
+    {
+        if (string.IsNullOrWhiteSpace(location))
+        {
+            return null;
+        }
+
+        var dot = location.IndexOf('.', StringComparison.Ordinal);
+        if (dot < 0)
+        {
+            return location;
+        }
+
+        var head = location[..dot];
+        return head == "body" || (head.StartsWith("body[", StringComparison.Ordinal) && head.EndsWith(']'))
+            ? location[(dot + 1)..]
+            : location;
+    }
+
+    private static string? StringOf(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/PoracleTrackingProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/PoracleTrackingProxy.cs
@@ -2,6 +2,7 @@ using Pgan.PoracleWebNet.Core.Models;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Pgan.PoracleWebNet.Core.Abstractions.Services;
@@ -11,8 +12,26 @@ namespace Pgan.PoracleWebNet.Core.Services;
 public partial class PoracleTrackingProxy(
     HttpClient httpClient,
     IConfiguration configuration,
+    IPoracleServerProfileService serverProfile,
+    IMemoryCache cache,
     ILogger<PoracleTrackingProxy> logger) : IPoracleTrackingProxy
 {
+    /// <summary>
+    /// The only type this build writes through <c>/api/v2</c>. See #805 — the other nine stay on the
+    /// frozen v1 surface, which 5.2.1 left unchanged, so leaving them is a no-op rather than a deferred
+    /// defect. Each needs its own field translation derived from its own schema.
+    /// </summary>
+    private const string V2PilotType = "pokemon";
+
+    /// <summary>
+    /// Set when the v2 route answered gin's plaintext 404, meaning this server does not carry it whatever
+    /// its version said. Held for as long as the server profile is cached, so an upgrade is picked up on
+    /// the same clock as everything else version-gated.
+    /// </summary>
+    private const string V2AbsentCacheKey = "poracle:v2-tracking-absent";
+
+    private static readonly TimeSpan V2AbsentFor = TimeSpan.FromMinutes(5);
+
     /// <summary>
     /// PoracleNG answers 404 for a user that no longer exists; that is a dead session, not a server fault.
     /// </summary>
@@ -33,6 +52,17 @@ public partial class PoracleTrackingProxy(
     private readonly HttpClient _httpClient = httpClient;
     private readonly string _apiAddress = configuration["Poracle:ApiAddress"] ?? string.Empty;
     private readonly string _apiSecret = configuration["Poracle:ApiSecret"] ?? string.Empty;
+
+    /// <summary>
+    /// <c>auto</c> (the default) asks the server what it is; <c>v1</c> and <c>v2</c> pin it. An operator
+    /// needs the override because a fork can carry v2 while reporting an older number, or the reverse,
+    /// and a version probe cannot see either.
+    /// </summary>
+    private readonly string _trackingApiVersion =
+        (configuration["Poracle:TrackingApiVersion"] ?? "auto").Trim().ToLowerInvariant();
+
+    private readonly IPoracleServerProfileService _serverProfile = serverProfile;
+    private readonly IMemoryCache _cache = cache;
     private readonly ILogger<PoracleTrackingProxy> _logger = logger;
 
     public async Task<JsonElement> GetByUserAsync(string type, string userId)
@@ -94,6 +124,34 @@ public partial class PoracleTrackingProxy(
             root.TryGetProperty("alreadyPresent", out var ap) ? ap.GetInt32() : 0,
             root.TryGetProperty("updates", out var upd) ? upd.GetInt32() : 0,
             root.TryGetProperty("insert", out var ins) ? ins.GetInt32() : 0);
+    }
+
+    /// <inheritdoc />
+    public async Task<TrackingUpdateResult> UpdateByUidAsync(
+        string type, string userId, int uid, JsonElement body)
+    {
+        if (uid > 0 && this.ShouldTryV2(type) && await this.ServerCarriesV2Async())
+        {
+            if (TrackingV2Translator.TryTranslatePokemon(body, out var v2Body, out var unsupported))
+            {
+                var applied = await this.PutV2Async(type, userId, uid, v2Body);
+                if (applied is { } result)
+                {
+                    return result;
+                }
+            }
+            else
+            {
+                // Not a fault. The row carries something v2 has no faithful place for, so it goes to v1,
+                // which stores whatever it is given. See TrackingV2Translator.
+                LogV2Untranslatable(this._logger, type, uid, unsupported ?? "unknown");
+            }
+        }
+
+        // v1: an update is a create carrying the uid, which PoracleNG upserts. Byte-identical to what
+        // PoracleWeb has always sent, which is what makes 5.1.0 a genuine no-change.
+        var created = await this.CreateAsync(type, userId, body);
+        return new TrackingUpdateResult(created.PrimaryUid ?? uid, false);
     }
 
     public async Task DeleteByUidAsync(string type, string userId, int uid)
@@ -162,6 +220,135 @@ public partial class PoracleTrackingProxy(
         response.EnsureSuccessStatusCode();
     }
 
+    /// <summary>Whether this type and this deployment are in scope for the v2 write path at all.</summary>
+    private bool ShouldTryV2(string type) =>
+        string.Equals(type, V2PilotType, StringComparison.Ordinal)
+        && this._trackingApiVersion != "v1";
+
+    /// <summary>
+    /// Whether the server is believed to carry v2. Pinned to <c>v2</c> this skips the probe but not the
+    /// runtime fallback, so pinning a server that turns out not to have the route degrades to v1 rather
+    /// than failing every edit.
+    /// </summary>
+    private async Task<bool> ServerCarriesV2Async()
+    {
+        if (this._cache.TryGetValue(V2AbsentCacheKey, out _))
+        {
+            return false;
+        }
+
+        if (this._trackingApiVersion == "v2")
+        {
+            return true;
+        }
+
+        var profile = await this._serverProfile.GetAsync();
+        return profile.SupportsV2Tracking;
+    }
+
+    /// <summary>
+    /// Full-replaces one rule through <c>/api/v2</c>. Returns null -- and remembers it -- when the route is
+    /// not there, so the caller can use v1 for this request instead of failing it.
+    /// </summary>
+    private async Task<TrackingUpdateResult?> PutV2Async(
+        string type, string userId, int uid, JsonElement body)
+    {
+        var bodyText = body.GetRawText();
+        LogV2UpdateRequest(this._logger, type, uid, userId, bodyText);
+
+        var request = this.CreateRequest(
+            HttpMethod.Put,
+            $"{this._apiAddress}/api/v2/humans/{Encode(userId)}/tracking/{type}/{uid}?silent=true");
+        request.Content = new StringContent(bodyText, Encoding.UTF8, "application/json");
+
+        var response = await this._httpClient.SendAsync(request);
+        var payload = await response.Content.ReadAsStringAsync();
+
+        if (response.IsSuccessStatusCode)
+        {
+            LogV2UpdateResponse(this._logger, type, uid, userId, payload);
+            return new TrackingUpdateResult(UidFromV2Envelope(payload) ?? uid, true);
+        }
+
+        switch (response.StatusCode)
+        {
+            case HttpStatusCode.NotFound when !PoracleProblemDetails.IsProblemJson(payload):
+                // gin answers a missing route with plaintext "404 page not found", so the route does not
+                // exist on this build whatever /health claimed. Verified against 5.1.0.
+                this._cache.Set(V2AbsentCacheKey, true, V2AbsentFor);
+                LogV2RouteAbsent(this._logger, type);
+                return null;
+
+            case HttpStatusCode.NotFound when payload.Contains("human not found", StringComparison.Ordinal):
+                // Same meaning as the bare 404 on a v1 tracking read: the account is gone.
+                throw new AccountGoneException();
+
+            case HttpStatusCode.NotFound:
+                throw new TrackingRuleNotFoundException(type, PoracleProblemDetails.Describe(payload));
+
+            case HttpStatusCode.Conflict:
+                // v2 refuses a replacement that would duplicate another rule outright, which is the guard
+                // TrackingUpdateReconciler had to reconstruct from a 200 on v1. Its wording names the uid.
+                throw new TrackingConflictException(type, PoracleProblemDetails.Describe(payload));
+
+            case HttpStatusCode.UnprocessableEntity:
+            case HttpStatusCode.BadRequest:
+                // v2 validates at 422 where v1 used 400. Both are the request being wrong, not the server;
+                // letting EnsureSuccessStatusCode throw would flatten them into an opaque 500. See #539.
+                throw new AlarmValidationException(PoracleProblemDetails.Describe(payload));
+
+            default:
+                response.EnsureSuccessStatusCode();
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// The uid the replacement lives under. v2 answers <c>{created, updated, unchanged}</c> and a PUT
+    /// reports under <c>updated</c> -- but reading all three costs nothing and stops a future shuffle
+    /// silently returning the dead uid.
+    /// </summary>
+    private static int? UidFromV2Envelope(string payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            var root = document.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var name in new[] { "updated", "created", "unchanged" })
+            {
+                if (!root.TryGetProperty(name, out var bucket) || bucket.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var rule in bucket.EnumerateArray())
+                {
+                    if (rule.ValueKind == JsonValueKind.Object
+                        && rule.TryGetProperty("uid", out var value)
+                        && value.ValueKind == JsonValueKind.Number
+                        && value.TryGetInt32(out var found)
+                        && found > 0)
+                    {
+                        return found;
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // A 200 that is not the envelope. The rule was written; we simply do not know its uid, and the
+            // caller keeps the one it had rather than losing the edit.
+        }
+
+        return null;
+    }
+
     /// <summary>Reads whatever explanation PoracleNG returned, falling back to something honest.</summary>
     private static async Task<string> ExtractMessageAsync(HttpResponseMessage response)
     {
@@ -200,6 +387,26 @@ public partial class PoracleTrackingProxy(
 
         return request;
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "v2 update {Type} uid={Uid} for {UserId} request: {Body}")]
+    private static partial void LogV2UpdateRequest(ILogger logger, string type, int uid, string userId, string body);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "v2 update {Type} uid={Uid} for {UserId} response: {Response}")]
+    private static partial void LogV2UpdateResponse(ILogger logger, string type, int uid, string userId, string response);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Sending {Type} uid={Uid} to the v1 surface: v2 cannot carry it faithfully ({Reason}).")]
+    private static partial void LogV2Untranslatable(ILogger logger, string type, int uid, string reason);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "PoracleNG has no /api/v2 {Type} route despite reporting a version that should carry it. Using v1.")]
+    private static partial void LogV2RouteAbsent(ILogger logger, string type);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Delete {Type} uid={Uid} returned 404 (already deleted)")]
     private static partial void LogDeleteNotFound(ILogger logger, string type, int uid);

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingV2Translator.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingV2Translator.cs
@@ -31,10 +31,15 @@ namespace Pgan.PoracleWebNet.Core.Services;
 /// </remarks>
 internal static class TrackingV2Translator
 {
-    /// <summary>Addressing and presentation. v2 carries none of it in the rule body.</summary>
+    /// <summary>
+    /// Addressing and presentation. v2 carries none of it in the rule body, and reconstructs all of it
+    /// itself: <c>uid</c>/<c>id</c>/<c>profile_no</c> come from the route, and <c>description</c> is a
+    /// display string PoracleNG computes rather than a stored column. <c>ping</c> is NOT here — it is a
+    /// real column that v2 blanks, so it is handled in <see cref="TryWriteProperty"/>.
+    /// </summary>
     private static readonly HashSet<string> Dropped = new(StringComparer.Ordinal)
     {
-        "uid", "id", "profile_no", "ping", "description",
+        "uid", "id", "profile_no", "description",
     };
 
     /// <summary>Every integer filter <c>V2PokemonRule</c> declares, taken from 5.2.1's openapi.golden.json.</summary>
@@ -111,6 +116,9 @@ internal static class TrackingV2Translator
             case "clean":
                 return TryWriteClean(writer, property.Value, out unsupported);
 
+            case "ping":
+                return TryWritePing(property.Value, out unsupported);
+
             case "gender":
                 return TryWriteGender(writer, property.Value, out unsupported);
 
@@ -179,6 +187,32 @@ internal static class TrackingV2Translator
         writer.WriteBoolean("edit", CleanFlags.IsEdit(mask));
         writer.WriteBoolean("summary", CleanFlags.IsSummary(mask));
         return true;
+    }
+
+    /// <summary>
+    /// <c>ping</c> is the mention prepended to the DM — a role or user the alert is meant to notify. It is
+    /// a real <c>monsters</c> column and the v1 body carries it, but <c>V2PokemonRule</c> has no field for
+    /// it and the handler stores <c>Ping: ""</c> unconditionally ("server-managed"). Verified live against
+    /// 5.2.1: a rule holding <c>&lt;@&amp;400027130022592512&gt;</c> came back with an empty ping after one
+    /// v2 PUT.
+    /// </summary>
+    /// <remarks>
+    /// So an empty ping is dropped — v2 would store the same empty string — but a set one sends the row to
+    /// v1, which keeps it. Silently discarding it here is exactly the #730 shape this translator exists to
+    /// avoid, and it lands on webhook alarms, where the role mention is the entire point of the alert.
+    /// </remarks>
+    private static bool TryWritePing(JsonElement value, out string? unsupported)
+    {
+        unsupported = null;
+
+        if (value.ValueKind is JsonValueKind.Null
+            || (value.ValueKind == JsonValueKind.String && string.IsNullOrEmpty(value.GetString())))
+        {
+            return true;
+        }
+
+        unsupported = "ping is set, and v2 would blank it";
+        return false;
     }
 
     private static bool TryWriteGender(Utf8JsonWriter writer, JsonElement value, out string? unsupported)

--- a/Core/Pgan.PoracleWebNet.Core.Services/TrackingV2Translator.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/TrackingV2Translator.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using Pgan.PoracleWebNet.Core.Models;
+
+namespace Pgan.PoracleWebNet.Core.Services;
+
+/// <summary>
+/// Rewrites a v1-shaped pokemon row into the body <c>/api/v2</c> will accept.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole of PoracleWeb builds and compares alarm bodies in v1's shape — <see cref="TrackingFieldPreserver"/>,
+/// <see cref="TrackingUpdateReconciler"/>, <c>BulkUidRemap</c> and <c>QuickPickService</c> all do. Keeping
+/// that shape as the single internal currency and translating once, at the wire, is what stops a v1-shaped
+/// row leaking into a v2 request: <c>V2PokemonRule</c> sets <c>additionalProperties: false</c>, so one stray
+/// <c>ping</c> is a 422 and the write fails outright. Verified live against 5.2.1.
+/// </para>
+/// <para>
+/// Three fields genuinely change shape. <c>clean</c> is a 3-bit mask on v1 and three booleans on v2
+/// (<c>clean</c>/<c>edit</c>/<c>summary</c>); <c>gender</c> is an int on v1 and
+/// <c>any|male|female|genderless</c> on v2; <c>pvp_ranking_league</c> is any int on v1 and an enum of
+/// {0, 500, 1500, 2500} on v2. Five more — <c>uid</c>, <c>id</c>, <c>profile_no</c>, <c>ping</c>,
+/// <c>description</c> — are addressing and presentation rather than filter, and v2 has no place for them.
+/// </para>
+/// <para>
+/// <b>The translator never widens or narrows what PoracleNG will accept.</b> Anything it cannot express
+/// faithfully — a property it does not know, a gender outside 0-3, a league outside the enum — makes it
+/// answer false, and the caller sends the row to the frozen v1 surface instead. Refusing outright would
+/// mean a PoracleNG newer than this translator broke every pokemon edit; dropping the field silently would
+/// be #730 all over again. Falling back does neither.
+/// </para>
+/// </remarks>
+internal static class TrackingV2Translator
+{
+    /// <summary>Addressing and presentation. v2 carries none of it in the rule body.</summary>
+    private static readonly HashSet<string> Dropped = new(StringComparer.Ordinal)
+    {
+        "uid", "id", "profile_no", "ping", "description",
+    };
+
+    /// <summary>Every integer filter <c>V2PokemonRule</c> declares, taken from 5.2.1's openapi.golden.json.</summary>
+    private static readonly HashSet<string> IntegerFields = new(StringComparer.Ordinal)
+    {
+        "atk", "costume", "def", "distance", "form", "max_atk", "max_cp", "max_def", "max_iv",
+        "max_level", "max_rarity", "max_size", "max_sta", "max_weight", "min_cp", "min_iv",
+        "min_level", "min_time", "min_weight", "pokemon_id", "pvp_ranking_best", "pvp_ranking_cap",
+        "pvp_ranking_evolution", "pvp_ranking_min_cp", "pvp_ranking_worst", "rarity", "size", "sta",
+    };
+
+    /// <summary>The four leagues <c>V2PokemonRule</c> permits. 0 means "no PVP filter".</summary>
+    private static readonly HashSet<int> Leagues = [0, 500, 1500, 2500];
+
+    /// <summary>v2's gender enum: index is the v1 integer.</summary>
+    private static readonly string[] Genders = ["any", "male", "female", "genderless"];
+
+    /// <summary>
+    /// Translates one v1-shaped pokemon row. Returns false — leaving <paramref name="translated"/>
+    /// untouched — when the row carries something v2 cannot be told faithfully.
+    /// </summary>
+    /// <param name="row">A single v1-shaped alarm object, as every alarm service already builds.</param>
+    /// <param name="translated">The v2 body on success.</param>
+    /// <param name="unsupported">What stopped the translation, for the log. Null on success.</param>
+    public static bool TryTranslatePokemon(JsonElement row, out JsonElement translated, out string? unsupported)
+    {
+        translated = default;
+        unsupported = null;
+
+        if (row.ValueKind != JsonValueKind.Object)
+        {
+            unsupported = "the body is not a single rule object";
+            return false;
+        }
+
+        if (!row.TryGetProperty("pokemon_id", out var speciesId) || speciesId.ValueKind != JsonValueKind.Number)
+        {
+            // v2 makes pokemon_id the one required field. A row without it could only ever 422.
+            unsupported = "pokemon_id is missing";
+            return false;
+        }
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+
+            foreach (var property in row.EnumerateObject())
+            {
+                if (Dropped.Contains(property.Name))
+                {
+                    continue;
+                }
+
+                if (!TryWriteProperty(writer, property, out unsupported))
+                {
+                    return false;
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        translated = JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
+        return true;
+    }
+
+    private static bool TryWriteProperty(Utf8JsonWriter writer, JsonProperty property, out string? unsupported)
+    {
+        unsupported = null;
+
+        switch (property.Name)
+        {
+            case "clean":
+                return TryWriteClean(writer, property.Value, out unsupported);
+
+            case "gender":
+                return TryWriteGender(writer, property.Value, out unsupported);
+
+            case "pvp_ranking_league":
+                return TryWriteLeague(writer, property.Value, out unsupported);
+
+            case "template":
+            case "override_location_label":
+                if (property.Value.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+                {
+                    unsupported = $"{property.Name} is not a string";
+                    return false;
+                }
+
+                property.WriteTo(writer);
+                return true;
+
+            case "override_areas":
+                return TryWriteOverrideAreas(writer, property.Value, out unsupported);
+
+            default:
+                if (!IntegerFields.Contains(property.Name))
+                {
+                    // A field this build has never heard of. Newer PoracleNG, older PoracleWeb — send the
+                    // row to v1, which takes anything, rather than dropping the user's value.
+                    unsupported = $"unknown property {property.Name}";
+                    return false;
+                }
+
+                if (property.Value.ValueKind is not (JsonValueKind.Number or JsonValueKind.Null))
+                {
+                    unsupported = $"{property.Name} is not a number";
+                    return false;
+                }
+
+                property.WriteTo(writer);
+                return true;
+        }
+    }
+
+    /// <summary>The 3-bit mask becomes three booleans. Bits outside the three known ones are not v2's.</summary>
+    private static bool TryWriteClean(Utf8JsonWriter writer, JsonElement value, out string? unsupported)
+    {
+        unsupported = null;
+
+        if (value.ValueKind == JsonValueKind.Null)
+        {
+            return true;
+        }
+
+        if (value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var mask))
+        {
+            unsupported = "clean is not a bitmask";
+            return false;
+        }
+
+        if ((mask & ~CleanFlags.All) != 0)
+        {
+            // A bit PoracleWeb does not model. v2 has no field for it, so translating would drop it;
+            // v1 stores the integer as-is. See the clean-bitmask note in CLAUDE.md.
+            unsupported = $"clean carries bits outside the three known flags ({mask})";
+            return false;
+        }
+
+        writer.WriteBoolean("clean", CleanFlags.IsAutoDelete(mask));
+        writer.WriteBoolean("edit", CleanFlags.IsEdit(mask));
+        writer.WriteBoolean("summary", CleanFlags.IsSummary(mask));
+        return true;
+    }
+
+    private static bool TryWriteGender(Utf8JsonWriter writer, JsonElement value, out string? unsupported)
+    {
+        unsupported = null;
+
+        if (value.ValueKind == JsonValueKind.Null)
+        {
+            return true;
+        }
+
+        if (value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt32(out var gender)
+            || gender < 0
+            || gender >= Genders.Length)
+        {
+            unsupported = "gender is outside 0-3";
+            return false;
+        }
+
+        writer.WriteString("gender", Genders[gender]);
+        return true;
+    }
+
+    private static bool TryWriteLeague(Utf8JsonWriter writer, JsonElement value, out string? unsupported)
+    {
+        unsupported = null;
+
+        if (value.ValueKind == JsonValueKind.Null)
+        {
+            return true;
+        }
+
+        if (value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var league))
+        {
+            unsupported = "pvp_ranking_league is not a number";
+            return false;
+        }
+
+        if (!Leagues.Contains(league))
+        {
+            unsupported = $"pvp_ranking_league {league} is not one of 0, 500, 1500, 2500";
+            return false;
+        }
+
+        writer.WriteNumber("pvp_ranking_league", league);
+        return true;
+    }
+
+    /// <summary>
+    /// Areas arrive as a real array from the model, but a stored row carried forward by
+    /// <see cref="TrackingFieldPreserver"/> can hold the column verbatim, and PoracleNG's own column is a
+    /// JSON string. Normalise rather than refuse — this is the one shape difference worth absorbing,
+    /// because it is PoracleWeb's own read that produced it.
+    /// </summary>
+    private static bool TryWriteOverrideAreas(Utf8JsonWriter writer, JsonElement value, out string? unsupported)
+    {
+        unsupported = null;
+
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Null:
+            case JsonValueKind.Array:
+                writer.WritePropertyName("override_areas");
+                value.WriteTo(writer);
+                return true;
+
+            case JsonValueKind.String:
+                var raw = value.GetString();
+                if (string.IsNullOrWhiteSpace(raw))
+                {
+                    writer.WriteNull("override_areas");
+                    return true;
+                }
+
+                try
+                {
+                    using var parsed = JsonDocument.Parse(raw);
+                    if (parsed.RootElement.ValueKind != JsonValueKind.Array)
+                    {
+                        unsupported = "override_areas is a string that is not a JSON array";
+                        return false;
+                    }
+
+                    writer.WritePropertyName("override_areas");
+                    parsed.RootElement.WriteTo(writer);
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    unsupported = "override_areas is a string that is not JSON";
+                    return false;
+                }
+
+            default:
+                unsupported = "override_areas is neither an array nor null";
+                return false;
+        }
+    }
+}

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserOwnedOverrideAreaProxy.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserOwnedOverrideAreaProxy.cs
@@ -61,6 +61,51 @@ public partial class UserOwnedOverrideAreaProxy(
 
     public Task ReloadStateAsync() => this._inner.ReloadStateAsync();
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// The same workaround as <see cref="CreateAsync"/>, with one difference that matters: on the v2
+    /// surface the replacement rule is a NEW row with a NEW uid, so the area write-back has to target the
+    /// uid PoracleNG just reported rather than the one that was addressed. Writing to the old uid would
+    /// touch a row that no longer exists, and the alarm would silently widen to the whole profile.
+    /// </remarks>
+    public async Task<TrackingUpdateResult> UpdateByUidAsync(
+        string type, string userId, int uid, JsonElement body)
+    {
+        EnsureScopeIsCoherent(body);
+
+        if (!MentionsAnyOverrideArea(body))
+        {
+            return await this._inner.UpdateByUidAsync(type, userId, uid, body);
+        }
+
+        var owned = await this.OwnedGeofenceNamesAsync(userId);
+        var full = OverrideAreasOf(body);
+
+        if (owned.Count == 0 || full is null || !full.Any(a => owned.Contains(a)))
+        {
+            return await this._inner.UpdateByUidAsync(type, userId, uid, body);
+        }
+
+        var sanitised = StripOwned(body, owned);
+        var result = await this._inner.UpdateByUidAsync(type, userId, uid, sanitised);
+        var written = await this._areaWriter.SetAlarmOverrideAreasAsync(
+            userId, type, result.Uid > 0 ? result.Uid : uid, full);
+
+        if (!written)
+        {
+            // The row PoracleNG just reported is not there to write to. Refusing loudly beats an alarm
+            // that silently alerts on the whole profile instead of one small geofence.
+            LogWriteBackMissedRow(this._logger, type, result.Uid, userId);
+            throw new InvalidOperationException(
+                $"Could not apply the area restriction to the {type} alarm that was just saved.");
+        }
+
+        // PoracleNG reloads its state on its own mutations, and a direct column write is not one.
+        await this._inner.ReloadStateAsync();
+
+        return result;
+    }
+
     public async Task<TrackingCreateResult> CreateAsync(string type, string userId, JsonElement body)
     {
         // Refuse an incoherent scope before anything is written. PoracleNG enforces the same three rules

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/AlarmWritePayloadTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/AlarmWritePayloadTests.cs
@@ -22,6 +22,7 @@ namespace Pgan.PoracleWebNet.Tests.Services;
 public class AlarmWritePayloadTests
 {
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
+    private readonly Mock<ITrackedUidRemapper> _remapper = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
     private readonly List<JsonElement> _sent = [];
 
@@ -32,9 +33,14 @@ public class AlarmWritePayloadTests
             .Setup(p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()))
             .Callback<string, string, JsonElement>((_, _, body) => this._sent.Add(body.Clone()))
             .ReturnsAsync(new TrackingCreateResult([1], 0, 0, 1));
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<JsonElement>()))
+            .Callback<string, string, int, JsonElement>((_, _, _, body) => this._sent.Add(body.Clone()))
+            .ReturnsAsync((string _, string _, int uid, JsonElement _) => new TrackingUpdateResult(uid, false));
     }
 
-    private MonsterService Monsters() => new(this._proxy.Object, this._featureGate.Object);
+    private MonsterService Monsters() => new(this._proxy.Object, this._featureGate.Object, this._remapper.Object);
 
     private static IEnumerable<JsonElement> Objects(JsonElement sent) =>
         sent.ValueKind == JsonValueKind.Array ? sent.EnumerateArray() : [sent];

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/CreateResultSemanticsTests.cs
@@ -296,7 +296,7 @@ public class CreateResultSemanticsTests
     [Fact]
     public async Task AddingTheSameSpeciesAtATighterIvIsRefused()
     {
-        var sut = new MonsterService(this._proxy.Object, this._gate.Object);
+        var sut = new MonsterService(this._proxy.Object, this._gate.Object, this._remapper.Object);
         this._proxy.Setup(p => p.GetByUserAsync("pokemon", "u1")).ReturnsAsync(Rows(
             new { uid = 1, id = "u1", pokemon_id = 140, min_iv = 90, distance = 4000 }));
 

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/MonsterServiceTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/MonsterServiceTests.cs
@@ -15,12 +15,13 @@ public class MonsterServiceTests
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
+    private readonly Mock<ITrackedUidRemapper> _remapper = new();
     private readonly MonsterService _sut;
 
     public MonsterServiceTests()
     {
         this._featureGate.Setup(g => g.EnsureEnabledAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-        this._sut = new MonsterService(this._proxy.Object, this._featureGate.Object);
+        this._sut = new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object);
     }
 
     [Fact]
@@ -87,14 +88,97 @@ public class MonsterServiceTests
     public async Task UpdateAsyncCallsProxy()
     {
         var monster = new Monster { Uid = 1, PokemonId = 25 };
-        var createResult = new TrackingCreateResult([], 0, 1, 0);
-        this._proxy.Setup(p => p.CreateAsync("pokemon", "user1", It.IsAny<JsonElement>()))
-            .ReturnsAsync(createResult);
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync("pokemon", "user1", 1, It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingUpdateResult(1, false));
 
         var result = await this._sut.UpdateAsync("user1", monster);
 
         Assert.Equal(1, result.Uid);
-        this._proxy.Verify(p => p.CreateAsync("pokemon", "user1", It.IsAny<JsonElement>()), Times.Once);
+        this._proxy.Verify(
+            p => p.UpdateByUidAsync("pokemon", "user1", 1, It.IsAny<JsonElement>()), Times.Once);
+    }
+
+    /// <summary>
+    /// The v2 PUT is delete-then-insert, so the rule comes back under a new uid. Anything holding the old
+    /// one has to follow it -- quick-pick applied state above all, whose "remove" button otherwise deletes
+    /// nothing and then wipes itself. See #403 and #805.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsyncFollowsARotatedUid()
+    {
+        var monster = new Monster { Uid = 36486, PokemonId = 25 };
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync("pokemon", "user1", 36486, It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingUpdateResult(36487, true));
+
+        var result = await this._sut.UpdateAsync("user1", monster);
+
+        Assert.Equal(36487, result.Uid);
+        this._remapper.Verify(r => r.RemapAsync("user1", "pokemon", 36486, 36487), Times.Once);
+    }
+
+    /// <summary>
+    /// The legitimate case that must still pass: on the v1 surface the uid does not move, and nothing
+    /// should be remapped. A remap fired on every save would rewrite applied state for no reason.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsyncDoesNotRemapWhenTheUidStays()
+    {
+        var monster = new Monster { Uid = 7, PokemonId = 25 };
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync("pokemon", "user1", 7, It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingUpdateResult(7, false));
+
+        var result = await this._sut.UpdateAsync("user1", monster);
+
+        Assert.Equal(7, result.Uid);
+        this._remapper.Verify(
+            r => r.RemapAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A proxy that named no uid -- an unparseable 200, or a v1 response carrying no newUids -- must leave
+    /// the alarm where it was rather than moving it to 0.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsyncKeepsItsUidWhenPoracleNamesNone()
+    {
+        var monster = new Monster { Uid = 7, PokemonId = 25 };
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync("pokemon", "user1", 7, It.IsAny<JsonElement>()))
+            .ReturnsAsync(default(TrackingUpdateResult));
+
+        var result = await this._sut.UpdateAsync("user1", monster);
+
+        Assert.Equal(7, result.Uid);
+    }
+
+    /// <summary>
+    /// The legitimate case #553 was about, kept alive across the surface change. Two alarms that differ by
+    /// more than one updatable field genuinely coexist upstream, so an edit onto that shape must still
+    /// save. On v1 the guard early-returns for pokemon (#606); on v2 the uid-addressed PUT cannot merge at
+    /// all, and PoracleNG answers 409 itself if the result would be an exact duplicate.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsyncStillSavesWhenAnotherAlarmIsMerelySimilar()
+    {
+        var stored = CreateJsonArray(
+            new { uid = 1, id = "user1", pokemon_id = 25, distance = 1000, min_iv = 90, template = "1" },
+            new { uid = 2, id = "user1", pokemon_id = 25, distance = 4000, min_iv = 90, template = "2" });
+        this._proxy.Setup(p => p.GetByUserAsync("pokemon", "user1")).ReturnsAsync(stored);
+        this._proxy
+            .Setup(p => p.UpdateByUidAsync("pokemon", "user1", 1, It.IsAny<JsonElement>()))
+            .ReturnsAsync(new TrackingUpdateResult(1, false));
+
+        // Both distance and template now match the sibling: two updatable differences, not one.
+        var result = await this._sut.UpdateAsync(
+            "user1", new Monster { Uid = 1, Id = "user1", PokemonId = 25, Distance = 4000, MinIv = 90, Template = "2" });
+
+        Assert.Equal(1, result.Uid);
+        this._proxy.Verify(
+            p => p.UpdateByUidAsync("pokemon", "user1", 1, It.IsAny<JsonElement>()), Times.Once);
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PokemonFilterRoundTripTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PokemonFilterRoundTripTests.cs
@@ -24,6 +24,7 @@ public class PokemonFilterRoundTripTests
     private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
 
     private readonly Mock<IPoracleTrackingProxy> _proxy = new();
+    private readonly Mock<ITrackedUidRemapper> _remapper = new();
     private readonly Mock<IFeatureGate> _featureGate = new();
     private JsonElement _sent;
 
@@ -52,7 +53,7 @@ public class PokemonFilterRoundTripTests
 
     private async Task<JsonElement> WriteAsync(MonsterCreate create)
     {
-        await new MonsterService(this._proxy.Object, this._featureGate.Object).CreateAsync("u1", create.ToMonster());
+        await new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object).CreateAsync("u1", create.ToMonster());
 
         return this._sent.ValueKind == JsonValueKind.Array ? this._sent.EnumerateArray().First() : this._sent;
     }
@@ -96,7 +97,7 @@ public class PokemonFilterRoundTripTests
             .ReturnsAsync(JsonDocument.Parse(
                 """[{"uid":7,"pokemon_id":6,"pvp_ranking_evolution":3,"min_time":600}]""").RootElement.Clone());
 
-        var monster = await new MonsterService(this._proxy.Object, this._featureGate.Object).GetByUidAsync("u1", 7);
+        var monster = await new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object).GetByUidAsync("u1", 7);
 
         Assert.Equal(3, monster!.PvpRankingEvolution);
         Assert.Equal(600, monster.MinTime);

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyTests.cs
@@ -2,9 +2,11 @@ using Pgan.PoracleWebNet.Core.Models;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
 using Pgan.PoracleWebNet.Core.Services;
 
 namespace Pgan.PoracleWebNet.Tests.Services;
@@ -30,13 +32,31 @@ public class PoracleTrackingProxyTests
         })
         .Build();
 
-    private static PoracleTrackingProxy CreateSut(MockHttpMessageHandler handler, IConfiguration? config = null)
+    /// <summary>
+    /// A server profile reporting nothing, so <c>SupportsV2Tracking</c> is false and every write in this
+    /// fixture goes to the v1 surface -- which is the point: v1 must stay byte-identical.
+    /// </summary>
+    private static PoracleTrackingProxy CreateSut(
+        MockHttpMessageHandler handler,
+        IConfiguration? config = null,
+        IPoracleServerProfileService? serverProfile = null)
     {
         var client = new HttpClient(handler);
         return new PoracleTrackingProxy(
             client,
             config ?? CreateConfig(),
+            serverProfile ?? UnknownServerProfile(),
+            new MemoryCache(new MemoryCacheOptions()),
             Mock.Of<ILogger<PoracleTrackingProxy>>());
+    }
+
+    private static IPoracleServerProfileService UnknownServerProfile()
+    {
+        var profile = new Mock<IPoracleServerProfileService>();
+        profile
+            .Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PoracleServerProfile.Unknown(DateTimeOffset.UtcNow));
+        return profile.Object;
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyV2Tests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyV2Tests.cs
@@ -1,0 +1,425 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Pgan.PoracleWebNet.Core.Abstractions.Services;
+using Pgan.PoracleWebNet.Core.Models;
+using Pgan.PoracleWebNet.Core.Services;
+
+namespace Pgan.PoracleWebNet.Tests.Services;
+
+/// <summary>
+/// The pokemon write path on PoracleNG's strict <c>/api/v2</c> surface, and every way it must decline to
+/// use it. See #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every response shape here was taken from a live 5.2.1 instance rather than from the Go source: the
+/// uid-rotating 200, the problem+json 404 and 409, the 422 with its <c>errors[]</c>, and 5.1.0's plaintext
+/// <c>404 page not found</c>. CLAUDE.md is explicit that source and running binary have disagreed before.
+/// </para>
+/// <para>
+/// The translator is exercised through the proxy on purpose. What matters is the bytes on the wire —
+/// <c>V2PokemonRule</c> sets <c>additionalProperties: false</c>, so one stray <c>ping</c> is a 422 — and a
+/// test of the translator in isolation would assert the translator's own model of the request instead.
+/// </para>
+/// </remarks>
+public class PoracleTrackingProxyV2Tests
+{
+    private const string ApiAddress = "http://localhost:3030";
+
+    /// <summary>A stored pokemon row exactly as v1 returns it, metadata and all.</summary>
+    private const string StoredRow = """
+        {
+          "uid": 36486, "id": "user1", "profile_no": 1, "ping": "", "description": "**Pikachu**",
+          "clean": 3, "distance": 1000, "template": "1", "pokemon_id": 25, "form": 0, "costume": 9000,
+          "min_iv": 90, "max_iv": 100, "gender": 2, "pvp_ranking_league": 1500, "rarity": -1,
+          "size": -1, "override_location_label": "", "override_areas": null
+        }
+        """;
+
+    private const string RotatedOk = """
+        {"created":null,"updated":[{"pokemon_id":25,"min_iv":90,"uid":36487}],"unchanged":null}
+        """;
+
+    [Fact]
+    public async Task V2PutSendsTheTranslatedRuleAndReportsTheNewUid()
+    {
+        var handler = ScriptedHandler.Ok(RotatedOk);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var result = await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Put, request.Method);
+        Assert.Equal(
+            $"{ApiAddress}/api/v2/humans/user1/tracking/pokemon/36486?silent=true",
+            request.Url);
+
+        using var body = JsonDocument.Parse(request.Body!);
+        var sent = body.RootElement;
+
+        // Addressing and presentation. v2 rejects the whole write if any of them arrive.
+        foreach (var name in new[] { "uid", "id", "profile_no", "ping", "description" })
+        {
+            Assert.False(sent.TryGetProperty(name, out _), $"{name} must not reach /api/v2");
+        }
+
+        // clean 3 is auto-delete + edit-in-place, and v2 wants three booleans rather than the mask.
+        Assert.True(sent.GetProperty("clean").GetBoolean());
+        Assert.True(sent.GetProperty("edit").GetBoolean());
+        Assert.False(sent.GetProperty("summary").GetBoolean());
+
+        Assert.Equal("female", sent.GetProperty("gender").GetString());
+        Assert.Equal(1500, sent.GetProperty("pvp_ranking_league").GetInt32());
+        Assert.Equal(90, sent.GetProperty("min_iv").GetInt32());
+        Assert.Equal(JsonValueKind.Null, sent.GetProperty("override_areas").ValueKind);
+
+        Assert.Equal(36487, result.Uid);
+        Assert.True(result.UsedV2);
+    }
+
+    [Fact]
+    public async Task AServerWithoutV2GetsTheSameV1WriteItAlwaysGot()
+    {
+        var handler = ScriptedHandler.Ok("""{"newUids":[36486],"alreadyPresent":0,"updates":1,"insert":0}""");
+        var sut = CreateSut(handler, version: "5.1.0");
+
+        var result = await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal($"{ApiAddress}/api/tracking/pokemon/user1?silent=true", request.Url);
+
+        // Byte-identical to the body it was handed: no translation, nothing stripped, nothing added.
+        Assert.Equal(Row(StoredRow).GetRawText(), request.Body);
+        Assert.Equal(36486, result.Uid);
+        Assert.False(result.UsedV2);
+    }
+
+    [Fact]
+    public async Task AnUnreachableServerWritesThroughV1()
+    {
+        var handler = ScriptedHandler.Ok("""{"newUids":[],"alreadyPresent":0,"updates":1,"insert":0}""");
+        var sut = CreateSut(handler, version: null);
+
+        var result = await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        Assert.Equal(HttpMethod.Post, Assert.Single(handler.Requests).Method);
+
+        // No uid named: the alarm stays where it was rather than moving to 0.
+        Assert.Equal(36486, result.Uid);
+    }
+
+    [Fact]
+    public async Task TheOtherNineTypesStayOnV1EvenOnA521Server()
+    {
+        // #805 is a pilot on pokemon. Each remaining type needs its own field translation derived from its
+        // own schema, and v1 is frozen and unchanged on 5.2.1, so leaving them is a no-op not a deferral.
+        var handler = ScriptedHandler.Ok("""{"newUids":[9],"alreadyPresent":0,"updates":1,"insert":0}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync("raid", "user1", 9, Row("""{"uid":9,"pokemon_id":9000,"level":5}"""));
+
+        Assert.Equal($"{ApiAddress}/api/tracking/raid/user1?silent=true", Assert.Single(handler.Requests).Url);
+    }
+
+    [Theory]
+    [InlineData("v1", "5.2.1", "/api/tracking/pokemon/user1?silent=true")]
+    [InlineData("v2", "5.1.0", "/api/v2/humans/user1/tracking/pokemon/36486?silent=true")]
+    [InlineData("auto", "5.2.1", "/api/v2/humans/user1/tracking/pokemon/36486?silent=true")]
+    public async Task TheOperatorOverridePinsTheSurface(string setting, string version, string expectedPath)
+    {
+        // A fork can carry v2 while reporting an older number, or report 5.2.1 without it. A version probe
+        // cannot see either, so the operator gets the last word.
+        var handler = ScriptedHandler.Ok(RotatedOk);
+        var sut = CreateSut(handler, version: version, trackingApiVersion: setting);
+
+        await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        Assert.Equal(ApiAddress + expectedPath, Assert.Single(handler.Requests).Url);
+    }
+
+    [Fact]
+    public async Task AMissingV2RouteFallsBackToV1RatherThanFailingTheEdit()
+    {
+        // gin answers an absent route with plaintext, huma answers an absent rule with problem+json. A
+        // server that reports 5.2.0+ without carrying the route would otherwise break every pokemon edit.
+        var handler = new ScriptedHandler(
+            new Reply(HttpStatusCode.NotFound, "404 page not found", "text/plain"),
+            new Reply(HttpStatusCode.OK, """{"newUids":[36486],"alreadyPresent":0,"updates":1,"insert":0}"""));
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var result = await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal($"{ApiAddress}/api/tracking/pokemon/user1?silent=true", handler.Requests[1].Url);
+        Assert.Equal(36486, result.Uid);
+        Assert.False(result.UsedV2);
+    }
+
+    [Fact]
+    public async Task AMissingV2RouteIsRememberedSoTheNextEditDoesNotProbeAgain()
+    {
+        var handler = new ScriptedHandler(
+            new Reply(HttpStatusCode.NotFound, "404 page not found", "text/plain"),
+            new Reply(HttpStatusCode.OK, """{"newUids":[36486],"alreadyPresent":0,"updates":1,"insert":0}"""),
+            new Reply(HttpStatusCode.OK, """{"newUids":[36486],"alreadyPresent":0,"updates":1,"insert":0}"""));
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateSut(handler, version: "5.2.1", cache: cache);
+
+        await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+        await sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow));
+
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.All(handler.Requests.Skip(1), r => Assert.Equal(HttpMethod.Post, r.Method));
+    }
+
+    [Fact]
+    public async Task ARuleThatIsNotTheirsIsReportedAsNotFound()
+    {
+        var handler = ScriptedHandler.Problem(
+            HttpStatusCode.NotFound,
+            """{"title":"Not Found","status":404,"detail":"pokemon rule 999999 not found for this human"}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var ex = await Assert.ThrowsAsync<TrackingRuleNotFoundException>(
+            () => sut.UpdateByUidAsync("pokemon", "user1", 999999, Row(StoredRow)));
+
+        Assert.Equal("pokemon", ex.TrackingType);
+        Assert.Contains("not found for this human", ex.Message, StringComparison.Ordinal);
+
+        // Not the route being absent: a problem+json 404 must not poison the capability cache.
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task AnAccountThatIsGoneIsReportedAsGone()
+    {
+        var handler = ScriptedHandler.Problem(
+            HttpStatusCode.NotFound,
+            """{"title":"Not Found","status":404,"detail":"human not found"}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await Assert.ThrowsAsync<AccountGoneException>(
+            () => sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow)));
+    }
+
+    [Fact]
+    public async Task ADuplicateReplacementCarriesPoraclesOwnWordingToTheDialog()
+    {
+        // The edit dialog shows err.error.error. A fixed string here would re-break #496.
+        var handler = ScriptedHandler.Problem(
+            HttpStatusCode.Conflict,
+            """{"title":"Conflict","status":409,"detail":"an identical rule already exists (uid 36488)"}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var ex = await Assert.ThrowsAsync<TrackingConflictException>(
+            () => sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow)));
+
+        Assert.Equal("an identical rule already exists (uid 36488)", ex.Message);
+        Assert.Equal("pokemon", ex.TrackingType);
+    }
+
+    [Fact]
+    public async Task AValidationFailureNamesTheFieldRatherThanTheJsonPointer()
+    {
+        // v2 validates at 422 where v1 used 400, and its location is body.x on a PUT and body[0].x on a
+        // POST. "body[0].pokemon_id: expected integer" teaches the user nothing the field name does not.
+        var handler = ScriptedHandler.Problem(
+            HttpStatusCode.UnprocessableEntity,
+            """
+            {"title":"Unprocessable Entity","status":422,"detail":"validation failed",
+             "errors":[{"message":"expected integer","location":"body.pokemon_id","value":"twenty-five"}]}
+            """);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var ex = await Assert.ThrowsAsync<AlarmValidationException>(
+            () => sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow)));
+
+        Assert.Equal("pokemon_id: expected integer", ex.Message);
+    }
+
+    [Fact]
+    public async Task ASemanticRefusalCarriesItsDetailEvenWithNoFieldErrors()
+    {
+        var handler = ScriptedHandler.Problem(
+            HttpStatusCode.UnprocessableEntity,
+            """
+            {"title":"Unprocessable Entity","status":422,
+             "detail":"override_areas and distance are mutually exclusive"}
+            """);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var ex = await Assert.ThrowsAsync<AlarmValidationException>(
+            () => sut.UpdateByUidAsync("pokemon", "user1", 36486, Row(StoredRow)));
+
+        Assert.Equal("override_areas and distance are mutually exclusive", ex.Message);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // The translator declines rather than guesses. Each of these is a row v1 stores happily and v2 either
+    // has no place for or would refuse, and each must still save.
+    // ──────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("""{"uid":7,"pokemon_id":25,"some_field_from_a_newer_poracle":4}""")]
+    [InlineData("""{"uid":7,"pokemon_id":25,"pvp_ranking_league":1234}""")]
+    [InlineData("""{"uid":7,"pokemon_id":25,"gender":9}""")]
+    [InlineData("""{"uid":7,"pokemon_id":25,"clean":9}""")]
+    [InlineData("""{"uid":7,"distance":1000}""")]
+    public async Task ARowV2CannotCarryFaithfullyGoesToV1InsteadOfFailing(string row)
+    {
+        // Refusing outright would mean a PoracleNG newer than this build broke every pokemon edit;
+        // dropping the field silently would be #730 again. Falling back to the frozen surface does neither.
+        var handler = ScriptedHandler.Ok("""{"newUids":[7],"alreadyPresent":0,"updates":1,"insert":0}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        var result = await sut.UpdateByUidAsync("pokemon", "user1", 7, Row(row));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal($"{ApiAddress}/api/tracking/pokemon/user1?silent=true", request.Url);
+        Assert.Equal(row.Replace(" ", string.Empty, StringComparison.Ordinal), request.Body);
+        Assert.Equal(7, result.Uid);
+    }
+
+    [Fact]
+    public async Task EveryLeagueAndGenderThatIsActuallyStoredStillGoesToV2()
+    {
+        // The legitimate-case half. Queried against the 5.2.1 copy of production: pvp_ranking_league holds
+        // exactly 0, 500, 1500 and 2500, and gender holds 0, 1 and 2. Nothing live must fall back.
+        foreach (var league in new[] { 0, 500, 1500, 2500 })
+        {
+            foreach (var gender in new[] { 0, 1, 2, 3 })
+            {
+                var handler = ScriptedHandler.Ok(RotatedOk);
+                var sut = CreateSut(handler, version: "5.2.1");
+
+                await sut.UpdateByUidAsync(
+                    "pokemon",
+                    "user1",
+                    36486,
+                    Row($$"""{"uid":36486,"pokemon_id":25,"pvp_ranking_league":{{league}},"gender":{{gender}}}"""));
+
+                Assert.Equal(HttpMethod.Put, Assert.Single(handler.Requests).Method);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(0, false, false, false)]
+    [InlineData(1, true, false, false)]
+    [InlineData(2, false, true, false)]
+    [InlineData(4, false, false, true)]
+    [InlineData(7, true, true, true)]
+    public async Task EveryCleanBitmaskBecomesItsThreeBooleans(int mask, bool clean, bool edit, bool summary)
+    {
+        var handler = ScriptedHandler.Ok(RotatedOk);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync(
+            "pokemon", "user1", 36486, Row($$"""{"uid":36486,"pokemon_id":25,"clean":{{mask}}}"""));
+
+        using var body = JsonDocument.Parse(Assert.Single(handler.Requests).Body!);
+        Assert.Equal(clean, body.RootElement.GetProperty("clean").GetBoolean());
+        Assert.Equal(edit, body.RootElement.GetProperty("edit").GetBoolean());
+        Assert.Equal(summary, body.RootElement.GetProperty("summary").GetBoolean());
+    }
+
+    [Fact]
+    public async Task AUserDrawnGeofenceStillReachesV2AsAnArray()
+    {
+        var handler = ScriptedHandler.Ok(RotatedOk);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync(
+            "pokemon",
+            "user1",
+            36486,
+            Row("""{"uid":36486,"pokemon_id":25,"override_areas":["terrigal"]}"""));
+
+        using var body = JsonDocument.Parse(Assert.Single(handler.Requests).Body!);
+        Assert.Equal("terrigal", body.RootElement.GetProperty("override_areas").EnumerateArray().Single().GetString());
+    }
+
+    [Fact]
+    public async Task ACreateIsNotAnUpdateAndNeverTouchesV2()
+    {
+        // uid 0 is an insert. v2's PUT is addressed by uid and would 404; v2's POST still diffs and merges,
+        // so it buys nothing. Creates stay on v1 for the pilot.
+        var handler = ScriptedHandler.Ok("""{"newUids":[1],"alreadyPresent":0,"updates":0,"insert":1}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync("pokemon", "user1", 0, Row("""{"pokemon_id":25}"""));
+
+        Assert.Equal(HttpMethod.Post, Assert.Single(handler.Requests).Method);
+    }
+
+    private static JsonElement Row(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static PoracleTrackingProxy CreateSut(
+        ScriptedHandler handler,
+        string? version,
+        string trackingApiVersion = "auto",
+        IMemoryCache? cache = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Poracle:ApiAddress"] = ApiAddress,
+                ["Poracle:ApiSecret"] = "test-secret",
+                ["Poracle:TrackingApiVersion"] = trackingApiVersion,
+            })
+            .Build();
+
+        var profile = new Mock<IPoracleServerProfileService>();
+        profile
+            .Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(version is null
+                ? PoracleServerProfile.Unknown(DateTimeOffset.UtcNow)
+                : new PoracleServerProfile { Version = version, Reachable = true, CheckedAt = DateTimeOffset.UtcNow });
+
+        return new PoracleTrackingProxy(
+            new HttpClient(handler),
+            config,
+            profile.Object,
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            Mock.Of<ILogger<PoracleTrackingProxy>>());
+    }
+
+    private sealed record Reply(HttpStatusCode Status, string Body, string ContentType = "application/json");
+
+    private sealed record Sent(HttpMethod Method, string Url, string? Body);
+
+    /// <summary>Answers a fixed sequence of replies and records everything that was sent.</summary>
+    private sealed class ScriptedHandler(params Reply[] replies) : HttpMessageHandler
+    {
+        private int _next;
+
+        public List<Sent> Requests { get; } = [];
+
+        public static ScriptedHandler Ok(string body) => new(new Reply(HttpStatusCode.OK, body));
+
+        public static ScriptedHandler Problem(HttpStatusCode status, string body) =>
+            new(new Reply(status, body, "application/problem+json"));
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            this.Requests.Add(new Sent(request.Method, request.RequestUri!.ToString(), body));
+
+            var reply = replies[Math.Min(this._next++, replies.Length - 1)];
+            return new HttpResponseMessage(reply.Status)
+            {
+                Content = new StringContent(reply.Body, Encoding.UTF8, reply.ContentType),
+            };
+        }
+    }
+}

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyV2Tests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/PoracleTrackingProxyV2Tests.cs
@@ -271,6 +271,7 @@ public class PoracleTrackingProxyV2Tests
     [InlineData("""{"uid":7,"pokemon_id":25,"gender":9}""")]
     [InlineData("""{"uid":7,"pokemon_id":25,"clean":9}""")]
     [InlineData("""{"uid":7,"distance":1000}""")]
+    [InlineData("""{"uid":7,"pokemon_id":25,"ping":"<@&400027130022592512>"}""")]
     public async Task ARowV2CannotCarryFaithfullyGoesToV1InsteadOfFailing(string row)
     {
         // Refusing outright would mean a PoracleNG newer than this build broke every pokemon edit;
@@ -284,6 +285,47 @@ public class PoracleTrackingProxyV2Tests
         Assert.Equal($"{ApiAddress}/api/tracking/pokemon/user1?silent=true", request.Url);
         Assert.Equal(row.Replace(" ", string.Empty, StringComparison.Ordinal), request.Body);
         Assert.Equal(7, result.Uid);
+    }
+
+    [Fact]
+    public async Task ASetPingSurvivesTheEditInsteadOfBeingBlanked()
+    {
+        // v2 stores Ping: "" unconditionally ("server-managed" in v2_pokemon.go), so translating a rule
+        // that carries one would discard it. Verified live against the 5.2.1 copy: a rule holding
+        // <@&400027130022592512> came back with an empty ping after a single v2 PUT. Two rules in
+        // production carry a ping and both are webhook alarms, where the role mention IS the alert.
+        const string WithPing = """
+            {"uid":7,"pokemon_id":25,"min_iv":90,"ping":"<@&400027130022592512>"}
+            """;
+
+        var handler = ScriptedHandler.Ok("""{"newUids":[7],"alreadyPresent":0,"updates":1,"insert":0}""");
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync("pokemon", "user1", 7, Row(WithPing));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal($"{ApiAddress}/api/tracking/pokemon/user1?silent=true", request.Url);
+
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.Equal("<@&400027130022592512>", body.RootElement.GetProperty("ping").GetString());
+    }
+
+    [Fact]
+    public async Task AnEmptyPingIsStillDroppedAndTheRowStaysOnV2()
+    {
+        // The legitimate-case half: 18488 of 18490 production rules carry no ping, and v2 would store the
+        // same empty string, so those must not all be pushed onto v1 by the guard above.
+        var handler = ScriptedHandler.Ok(RotatedOk);
+        var sut = CreateSut(handler, version: "5.2.1");
+
+        await sut.UpdateByUidAsync(
+            "pokemon", "user1", 7, Row("""{"uid":7,"pokemon_id":25,"min_iv":90,"ping":""}"""));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal($"{ApiAddress}/api/v2/humans/user1/tracking/pokemon/7?silent=true", request.Url);
+
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.False(body.RootElement.TryGetProperty("ping", out _));
     }
 
     [Fact]

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperCoverageTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/TrackedUidRemapperCoverageTests.cs
@@ -11,14 +11,20 @@ namespace Pgan.PoracleWebNet.Tests.Services;
 public class TrackedUidRemapperCoverageTests
 {
     /// <summary>
-    /// Every service whose update rotates the uid — all of them except monsters, which PoracleNG
-    /// genuinely upserts in place.
+    /// Every service whose update rotates the uid.
     /// </summary>
+    /// <remarks>
+    /// Monsters were the exception until #805: PoracleNG upserts pokemon in place on the v1 surface, so
+    /// there was no rotation to follow, and this class carried a fact asserting MonsterService did NOT take
+    /// the remapper. The v2 full-replace PUT is delete-then-insert, so pokemon rotates like the other nine
+    /// whenever the server carries v2. The tripwire fired exactly as it was written to; it has been moved
+    /// rather than weakened.
+    /// </remarks>
     public static TheoryData<Type> RotatingServices =>
     [
-        typeof(RaidService), typeof(EggService), typeof(QuestService), typeof(NestService),
-        typeof(GymService), typeof(FortChangeService), typeof(InvasionService), typeof(LureService),
-        typeof(MaxBattleService)
+        typeof(MonsterService), typeof(RaidService), typeof(EggService), typeof(QuestService),
+        typeof(NestService), typeof(GymService), typeof(FortChangeService), typeof(InvasionService),
+        typeof(LureService), typeof(MaxBattleService)
     ];
 
     [Theory]
@@ -33,17 +39,5 @@ public class TrackedUidRemapperCoverageTests
             takesRemapper,
             $"{serviceType.Name} rewrites the row on update, so its uid changes. Without ITrackedUidRemapper "
             + "any quick pick that created the alarm keeps pointing at the dead uid and can never remove it.");
-    }
-
-    [Fact]
-    public void MonsterServiceDoesNotNeedIt()
-    {
-        // Documented deliberately: monsters are the one type PoracleNG updates in place, so there is no
-        // rotation to follow. If that ever changes, this test failing is the reminder.
-        var takesRemapper = typeof(MonsterService)
-            .GetConstructors()
-            .Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(ITrackedUidRemapper)));
-
-        Assert.False(takesRemapper);
     }
 }

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/TrackingFieldCoverageTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/TrackingFieldCoverageTests.cs
@@ -146,7 +146,7 @@ public class TrackingFieldCoverageTests
 
     private Task CreateAsync(string type) => type switch
     {
-        "pokemon" => new MonsterService(this._proxy.Object, this._featureGate.Object)
+        "pokemon" => new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object)
             .CreateAsync("u1", new MonsterCreate { PokemonId = 201 }.ToMonster()),
         "raid" => new RaidService(
                 this._proxy.Object, this._featureGate.Object, NullLogger<RaidService>.Instance, this._remapper.Object)

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UnmodelledFieldPreservationTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UnmodelledFieldPreservationTests.cs
@@ -70,6 +70,11 @@ public class UnmodelledFieldPreservationTests
             .Callback<string, string, JsonElement>((_, _, body) => this._sent.Add(body.Clone()))
             .ReturnsAsync(new TrackingCreateResult([7], 0, 0, 1));
         this._proxy
+            .Setup(p => p.UpdateByUidAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<JsonElement>()))
+            .Callback<string, string, int, JsonElement>((_, _, _, body) => this._sent.Add(body.Clone()))
+            .ReturnsAsync((string _, string _, int uid, JsonElement _) => new TrackingUpdateResult(uid, false));
+        this._proxy
             .Setup(p => p.DeleteByUidAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
             .Returns(Task.CompletedTask);
         this._proxy
@@ -149,7 +154,7 @@ public class UnmodelledFieldPreservationTests
     [Fact]
     public async Task EditKeepsUnmodelledFieldsOnPokemon()
     {
-        var service = new MonsterService(this._proxy.Object, this._featureGate.Object);
+        var service = new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object);
 
         await service.UpdateAsync("u1", new Monster { Uid = 7, PokemonId = 201, Distance = 1500 });
 
@@ -200,7 +205,7 @@ public class UnmodelledFieldPreservationTests
     {
         // The other half of the null rule. Null means "not stated, keep what is stored"; empty is how a
         // person says "remove it". Without this, an override could be set but never taken off.
-        var service = new MonsterService(this._proxy.Object, this._featureGate.Object);
+        var service = new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object);
 
         await service.UpdateAsync("u1", new Monster
         {
@@ -221,7 +226,7 @@ public class UnmodelledFieldPreservationTests
     {
         // uid 0 is a create. There is no stored row to carry anything forward from, and matching on
         // "some row the user already has" would staple a stranger's location override onto a new alarm.
-        var service = new MonsterService(this._proxy.Object, this._featureGate.Object);
+        var service = new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object);
 
         await service.CreateAsync("u1", new Monster { PokemonId = 999, Distance = 1500 });
 
@@ -278,7 +283,7 @@ public class UnmodelledFieldPreservationTests
 
     private object ServiceFor(string trackingType) => trackingType switch
     {
-        "pokemon" => new MonsterService(this._proxy.Object, this._featureGate.Object),
+        "pokemon" => new MonsterService(this._proxy.Object, this._featureGate.Object, this._remapper.Object),
         "raid" => new RaidService(
             this._proxy.Object, this._featureGate.Object, NullLogger<RaidService>.Instance, this._remapper.Object),
         "egg" => new EggService(

--- a/Tests/Pgan.PoracleWebNet.Tests/Services/UserOwnedOverrideAreaProxyTests.cs
+++ b/Tests/Pgan.PoracleWebNet.Tests/Services/UserOwnedOverrideAreaProxyTests.cs
@@ -21,6 +21,9 @@ public class UserOwnedOverrideAreaProxyTests
 {
     private const string User = "u1";
 
+    /// <summary>What the v2 full-replace PUT hands back: a new row, under a new uid.</summary>
+    private const int RotatedUid = 8;
+
     private readonly Mock<IPoracleTrackingProxy> _inner = new();
     private readonly Mock<IUserGeofenceRepository> _geofences = new();
     private readonly Mock<IUserAreaDualWriter> _writer = new();
@@ -32,6 +35,11 @@ public class UserOwnedOverrideAreaProxyTests
             .Setup(p => p.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JsonElement>()))
             .Callback<string, string, JsonElement>((_, _, body) => this._sentToPoracle.Add(body.Clone()))
             .ReturnsAsync(new TrackingCreateResult([7], 0, 0, 1));
+        this._inner
+            .Setup(p => p.UpdateByUidAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<JsonElement>()))
+            .Callback<string, string, int, JsonElement>((_, _, _, body) => this._sentToPoracle.Add(body.Clone()))
+            .ReturnsAsync(new TrackingUpdateResult(RotatedUid, true));
         this._inner.Setup(p => p.ReloadStateAsync()).Returns(Task.CompletedTask);
         this._geofences.Setup(r => r.GetByHumanIdAsync(It.IsAny<string>()))
             .ReturnsAsync([new UserGeofence { KojiName = "back garden", HumanId = User }]);
@@ -63,6 +71,54 @@ public class UserOwnedOverrideAreaProxyTests
             w => w.SetAlarmOverrideAreasAsync(
                 User, "pokemon", 7, It.Is<IReadOnlyCollection<string>>(a => a.Contains("back garden"))),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task AnEditWritesTheAreaBackAgainstTheUidPoracleJustReported()
+    {
+        // The v2 PUT is delete-then-insert, so the row the areas belong to is NOT the one that was
+        // addressed. Writing to the old uid would touch a row that no longer exists and the alarm would
+        // silently widen to the whole profile -- the same failure the write-back guard exists to prevent.
+        var result = await this.Proxy().UpdateByUidAsync("pokemon", User, 7, Row(
+            """{"uid":7,"pokemon_id":201,"distance":0,"override_areas":["back garden"]}"""));
+
+        Assert.False(Assert.Single(this._sentToPoracle).TryGetProperty("override_areas", out _));
+        Assert.Equal(RotatedUid, result.Uid);
+
+        this._writer.Verify(
+            w => w.SetAlarmOverrideAreasAsync(
+                User, "pokemon", RotatedUid, It.Is<IReadOnlyCollection<string>>(a => a.Contains("back garden"))),
+            Times.Once);
+        this._writer.Verify(
+            w => w.SetAlarmOverrideAreasAsync(
+                It.IsAny<string>(), It.IsAny<string>(), 7, It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AnEditThatNamesNoOwnedGeofenceGoesStraightThrough()
+    {
+        // The legitimate-case half: almost every edit carries no override at all, and this must not add a
+        // geofence query or a column write to any of them.
+        var result = await this.Proxy().UpdateByUidAsync("pokemon", User, 7, Row(
+            """{"uid":7,"pokemon_id":201,"distance":1000}"""));
+
+        Assert.Equal(RotatedUid, result.Uid);
+        this._writer.Verify(
+            w => w.SetAlarmOverrideAreasAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+        this._inner.Verify(p => p.ReloadStateAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnEditWithAnIncoherentScopeIsRefusedBeforeAnythingIsWritten()
+    {
+        await Assert.ThrowsAsync<AlarmValidationException>(() => this.Proxy().UpdateByUidAsync(
+            "pokemon", User, 7, Row(
+                """{"uid":7,"pokemon_id":201,"distance":1000,"override_areas":["back garden"]}""")));
+
+        Assert.Empty(this._sentToPoracle);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #805. **Merge this first** — #806 and #810 build on the v2 client it introduces.

Pilots PoracleNG 5.2.1's strict `/api/v2` tracking surface on **pokemon only**. Nothing else moves: the other nine alarm types, humans and profiles all stay on v1.

## Why v2 is worth having

`PUT /api/v2/humans/{id}/tracking/pokemon/{uid}` addresses a rule by its id, 404s if the uid is not the caller's, and 409s if the replacement would duplicate another rule. Today every write is a POST that PoracleNG diffs, and `TrackingUpdateReconciler` exists purely to mirror `DiffTracking` so we can predict a takeover and refuse before it happens. On the v2 update path the server answers the question directly.

Responses are typed `{created, updated, unchanged}` with the uid in the envelope, so nothing has to be inferred from a success body.

## The hazard, handled

**v2 PUT is delete-then-insert, so the replacement gets a new uid.** Anything holding a uid across an edit breaks — `quick_pick_applied_states.TrackedUidsJson` most of all. The new uid comes back in `{updated}` and is threaded through rather than assumed stable.

## HIGH severity caught in review, fixed in 9a4c7e7

`ping` was put in the unconditional dropped set alongside `uid`/`id`/`profile_no`/`description`, on the reading that it was addressing metadata. It is a real `monsters` column, and 5.2.1's `v2_pokemon.go` stores `Ping: ""` unconditionally — so a v2 write would blank it.

Checked against production rather than reasoned about:

```
total_monster_rules  rules_with_ping
18489                2
```

Both are webhook humans carrying `<@&…>` role mentions, reachable from this UI through webhook delegation, where the mention is the entire point of the alert. Two live rules would have lost it on their next edit.

`ping` now refuses v2 and falls back to v1 when set. Empty still drops, so the other 18,487 rules keep the v2 path. Two tests cover it, both watched failing first.

## Safety

- Version-gated via `ShouldTryV2`, with v1 as the fallback. PoracleNG's v1 surface is frozen and unchanged on 5.2.1 (verified live), so the fallback is not theoretical.
- An edit carrying anything v2 cannot express takes the old path rather than failing.
- `PORACLE_TRACKING_API_VERSION` pins to `v1` or `v2` if you need to force it.
- The reconciler is retained for v1 and for v2 POST, which still diffs.

## Verification

Backend **2167 passed**. Angular production build passes; frontend diff is empty. v2 calls were exercised against a live PoracleNG 5.2.1 instance, not just against its source.
