### PR TITLE
chore(humans): delete a dead repository read, and say why its neighbour stays

### DIFF
--- a/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Abstractions/Repositories/IHumanRepository.cs
@@ -8,7 +8,6 @@ public interface IHumanRepository
 
     /// <summary>The webhook humans, id and name. Used to resolve a delegated webhook named by name.</summary>
     public Task<IEnumerable<Human>> GetWebhooksAsync();
-    public Task<Human?> GetByIdAsync(string id);
     public Task<IEnumerable<Human>> GetByIdsAsync(IEnumerable<string> ids);
     public Task<bool> ExistsAsync(string id);
     public Task<bool> DeleteUserAsync(string userId);

--- a/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Repositories/HumanRepository.cs
@@ -23,12 +23,6 @@ public class HumanRepository(PoracleContext context) : IHumanRepository
         return entities.Select(e => e.ToModel());
     }
 
-    public async Task<Human?> GetByIdAsync(string id)
-    {
-        var entity = await this._context.Humans.FirstOrDefaultAsync(h => h.Id == id);
-        return entity is null ? null : entity.ToModel();
-    }
-
     public async Task<IEnumerable<Human>> GetByIdsAsync(IEnumerable<string> ids)
     {
         var idArray = ids.ToArray();

--- a/Core/Pgan.PoracleWebNet.Core.Services/UserPurgeService.cs
+++ b/Core/Pgan.PoracleWebNet.Core.Services/UserPurgeService.cs
@@ -26,6 +26,11 @@ public partial class UserPurgeService(
 
     public async Task<bool> PurgeAsync(string userId)
     {
+        // Deliberately the DATABASE, not IHumanService.ExistsAsync, which is otherwise identical and
+        // already injected here. That one reads through the proxy, and the proxy answers null for any
+        // non-success -- so a Poracle that is merely unreachable is indistinguishable from an account
+        // that does not exist, and this method would answer false. The caller turns false into 404, so
+        // an outage would tell an admin the account they are deleting is already gone.
         if (!await this._humanRepository.ExistsAsync(userId))
         {
             return false;


### PR DESCRIPTION
Two of the three loose ends from auditing what still needs the Poracle database. One is a deletion; the other turned out **not** to be safe, and this records why.

## Deleted: `IHumanRepository.GetByIdAsync`

No callers, tests included. `HumanService.GetByIdAsync` reads through the proxy, so all thirty-odd controller call sites are already on the API — this method was left behind by that migration and nothing noticed.

## Not done: moving `ExistsAsync` off the database

I proposed this as the other cheap win. It isn't one.

`IHumanService.ExistsAsync` is otherwise identical, and `UserPurgeService` already injects `IHumanService`, so the swap looked like a one-liner. But it reads through `GetHumanAsync`, which **returns `null` for any non-success**:

```csharp
if (!response.IsSuccessStatusCode)
{
    return null;
}
```

So a Poracle that is merely unreachable is indistinguishable from an account that does not exist, and `ExistsAsync` would answer `false`. `AdminController` turns `false` into a **404** — meaning during a Poracle outage, an admin deleting a user would be told the account is already gone.

The database read is the correct one here *precisely because* it does not depend on Poracle being up. The call site now carries a comment saying so, so it does not get tidied away later by someone applying the same reasoning I did.

This is the shape `CLAUDE.md` warns about: tightening a rule without enumerating who depended on the loose one. The loose thing being depended on was "this check works when Poracle is down".

## The third loose end, filed rather than fixed

`HumanRepository.GetByIdsAsync` batch-reads humans by id for the admin geofence review list, resolving owner and reviewer names. v2 is single-`{id}`, so through the API that becomes one request per distinct person on the page. Swapping one query for an N+1 would be a regression, so it stays until upstream offers a batch read — raised on [jfberry/PoracleNG#214](https://github.com/jfberry/PoracleNG/issues/214).

## What still needs the Poracle database after this

| Path | Blocked by | Upstream |
|---|---|---|
| `UserAreaDualWriter`, 6 methods | `setAreas` `userSelectable` filter | [#215](https://github.com/jfberry/PoracleNG/issues/215) |
| `ProfileRepository.RenameAsync` / `UpdateAsync` | PATCH writes `active_hours` only | [#213](https://github.com/jfberry/PoracleNG/issues/213) |
| `HumanRepository.GetAllAsync` / `GetWebhooksAsync` / `DeleteUserAsync` / `GetByIdsAsync` | no list, delete or batch read | [#214](https://github.com/jfberry/PoracleNG/issues/214) |
| `HumanRepository.ExistsAsync` | not blocked upstream — see above | — |
| `PoracleSchemaVersionReader` | no migration number on `/health` | [#212](https://github.com/jfberry/PoracleNG/issues/212) |
| `UserAreaDualWriter.SetAlarmOverrideAreasAsync` | premise did not reproduce; awaiting an answer | [#211](https://github.com/jfberry/PoracleNG/issues/211) |
| `PwebSettingRepository` | not an API question — legacy `pweb_settings` migration source | — |

Three `DbSet`s remain: `Humans`, `Profiles`, `PwebSettings`. Every alarm table is gone as of #827, so a direct alarm write is a compile error.

## Verification

Backend **2595 passing**, unchanged. Two files, six lines removed, five comment lines added.
